### PR TITLE
[#5069] Apply annotated templates for Style cops T-Z

### DIFF
--- a/lib/rubocop/cop/mixin/trailing_comma.rb
+++ b/lib/rubocop/cop/mixin/trailing_comma.rb
@@ -7,7 +7,7 @@ module RuboCop
     module TrailingComma
       include ConfigurableEnforcedStyle
 
-      MSG = '%s comma after the last %s'.freeze
+      MSG = '%<command>s comma after the last %<unit>s.'.freeze
 
       def style_parameter_name
         'EnforcedStyleForMultiline'
@@ -116,7 +116,11 @@ module RuboCop
       def avoid_comma(kind, comma_begin_pos, extra_info)
         range = range_between(comma_begin_pos, comma_begin_pos + 1)
         article = kind =~ /array/ ? 'an' : 'a'
-        msg = format(MSG, 'Avoid', format(kind, article)) + "#{extra_info}."
+        msg = format(
+          MSG,
+          command: 'Avoid',
+          unit: format(kind, article: article) + extra_info.to_s
+        )
 
         add_offense(range, location: range, message: msg)
       end
@@ -128,7 +132,11 @@ module RuboCop
         return if last_item.block_pass_type?
 
         range = autocorrect_range(last_item)
-        msg = format(MSG, 'Put a', format(kind, 'a multiline') + '.')
+        msg = format(
+          MSG,
+          command: 'Put a',
+          unit: format(kind, article: 'a multiline')
+        )
 
         add_offense(range, location: range, message: msg)
       end

--- a/lib/rubocop/cop/style/ternary_parentheses.rb
+++ b/lib/rubocop/cop/style/ternary_parentheses.rb
@@ -48,8 +48,8 @@ module RuboCop
         VARIABLE_TYPES = AST::Node::VARIABLES
         NON_COMPLEX_TYPES = [*VARIABLE_TYPES, :const, :defined?, :yield].freeze
 
-        MSG = '%s parentheses for ternary conditions.'.freeze
-        MSG_COMPLEX = '%s parentheses for ternary expressions with' \
+        MSG = '%<command>s parentheses for ternary conditions.'.freeze
+        MSG_COMPLEX = '%<command>s parentheses for ternary expressions with' \
           ' complex conditions.'.freeze
 
         def on_if(node)
@@ -115,11 +115,11 @@ module RuboCop
 
         def message(node)
           if require_parentheses_when_complex?
-            omit = parenthesized?(node.condition) ? 'Only use' : 'Use'
-            format(MSG_COMPLEX, omit)
+            command = parenthesized?(node.condition) ? 'Only use' : 'Use'
+            format(MSG_COMPLEX, command: command)
           else
-            verb = require_parentheses? ? 'Use' : 'Omit'
-            format(MSG, verb)
+            command = require_parentheses? ? 'Use' : 'Omit'
+            format(MSG, command: command)
           end
         end
 

--- a/lib/rubocop/cop/style/trailing_comma_in_arguments.rb
+++ b/lib/rubocop/cop/style/trailing_comma_in_arguments.rb
@@ -46,7 +46,7 @@ module RuboCop
         def on_send(node)
           return unless node.arguments? && node.parenthesized?
 
-          check(node, node.arguments, 'parameter of %s method call',
+          check(node, node.arguments, 'parameter of %<article>s method call',
                 node.last_argument.source_range.end_pos,
                 node.source_range.end_pos)
         end

--- a/lib/rubocop/cop/style/trailing_comma_in_literal.rb
+++ b/lib/rubocop/cop/style/trailing_comma_in_literal.rb
@@ -45,11 +45,12 @@ module RuboCop
         include TrailingComma
 
         def on_array(node)
-          check_literal(node, 'item of %s array') if node.square_brackets?
+          return unless node.square_brackets?
+          check_literal(node, 'item of %<article>s array')
         end
 
         def on_hash(node)
-          check_literal(node, 'item of %s hash')
+          check_literal(node, 'item of %<article>s hash')
         end
 
         private

--- a/lib/rubocop/cop/style/trailing_underscore_variable.rb
+++ b/lib/rubocop/cop/style/trailing_underscore_variable.rb
@@ -26,7 +26,7 @@ module RuboCop
         include SurroundingSpace
 
         MSG = 'Do not use trailing `_`s in parallel assignment. ' \
-              'Prefer `%s`.'.freeze
+              'Prefer `%<code>s`.'.freeze
         UNDERSCORE = '_'.freeze
 
         def on_masgn(node)
@@ -37,7 +37,9 @@ module RuboCop
             offset = range.begin_pos - node.source_range.begin_pos
             good_code[offset, range.size] = ''
 
-            add_offense(node, location: range, message: format(MSG, good_code))
+            add_offense(node,
+                        location: range,
+                        message: format(MSG, code: good_code))
           end
         end
 

--- a/lib/rubocop/cop/style/trivial_accessors.rb
+++ b/lib/rubocop/cop/style/trivial_accessors.rb
@@ -6,7 +6,7 @@ module RuboCop
       # This cop looks for trivial reader/writer methods, that could
       # have been created with the attr_* family of functions automatically.
       class TrivialAccessors < Cop
-        MSG = 'Use `attr_%s` to define trivial %s methods.'.freeze
+        MSG = 'Use `attr_%<kind>s` to define trivial %<kind>s methods.'.freeze
 
         def on_def(node)
           return if in_module_or_instance_eval?(node)
@@ -42,7 +42,7 @@ module RuboCop
 
           add_offense(node,
                       location: :keyword,
-                      message: format(MSG, kind, kind))
+                      message: format(MSG, kind: kind))
         end
 
         def exact_name_match?

--- a/lib/rubocop/cop/style/unneeded_percent_q.rb
+++ b/lib/rubocop/cop/style/unneeded_percent_q.rb
@@ -5,8 +5,8 @@ module RuboCop
     module Style
       # This cop checks for usage of the %q/%Q syntax when '' or "" would do.
       class UnneededPercentQ < Cop
-        MSG = 'Use `%s` only for strings that contain both single quotes and ' \
-              'double quotes%s.'.freeze
+        MSG = 'Use `%<q_type>s` only for strings that contain both ' \
+              'single quotes and double quotes%<extra>s.'.freeze
         DYNAMIC_MSG = ', or for dynamic strings that contain ' \
                       'double quotes'.freeze
         SINGLE_QUOTE = "'".freeze
@@ -56,7 +56,7 @@ module RuboCop
                   else
                     EMPTY
                   end
-          format(MSG, src[0, 2], extra)
+          format(MSG, q_type: src[0, 2], extra: extra)
         end
 
         def autocorrect(node)

--- a/lib/rubocop/cop/style/variable_interpolation.rb
+++ b/lib/rubocop/cop/style/variable_interpolation.rb
@@ -5,8 +5,8 @@ module RuboCop
     module Style
       # This cop checks for variable interpolation (like "#@ivar").
       class VariableInterpolation < Cop
-        MSG = 'Replace interpolated variable `%s` ' \
-              'with expression `#{%s}`.'.freeze
+        MSG = 'Replace interpolated variable `%<variable>s` ' \
+              'with expression `#{%<variable>s}`.'.freeze
 
         def on_dstr(node)
           check_for_interpolation(node)
@@ -29,7 +29,7 @@ module RuboCop
         end
 
         def message(node)
-          format(MSG, node.source, node.source)
+          format(MSG, variable: node.source)
         end
 
         def autocorrect(node)

--- a/lib/rubocop/cop/style/while_until_do.rb
+++ b/lib/rubocop/cop/style/while_until_do.rb
@@ -5,7 +5,7 @@ module RuboCop
     module Style
       # Checks for uses of `do` in multi-line `while/until` statements.
       class WhileUntilDo < Cop
-        MSG = 'Do not use `do` with multi-line `%s`.'.freeze
+        MSG = 'Do not use `do` with multi-line `%<keyword>s`.'.freeze
 
         def on_while(node)
           handle(node)
@@ -19,7 +19,7 @@ module RuboCop
           return unless node.multiline? && node.do?
 
           add_offense(node, location: :begin,
-                            message: format(MSG, node.keyword))
+                            message: format(MSG, keyword: node.keyword))
         end
 
         private

