### PR TITLE
Add examples to six Style/* cops

### DIFF
--- a/lib/rubocop/cop/style/signal_exception.rb
+++ b/lib/rubocop/cop/style/signal_exception.rb
@@ -4,6 +4,106 @@ module RuboCop
   module Cop
     module Style
       # This cop checks for uses of `fail` and `raise`.
+      #
+      # @example EnforcedStyle: only_raise (default)
+      #   # The `only_raise` style enforces the sole use of `raise`.
+      #   # bad
+      #   begin
+      #     fail
+      #   rescue Exception
+      #     # handle it
+      #   end
+      #
+      #   def watch_out
+      #     fail
+      #   rescue Exception
+      #     # handle it
+      #   end
+      #
+      #   Kernel.fail
+      #
+      #   # good
+      #   begin
+      #     raise
+      #   rescue Exception
+      #     # handle it
+      #   end
+      #
+      #   def watch_out
+      #     raise
+      #   rescue Exception
+      #     # handle it
+      #   end
+      #
+      #   Kernel.raise
+      #
+      # @example EnforcedStyle: only_fail
+      #   # The `only_fail` style enforces the sole use of `fail`.
+      #   # bad
+      #   begin
+      #     raise
+      #   rescue Exception
+      #     # handle it
+      #   end
+      #
+      #   def watch_out
+      #     raise
+      #   rescue Exception
+      #     # handle it
+      #   end
+      #
+      #   Kernel.raise
+      #
+      #   # good
+      #   begin
+      #     fail
+      #   rescue Exception
+      #     # handle it
+      #   end
+      #
+      #   def watch_out
+      #     fail
+      #   rescue Exception
+      #     # handle it
+      #   end
+      #
+      #   Kernel.fail
+      #
+      # @example EnforcedStyle: semantic
+      #   # The `semantic` style enforces the use of `fail` to signal an
+      #   # exception, then will use `raise` to trigger an offense after
+      #   # it has been rescued.
+      #   # bad
+      #   begin
+      #     raise
+      #   rescue Exception
+      #     # handle it
+      #   end
+      #
+      #   def watch_out
+      #     # Error thrown
+      #   rescue Exception
+      #     fail
+      #   end
+      #
+      #   Kernel.fail
+      #   Kernel.raise
+      #
+      #   # good
+      #   begin
+      #     fail
+      #   rescue Exception
+      #     # handle it
+      #   end
+      #
+      #   def watch_out
+      #     fail
+      #   rescue Exception
+      #     raise 'Preferably with descriptive message'
+      #   end
+      #
+      #   explicit_receiver.fail
+      #   explicit_receiver.raise
       class SignalException < Cop
         include ConfigurableEnforcedStyle
 

--- a/lib/rubocop/cop/style/string_literals.rb
+++ b/lib/rubocop/cop/style/string_literals.rb
@@ -4,6 +4,28 @@ module RuboCop
   module Cop
     module Style
       # Checks if uses of quotes match the configured preference.
+      #
+      # @example EnforcedStyle: single_quotes (default)
+      #   # bad
+      #   "No special symbols"
+      #   "No string interpolation"
+      #   "Just text"
+      #
+      #   # good
+      #   'No special symbols'
+      #   'No string interpolation'
+      #   'Just text'
+      #   "Wait! What's #{this}!"
+      #
+      # @example EnforcedStyle: double_quotes
+      #   # bad
+      #   'Just some text'
+      #   'No special chars or interpolation'
+      #
+      #   # good
+      #   "Just some text"
+      #   "No special chars or interpolation"
+      #   "Every string in #{project} uses double_quotes"
       class StringLiterals < Cop
         include ConfigurableEnforcedStyle
         include StringLiteralsHelp

--- a/lib/rubocop/cop/style/string_methods.rb
+++ b/lib/rubocop/cop/style/string_methods.rb
@@ -5,6 +5,15 @@ module RuboCop
     module Style
       # This cop enforces the use of consistent method names
       # from the String class.
+      #
+      # @example
+      #   # bad
+      #   'name'.intern
+      #   'var'.unfavored_method
+      #
+      #   # good
+      #   'name'.to_sym
+      #   'var'.preferred_method
       class StringMethods < Cop
         include MethodPreference
 

--- a/lib/rubocop/cop/style/trivial_accessors.rb
+++ b/lib/rubocop/cop/style/trivial_accessors.rb
@@ -25,7 +25,7 @@ module RuboCop
       #   attr_writer :bar
       #
       #   class << self
-      #     attr_reader: baz
+      #     attr_reader :baz
       #   end
       class TrivialAccessors < Cop
         MSG = 'Use `attr_%<kind>s` to define trivial %<kind>s methods.'.freeze

--- a/lib/rubocop/cop/style/trivial_accessors.rb
+++ b/lib/rubocop/cop/style/trivial_accessors.rb
@@ -5,6 +5,28 @@ module RuboCop
     module Style
       # This cop looks for trivial reader/writer methods, that could
       # have been created with the attr_* family of functions automatically.
+      #
+      # @example
+      #   # bad
+      #   def foo
+      #     @foo
+      #   end
+      #
+      #   def bar=(val)
+      #     @bar = val
+      #   end
+      #
+      #   def self.baz
+      #     @baz
+      #   end
+      #
+      #   # good
+      #   attr_reader :foo
+      #   attr_writer :bar
+      #
+      #   class << self
+      #     attr_reader: baz
+      #   end
       class TrivialAccessors < Cop
         MSG = 'Use `attr_%<kind>s` to define trivial %<kind>s methods.'.freeze
 

--- a/lib/rubocop/cop/style/unneeded_capital_w.rb
+++ b/lib/rubocop/cop/style/unneeded_capital_w.rb
@@ -4,6 +4,16 @@ module RuboCop
   module Cop
     module Style
       # This cop checks for usage of the %W() syntax when %w() would do.
+      #
+      # @example
+      #   # bad
+      #   %W(cat dog pig)
+      #   %W[door wall floor]
+      #
+      #   # good
+      #   %w/swim run bike/
+      #   %w[shirt pants shoes]
+      #   %W(apple #{fruit} grape)
       class UnneededCapitalW < Cop
         include PercentLiteral
 

--- a/lib/rubocop/cop/style/variable_interpolation.rb
+++ b/lib/rubocop/cop/style/variable_interpolation.rb
@@ -4,6 +4,17 @@ module RuboCop
   module Cop
     module Style
       # This cop checks for variable interpolation (like "#@ivar").
+      #
+      # @example
+      #   # bad
+      #   "His name is #$name"
+      #   /check #$pattern/
+      #   "Let's go to the #@store"
+      #
+      #   # good
+      #   "His name is #{$name}"
+      #   /check #{$pattern}/
+      #   "Let's go to the #{@store}"
       class VariableInterpolation < Cop
         MSG = 'Replace interpolated variable `%<variable>s` ' \
               'with expression `#{%<variable>s}`.'.freeze

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -4338,6 +4338,31 @@ Enabled | Yes
 
 Checks if uses of quotes match the configured preference.
 
+### Example
+
+```ruby
+# bad
+"No special symbols"
+"No string interpolation"
+"Just text"
+
+# good
+'No special symbols'
+'No string interpolation'
+'Just text'
+"Wait! What's #{this}!"
+```
+```ruby
+# bad
+'Just some text'
+'No special chars or interpolation'
+
+# good
+"Just some text"
+"No special chars or interpolation"
+"Every string in #{project} uses double_quotes"
+```
+
 ### Configurable attributes
 
 Name | Default value | Configurable values

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -4168,6 +4168,109 @@ Enabled | Yes
 
 This cop checks for uses of `fail` and `raise`.
 
+### Example
+
+```ruby
+# The `only_raise` style enforces the sole use of `raise`.
+# bad
+begin
+  fail
+rescue Exception
+  # handle it
+end
+
+def watch_out
+  fail
+rescue Exception
+  # handle it
+end
+
+Kernel.fail
+
+# good
+begin
+  raise
+rescue Exception
+  # handle it
+end
+
+def watch_out
+  raise
+rescue Exception
+  # handle it
+end
+
+Kernel.raise
+```
+```ruby
+# The `only_fail` style enforces the sole use of `fail`.
+# bad
+begin
+  raise
+rescue Exception
+  # handle it
+end
+
+def watch_out
+  raise
+rescue Exception
+  # handle it
+end
+
+Kernel.raise
+
+# good
+begin
+  fail
+rescue Exception
+  # handle it
+end
+
+def watch_out
+  fail
+rescue Exception
+  # handle it
+end
+
+Kernel.fail
+```
+```ruby
+# The `semantic` style enforces the use of `fail` to signal an
+# exception, then will use `raise` to trigger an offense after
+# it has been rescued.
+# bad
+begin
+  raise
+rescue Exception
+  # handle it
+end
+
+def watch_out
+  # Error thrown
+rescue Exception
+  fail
+end
+
+Kernel.fail
+Kernel.raise
+
+# good
+begin
+  fail
+rescue Exception
+  # handle it
+end
+
+def watch_out
+  fail
+rescue Exception
+  raise 'Preferably with descriptive message'
+end
+
+explicit_receiver.fail
+explicit_receiver.raise
+```
+
 ### Configurable attributes
 
 Name | Default value | Configurable values

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -4880,6 +4880,20 @@ Enabled | Yes
 
 This cop checks for variable interpolation (like "#@ivar").
 
+### Example
+
+```ruby
+# bad
+"His name is #$name"
+/check #$pattern/
+"Let's go to the #@store"
+
+# good
+"His name is #{$name}"
+/check #{$pattern}/
+"Let's go to the #{@store}"
+```
+
 ### References
 
 * [https://github.com/bbatsov/ruby-style-guide#curlies-interpolate](https://github.com/bbatsov/ruby-style-guide#curlies-interpolate)

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -4948,7 +4948,7 @@ attr_reader :foo
 attr_writer :bar
 
 class << self
-  attr_reader: baz
+  attr_reader :baz
 end
 ```
 

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -4390,6 +4390,18 @@ Disabled | Yes
 This cop enforces the use of consistent method names
 from the String class.
 
+### Example
+
+```ruby
+# bad
+'name'.intern
+'var'.unfavored_method
+
+# good
+'name'.to_sym
+'var'.preferred_method
+```
+
 ### Configurable attributes
 
 Name | Default value | Configurable values

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -4839,6 +4839,19 @@ Enabled | Yes
 
 This cop checks for usage of the %W() syntax when %w() would do.
 
+### Example
+
+```ruby
+# bad
+%W(cat dog pig)
+%W[door wall floor]
+
+# good
+%w/swim run bike/
+%w[shirt pants shoes]
+%W(apple #{fruit} grape)
+```
+
 ## Style/UnneededInterpolation
 
 Enabled by default | Supports autocorrection

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -4787,6 +4787,31 @@ Enabled | Yes
 This cop looks for trivial reader/writer methods, that could
 have been created with the attr_* family of functions automatically.
 
+### Example
+
+```ruby
+# bad
+def foo
+  @foo
+end
+
+def bar=(val)
+  @bar = val
+end
+
+def self.baz
+  @baz
+end
+
+# good
+attr_reader :foo
+attr_writer :bar
+
+class << self
+  attr_reader: baz
+end
+```
+
 ### Configurable attributes
 
 Name | Default value | Configurable values


### PR DESCRIPTION
This PR adds examples to six Style Cops listed in the documentation issue #4910 .  Each example set is contained to one commit.

Those Cops are:

1. `Stlye/SignalException`
1. `Stlye/StringLiterals`
1. `Stlye/StringMethods`
1. `Stlye/TrivialAccessors`
1. `Stlye/UnneededCapitalW`
1. `Stlye/VariableInterpolation`

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
