### PR TITLE
[#5069] Apply annotated templates for style cops O-S

### DIFF
--- a/lib/rubocop/cop/style/one_line_conditional.rb
+++ b/lib/rubocop/cop/style/one_line_conditional.rb
@@ -9,7 +9,7 @@ module RuboCop
         include OnNormalIfUnless
 
         MSG = 'Favor the ternary operator (`?:`) ' \
-              'over `%s/then/else/end` constructs.'.freeze
+              'over `%<keyword>s/then/else/end` constructs.'.freeze
 
         def on_normal_if_unless(node)
           return unless node.single_line? && node.else_branch
@@ -26,7 +26,7 @@ module RuboCop
         end
 
         def message(node)
-          format(MSG, node.keyword)
+          format(MSG, keyword: node.keyword)
         end
 
         def replacement(node)

--- a/lib/rubocop/cop/style/preferred_hash_methods.rb
+++ b/lib/rubocop/cop/style/preferred_hash_methods.rb
@@ -28,7 +28,7 @@ module RuboCop
       class PreferredHashMethods < Cop
         include ConfigurableEnforcedStyle
 
-        MSG = 'Use `Hash#%s` instead of `Hash#%s`.'.freeze
+        MSG = 'Use `Hash#%<prefer>s` instead of `Hash#%<current>s`.'.freeze
 
         OFFENDING_SELECTORS = {
           short: %i[has_key? has_value?],
@@ -52,7 +52,9 @@ module RuboCop
         private
 
         def message(node)
-          format(MSG, proper_method_name(node.method_name), node.method_name)
+          format(MSG,
+                 prefer: proper_method_name(node.method_name),
+                 current: node.method_name)
         end
 
         def proper_method_name(method_name)

--- a/lib/rubocop/cop/style/raise_args.rb
+++ b/lib/rubocop/cop/style/raise_args.rb
@@ -36,9 +36,9 @@ module RuboCop
         include ConfigurableEnforcedStyle
 
         EXPLODED_MSG = 'Provide an exception class and message ' \
-          'as arguments to `%s`.'.freeze
+          'as arguments to `%<method>s`.'.freeze
         COMPACT_MSG = 'Provide an exception object ' \
-          'as an argument to `%s`.'.freeze
+          'as an argument to `%<method>s`.'.freeze
 
         def on_send(node)
           return unless node.command?(:raise) || node.command?(:fail)
@@ -122,9 +122,9 @@ module RuboCop
 
         def message(node)
           if style == :compact
-            format(COMPACT_MSG, node.method_name)
+            format(COMPACT_MSG, method: node.method_name)
           else
-            format(EXPLODED_MSG, node.method_name)
+            format(EXPLODED_MSG, method: node.method_name)
           end
         end
       end

--- a/lib/rubocop/cop/style/redundant_conditional.rb
+++ b/lib/rubocop/cop/style/redundant_conditional.rb
@@ -29,7 +29,8 @@ module RuboCop
 
         COMPARISON_OPERATORS = RuboCop::AST::Node::COMPARISON_OPERATORS
 
-        MSG = 'This conditional expression can just be replaced by `%s`.'.freeze
+        MSG = 'This conditional expression can just be replaced ' \
+              'by `%<msg>s`.'.freeze
 
         def on_if(node)
           return unless offense?(node)
@@ -43,7 +44,7 @@ module RuboCop
           replacement = replacement_condition(node)
           msg = node.elsif? ? "\n#{replacement}" : replacement
 
-          format(MSG, msg)
+          format(MSG, msg: msg)
         end
 
         def_node_matcher :redundant_condition?, <<-RUBY

--- a/lib/rubocop/cop/style/self_assignment.rb
+++ b/lib/rubocop/cop/style/self_assignment.rb
@@ -13,7 +13,7 @@ module RuboCop
       #   # good
       #   x += 1
       class SelfAssignment < Cop
-        MSG = 'Use self-assignment shorthand `%s=`.'.freeze
+        MSG = 'Use self-assignment shorthand `%<method>s=`.'.freeze
         OPS = %i[+ - * ** / | &].freeze
 
         def self.autocorrect_incompatible_with
@@ -52,7 +52,7 @@ module RuboCop
           target_node = s(var_type, var_name)
           return unless receiver == target_node
 
-          add_offense(node, message: format(MSG, method_name))
+          add_offense(node, message: format(MSG, method: method_name))
         end
 
         def check_boolean_node(node, rhs, var_name, var_type)
@@ -62,7 +62,7 @@ module RuboCop
           return unless first_operand == target_node
 
           operator = rhs.loc.operator.source
-          add_offense(node, message: format(MSG, operator))
+          add_offense(node, message: format(MSG, method: operator))
         end
 
         def autocorrect(node)

--- a/lib/rubocop/cop/style/single_line_block_params.rb
+++ b/lib/rubocop/cop/style/single_line_block_params.rb
@@ -9,7 +9,7 @@ module RuboCop
       # For instance one can configure `reduce`(`inject`) to use |a, e| as
       # parameters.
       class SingleLineBlockParams < Cop
-        MSG = 'Name `%s` block params `|%s|`.'.freeze
+        MSG = 'Name `%<method>s` block params `|%<params>s|`.'.freeze
 
         def on_block(node)
           return unless node.single_line?
@@ -28,7 +28,7 @@ module RuboCop
           method_name = node.parent.send_node.method_name
           arguments   = target_args(method_name).join(', ')
 
-          format(MSG, method_name, arguments)
+          format(MSG, method: method_name, params: arguments)
         end
 
         def eligible_arguments?(node)

--- a/lib/rubocop/cop/style/special_global_vars.rb
+++ b/lib/rubocop/cop/style/special_global_vars.rb
@@ -7,11 +7,12 @@ module RuboCop
       class SpecialGlobalVars < Cop
         include ConfigurableEnforcedStyle
 
-        MSG_BOTH = 'Prefer `%s` from the stdlib \'English\' module ' \
-        '(don\'t forget to require it), or `%s` over `%s`.'.freeze
-        MSG_ENGLISH = 'Prefer `%s` from the stdlib \'English\' module ' \
-        '(don\'t forget to require it) over `%s`.'.freeze
-        MSG_REGULAR = 'Prefer `%s` over `%s`.'.freeze
+        MSG_BOTH = 'Prefer `%<prefer>s` from the stdlib \'English\' ' \
+        'module (don\'t forget to require it), or `%<regular>s` over ' \
+        '`%<global>s`.'.freeze
+        MSG_ENGLISH = 'Prefer `%<prefer>s` from the stdlib \'English\' ' \
+        'module (don\'t forget to require it) over `%<global>s`.'.freeze
+        MSG_REGULAR = 'Prefer `%<prefer>s` over `%<global>s`.'.freeze
 
         ENGLISH_VARS = { # rubocop:disable Style/MutableConstant
           :$: => [:$LOAD_PATH],
@@ -77,7 +78,9 @@ module RuboCop
           if style == :use_english_names
             format_english_message(global_var)
           else
-            format(MSG_REGULAR, preferred_names(global_var).first, global_var)
+            format(MSG_REGULAR,
+                   prefer: preferred_names(global_var).first,
+                   global: global_var)
           end
         end
 
@@ -104,14 +107,16 @@ module RuboCop
           format_message(english, regular, global_var)
         end
 
-        def format_message(english, regular, global_var)
+        def format_message(english, regular, global)
           if !regular.empty? && !english.empty?
-            format(MSG_BOTH, format_list(english), format_list(regular),
-                   global_var)
+            format(MSG_BOTH,
+                   prefer: format_list(english),
+                   regular: format_list(regular),
+                   global: global)
           elsif !regular.empty?
-            format(MSG_REGULAR, format_list(regular), global_var)
+            format(MSG_REGULAR, prefer: format_list(regular), global: global)
           elsif !english.empty?
-            format(MSG_ENGLISH, format_list(english), global_var)
+            format(MSG_ENGLISH, prefer: format_list(english), global: global)
           else
             raise 'Bug in SpecialGlobalVars - global var w/o preferred vars!'
           end

--- a/lib/rubocop/cop/style/string_methods.rb
+++ b/lib/rubocop/cop/style/string_methods.rb
@@ -8,7 +8,7 @@ module RuboCop
       class StringMethods < Cop
         include MethodPreference
 
-        MSG = 'Prefer `%s` over `%s`.'.freeze
+        MSG = 'Prefer `%<prefer>s` over `%<current>s`.'.freeze
 
         def on_send(node)
           return unless preferred_method(node.method_name)
@@ -19,7 +19,9 @@ module RuboCop
         private
 
         def message(node)
-          format(MSG, preferred_method(node.method_name), node.method_name)
+          format(MSG,
+                 prefer: preferred_method(node.method_name),
+                 current: node.method_name)
         end
 
         def autocorrect(node)

--- a/lib/rubocop/cop/style/symbol_proc.rb
+++ b/lib/rubocop/cop/style/symbol_proc.rb
@@ -12,7 +12,8 @@ module RuboCop
       #   # good
       #   something.map(&:upcase)
       class SymbolProc < Cop
-        MSG = 'Pass `&:%s` as an argument to `%s` instead of a block.'.freeze
+        MSG = 'Pass `&:%<method>s` as an argument to `%<block_method>s` ' \
+              'instead of a block.'.freeze
         SUPER_TYPES = %i[super zsuper].freeze
 
         def_node_matcher :proc_node?, '(send (const nil? :Proc) :new)'
@@ -73,8 +74,8 @@ module RuboCop
           add_offense(node,
                       location: range,
                       message: format(MSG,
-                                      method_name,
-                                      block_method_name))
+                                      method: method_name,
+                                      block_method: block_method_name))
         end
 
         def autocorrect_method(corrector, node, args, method_name)


### PR DESCRIPTION
Applies annotated templates for style cops O-S.  There were two on the check list in this range that did not have template strings to annotate: `Style/SymbolArray` & `Style/PercentLiteralDelimiters`.

CI issue is documentation fix applied in #5124 .

-----------------

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.  Changes already covered by tests.
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/