--- a/lib/rubocop/cop/style/while_until_modifier.rb
+++ b/lib/rubocop/cop/style/while_until_modifier.rb
@@ -9,7 +9,8 @@ module RuboCop
       class WhileUntilModifier < Cop
         include StatementModifier
 
-        MSG = 'Favor modifier `%s` usage when having a single-line body.'.freeze
+        MSG = 'Favor modifier `%<keyword>s` usage when ' \
+              'having a single-line body.'.freeze
 
         def on_while(node)
           check(node)
@@ -34,7 +35,7 @@ module RuboCop
           return unless node.multiline? && single_line_as_modifier?(node)
 
           add_offense(node, location: :keyword,
-                            message: format(MSG, node.keyword))
+                            message: format(MSG, keyword: node.keyword))
         end
       end
     end

--- a/lib/rubocop/cop/style/yoda_condition.rb
+++ b/lib/rubocop/cop/style/yoda_condition.rb
@@ -31,7 +31,7 @@ module RuboCop
       class YodaCondition < Cop
         include ConfigurableEnforcedStyle
 
-        MSG = 'Reverse the order of the operands `%s`.'.freeze
+        MSG = 'Reverse the order of the operands `%<source>s`.'.freeze
 
         REVERSE_COMPARISON = {
           '<' => '>',
@@ -66,7 +66,7 @@ module RuboCop
         end
 
         def message(node)
-          format(MSG, node.source)
+          format(MSG, source: node.source)
         end
 
         def autocorrect(node)

--- a/lib/rubocop/cop/style/zero_length_predicate.rb
+++ b/lib/rubocop/cop/style/zero_length_predicate.rb
@@ -26,8 +26,9 @@ module RuboCop
       #   !string.empty?
       #   !hash.empty?
       class ZeroLengthPredicate < Cop
-        ZERO_MSG = 'Use `empty?` instead of `%s %s %s`.'.freeze
-        NONZERO_MSG = 'Use `!empty?` instead of `%s %s %s`.'.freeze
+        ZERO_MSG = 'Use `empty?` instead of `%<lhs>s %<opr>s %<rhs>s`.'.freeze
+        NONZERO_MSG = 'Use `!empty?` instead of ' \
+                      '`%<lhs>s %<opr>s %<rhs>s`.'.freeze
 
         def on_send(node)
           check_zero_length_predicate(node)
@@ -41,8 +42,12 @@ module RuboCop
 
           return unless zero_length_predicate
 
-          add_offense(node,
-                      message: format(ZERO_MSG, *zero_length_predicate))
+          lhs, opr, rhs = zero_length_predicate
+
+          add_offense(
+            node,
+            message: format(ZERO_MSG, lhs: lhs, opr: opr, rhs: rhs)
+          )
         end
 
         def check_nonzero_length_predicate(node)
@@ -50,8 +55,12 @@ module RuboCop
 
           return unless nonzero_length_predicate
 
-          add_offense(node,
-                      message: format(NONZERO_MSG, *nonzero_length_predicate))
+          lhs, opr, rhs = nonzero_length_predicate
+
+          add_offense(
+            node,
+            message: format(NONZERO_MSG, lhs: lhs, opr: opr, rhs: rhs)
+          )
         end
 
         def_node_matcher :zero_length_predicate, <<-PATTERN


### PR DESCRIPTION
These changes apply annotated string templates for style cops starting with T through Z. This also required updating the trailing comma mixin.

CI issue is documentation fix applied in #5124 .

-----------------

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests. There is already coverage for changes.
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/
