### PR TITLE
Restyle example formatting for `Layout/MultilineArrayBraceLayout` cop

### DIFF
--- a/lib/rubocop/cop/layout/multiline_array_brace_layout.rb
+++ b/lib/rubocop/cop/layout/multiline_array_brace_layout.rb
@@ -26,35 +26,68 @@ module RuboCop
       # The closing brace of a multi-line array literal must be on the same
       # line as the last element of the array.
       #
-      # @example
-      #
-      #     # symmetrical: bad
-      #     # new_line: good
-      #     # same_line: bad
+      # @example EnforcedStyle: symmetrical (default)
+      #     # bad
       #     [ :a,
       #       :b
       #     ]
       #
-      #     # symmetrical: bad
-      #     # new_line: bad
-      #     # same_line: good
+      #     # bad
       #     [
       #       :a,
       #       :b ]
       #
-      #     # symmetrical: good
-      #     # new_line: bad
-      #     # same_line: good
+      #     # good
       #     [ :a,
       #       :b ]
       #
-      #     # symmetrical: good
-      #     # new_line: good
-      #     # same_line: bad
+      #     # good
       #     [
       #       :a,
       #       :b
       #     ]
+      #
+      # @example EnforcedStyle: new_line
+      #     # bad
+      #     [
+      #       :a,
+      #       :b ]
+      #
+      #     # bad
+      #     [ :a,
+      #       :b ]
+      #
+      #     # good
+      #     [ :a,
+      #       :b
+      #     ]
+      #
+      #     # good
+      #     [
+      #       :a,
+      #       :b
+      #     ]
+      #
+      # @example EnforcedStyle: same_line
+      #     # bad
+      #     [ :a,
+      #       :b
+      #     ]
+      #
+      #     # bad
+      #     [
+      #       :a,
+      #       :b
+      #     ]
+      #
+      #     # good
+      #     [
+      #       :a,
+      #       :b ]
+      #
+      #     # good
+      #     [ :a,
+      #       :b ]
       class MultilineArrayBraceLayout < Cop
         include MultilineLiteralBraceLayout
 

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -1549,33 +1549,67 @@ line as the last element of the array.
 ### Example
 
 ```ruby
-# symmetrical: bad
-# new_line: good
-# same_line: bad
+# bad
 [ :a,
   :b
 ]
 
-# symmetrical: bad
-# new_line: bad
-# same_line: good
+# bad
 [
   :a,
   :b ]
 
-# symmetrical: good
-# new_line: bad
-# same_line: good
+# good
 [ :a,
   :b ]
 
-# symmetrical: good
-# new_line: good
-# same_line: bad
+# good
 [
   :a,
   :b
 ]
+```
+```ruby
+# bad
+[
+  :a,
+  :b ]
+
+# bad
+[ :a,
+  :b ]
+
+# good
+[ :a,
+  :b
+]
+
+# good
+[
+  :a,
+  :b
+]
+```
+```ruby
+# bad
+[ :a,
+  :b
+]
+
+# bad
+[
+  :a,
+  :b
+]
+
+# good
+[
+  :a,
+  :b ]
+
+# good
+[ :a,
+  :b ]
 ```
 
 ### Configurable attributes


### PR DESCRIPTION
Follow up of https://github.com/bbatsov/rubocop/pull/4880#issuecomment-338499947.

This commit is a change of document format for `Layout/MultilineArrayBraceLayout` cop.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
