### PR TITLE
Add an example of `EnforcedStyle` for `Layout/EmptyLinesAroundClassBody` cop

### DIFF
--- a/lib/rubocop/cop/layout/empty_lines_around_class_body.rb
+++ b/lib/rubocop/cop/layout/empty_lines_around_class_body.rb
@@ -11,10 +11,38 @@ module RuboCop
       #
       #   class Foo
       #
-      #      def bar
-      #        # ...
-      #      end
+      #     def bar
+      #       # ...
+      #     end
       #
+      #   end
+      #
+      # @example EnforcedStyle: empty_lines_except_namespace
+      #   # good
+      #
+      #   class Foo
+      #     class Bar
+      #
+      #       # ...
+      #
+      #     end
+      #   end
+      #
+      # @example EnforcedStyle: empty_lines_special
+      #   # good
+      #   class Foo
+      #
+      #     def bar; end
+      #
+      #   end
+      #
+      # @example EnforcedStyle: no_empty_lines (default)
+      #   # good
+      #
+      #   class Foo
+      #     def bar
+      #       # ...
+      #     end
       #   end
       class EmptyLinesAroundClassBody < Cop
         include EmptyLinesAroundBody

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -835,10 +835,38 @@ the configuration.
 
 class Foo
 
-   def bar
-     # ...
-   end
+  def bar
+    # ...
+  end
 
+end
+```
+```ruby
+# good
+
+class Foo
+  class Bar
+
+    # ...
+
+  end
+end
+```
+```ruby
+# good
+class Foo
+
+  def bar; end
+
+end
+```
+```ruby
+# good
+
+class Foo
+  def bar
+    # ...
+  end
 end
 ```
 


### PR DESCRIPTION
This is only document change.

This commit adds an example of `EnforcedStyle` to `Layout/EmptyLinesAroundClassBody` cop.

Especially since it was written as `good` case which is not the default, this commit will improve mislead.

I found it when I was investigating #4880.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
