### PR TITLE
Fix build error in manual/cops_rails.md

### DIFF
--- a/manual/cops_rails.md
+++ b/manual/cops_rails.md
@@ -203,11 +203,11 @@ create_table :users do |t|
 end
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-Include | db/migrate/\*.rb
+Name | Default value | Configurable values
+--- | --- | ---
+Include | `db/migrate/*.rb` | Array
 
 ## Rails/Date
 


### PR DESCRIPTION
This PR fixes the following error on Travis CI.

```console
$ bundle exec rake documentation_syntax_check generate_cops_documentation

(snip)

-### Important attributes
+### Configurable attributes

-Attribute | Value
---- | ---
-Include | db/migrate/\*.rb
+Name | Default value | Configurable values
+--- | --- | ---
+Include | `db/migrate/*.rb` | Array

(snip)

.travis.rb:25:in `sh!': `bundle exec rake documentation_syntax_check generate_cops_documentation` is failed (RuntimeError)
	from .travis.rb:40:in `<main>'
The command "ruby .travis.rb" exited with 1.
```

https://travis-ci.org/bbatsov/rubocop/jobs/307082624#L708-L716

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
