### PR TITLE
Remove unnecessary Ruby version in numeric_predicate_spec

### DIFF
--- a/spec/rubocop/cop/style/numeric_predicate_spec.rb
+++ b/spec/rubocop/cop/style/numeric_predicate_spec.rb
@@ -96,7 +96,7 @@ describe RuboCop::Cop::Style::NumericPredicate, :config do
     end
 
     context 'when checking if a number is positive' do
-      context 'when target ruby version is 2.3 or higher', :ruby23, :ruby24 do
+      context 'when target ruby version is 2.3 or higher', :ruby23 do
         it_behaves_like 'code with offense',
                         'number > 0',
                         'number.positive?'
@@ -126,7 +126,7 @@ describe RuboCop::Cop::Style::NumericPredicate, :config do
     end
 
     context 'when checking if a number is negative' do
-      context 'when target ruby version is 2.3 or higher', :ruby23, :ruby24 do
+      context 'when target ruby version is 2.3 or higher', :ruby23 do
         it_behaves_like 'code with offense',
                         'number < 0',
                         'number.negative?'


### PR DESCRIPTION
This is a small change to the test code (cop/style/numeric_predicate_spec.rb).

I think that it is unnecessary to mention Ruby 2.4 when testing for Ruby 2.3 or higher. The reason is two points below.

- Specify only the minimum required Ruby version as in other test cases
- There is no need to add the mention to Ruby 2.5 or higher in the future

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
