### PR TITLE
Add an example of `EnforcedStyle` for `Layout/EmptyLinesAroundModuleBody` cop

### DIFF
--- a/lib/rubocop/cop/layout/empty_lines_around_module_body.rb
+++ b/lib/rubocop/cop/layout/empty_lines_around_module_body.rb
@@ -17,6 +17,25 @@ module RuboCop
       #
       #   end
       #
+      # @example EnforcedStyle: empty_lines_except_namespace
+      #   # good
+      #
+      #   module Foo
+      #     module Bar
+      #
+      #       # ...
+      #
+      #     end
+      #   end
+      #
+      # @example EnforcedStyle: empty_lines_special
+      #   # good
+      #   module Foo
+      #
+      #     def bar; end
+      #
+      #   end
+      #
       # @example EnforcedStyle: no_empty_lines (default)
       #   # good
       #

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -976,6 +976,25 @@ end
 # good
 
 module Foo
+  module Bar
+
+    # ...
+
+  end
+end
+```
+```ruby
+# good
+module Foo
+
+  def bar; end
+
+end
+```
+```ruby
+# good
+
+module Foo
   def bar
     # ...
   end


### PR DESCRIPTION
This is only document change.

This commit adds an examples of `EnforcedStyle` to `Layout/EmptyLinesAroundModuleBody` cop.

I found it when I was investigating #4880 and #5140.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
