### PR TITLE
Fix typos with misspell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -356,7 +356,7 @@
 * [#4055](https://github.com/bbatsov/rubocop/pull/4055): Add parameters count to offense message for `Metrics/ParameterLists` cop. ([@pocke][])
 * [#4081](https://github.com/bbatsov/rubocop/pull/4081): Allow `Marshal.load` if argument is a `Marshal.dump` in `Security/MarshalLoad` cop. ([@droptheplot][])
 * [#4124](https://github.com/bbatsov/rubocop/issues/4124): Make `Style/SymbolArray` cop to enable by default. ([@pocke][])
-* [#3331](https://github.com/bbatsov/rubocop/issues/3331): Change `Style/MultilineMethodCallIndentation` `indented_relative_to_receiver` to indent relative to the reciever and not relative to the caller. ([@jfelchner][])
+* [#3331](https://github.com/bbatsov/rubocop/issues/3331): Change `Style/MultilineMethodCallIndentation` `indented_relative_to_receiver` to indent relative to the receiver and not relative to the caller. ([@jfelchner][])
 * [#4137](https://github.com/bbatsov/rubocop/pull/4137): Allow lines to be exempted from `IndentationWidth` by regex. ([@jfelchner][])
 
 ### Bug fixes
@@ -418,7 +418,7 @@
 * [#3804](https://github.com/bbatsov/rubocop/pull/3804): Add new `Lint/SafeNavigationChain` cop. ([@pocke][])
 * [#3670](https://github.com/bbatsov/rubocop/pull/3670): Add `CountBlocks` boolean option to `Metrics/BlockNesting`. It allows blocks to be counted towards the nesting limit. ([@georgyangelov][])
 * [#2992](https://github.com/bbatsov/rubocop/issues/2992): Add a configuration to `Style/ConditionalAssignment` to toggle offenses for ternary expressions. ([@rrosenblum][])
-* [#3824](https://github.com/bbatsov/rubocop/pull/3824): Add new `Perfomance/RegexpMatch` cop. ([@pocke][])
+* [#3824](https://github.com/bbatsov/rubocop/pull/3824): Add new `Performance/RegexpMatch` cop. ([@pocke][])
 * [#3825](https://github.com/bbatsov/rubocop/pull/3825): Add new `Rails/SkipsModelValidations` cop. ([@rahulcs][])
 * [#3737](https://github.com/bbatsov/rubocop/issues/3737): Add new `Style/MethodCallWithArgsParentheses` cop. ([@dominh][])
 * Renamed `MethodCallParentheses` to `MethodCallWithoutArgsParentheses`. ([@dominh][])
@@ -483,7 +483,7 @@
 * The offense range for `Performance/FlatMap` now includes any parameters that are passed to `flatten`. ([@rrosenblum][])
 * [#1747](https://github.com/bbatsov/rubocop/issues/1747): Update `Style/SpecialGlobalVars` messages with a reminder to `require 'English'`. ([@ivanovaleksey][])
 * Checks `binding.irb` call by `Lint/Debugger` cop. ([@pocke][])
-* [#3742](https://github.com/bbatsov/rubocop/pull/3742): Checks `min` and `max` call by `Perfomance/CompareWithBlock` cop. ([@pocke][])
+* [#3742](https://github.com/bbatsov/rubocop/pull/3742): Checks `min` and `max` call by `Performance/CompareWithBlock` cop. ([@pocke][])
 
 ### Bug fixes
 
@@ -992,7 +992,7 @@
 * [#2614](https://github.com/bbatsov/rubocop/issues/2614): Check for zero return value from `casecmp` in `Performance/casecmp`. ([@segiddins][])
 * [#2647](https://github.com/bbatsov/rubocop/issues/2647): Allow `xstr` interpolations in `Lint/LiteralInInterpolation`. ([@segiddins][])
 * Report a violation when `freeze` is called on a frozen string literal in `Style/RedundantFreeze`. ([@segiddins][])
-* [#2641](https://github.com/bbatsov/rubocop/issues/2641): Fix crashing on empty methods with block args in `Perfomance/RedundantBlockCall`. ([@segiddins][])
+* [#2641](https://github.com/bbatsov/rubocop/issues/2641): Fix crashing on empty methods with block args in `Performance/RedundantBlockCall`. ([@segiddins][])
 * `Lint/DuplicateMethods` doesn't crash when `class_eval` is used with an implicit receiver. ([@lumeet][])
 * [#2654](https://github.com/bbatsov/rubocop/issues/2654): Fix handling of unary operations in `Style/RedundantParentheses`. ([@lumeet][])
 * [#2661](https://github.com/bbatsov/rubocop/issues/2661): `Style/Next` doesn't crash when auto-correcting modifier `if/unless`. ([@lumeet][])
@@ -1186,7 +1186,7 @@
 ### New features
 
 * [#2028](https://github.com/bbatsov/rubocop/issues/2028): New config `ExtraDetails` supports addition of `Details` param to all cops to allow extra details on offense to be displayed. ([@tansaku][])
-* [#2036](https://github.com/bbatsov/rubocop/issues/2036): New cop `Style/StabbyLambdaParentheses` will find and correct cases where a stabby lambda's paramaters are not wrapped in parentheses. ([@hmadison][])
+* [#2036](https://github.com/bbatsov/rubocop/issues/2036): New cop `Style/StabbyLambdaParentheses` will find and correct cases where a stabby lambda's parameters are not wrapped in parentheses. ([@hmadison][])
 * [#2246](https://github.com/bbatsov/rubocop/pull/2246): `Style/TrailingUnderscoreVariable` will now register an offense for `*_`. ([@rrosenblum][])
 * [#2246](https://github.com/bbatsov/rubocop/pull/2246): `Style/TrailingUnderscoreVariable` now has a configuration to remove named underscore variables (Defaulted to false). ([@rrosenblum][])
 * [#2276](https://github.com/bbatsov/rubocop/pull/2276): New cop `Performance/FixedSize` will register an offense when calling `length`, `size`, or `count` on statically sized objected (strings, symbols, arrays, and hashes). ([@rrosenblum][])
@@ -1222,7 +1222,7 @@
 * `Style/IfUnlessModifier` accepts blocks followed by a chained call. ([@lumeet][])
 * [#2261](https://github.com/bbatsov/rubocop/issues/2261): Make relative `Exclude` paths in `$HOME/.rubocop_todo.yml` be relative to current directory. ([@jonas054][])
 * [#2286](https://github.com/bbatsov/rubocop/issues/2286): Handle auto-correction of empty method when `AllowIfMethodIsEmpty` is `false` in `Style/SingleLineMethods`. ([@jonas054][])
-* [#2246](https://github.com/bbatsov/rubocop/pull/2246): Do not register an offense for `Style/TrailingUnderscoreVariable` when the underscore variable is preceeded by a splat variable. ([@rrosenblum][])
+* [#2246](https://github.com/bbatsov/rubocop/pull/2246): Do not register an offense for `Style/TrailingUnderscoreVariable` when the underscore variable is preceded by a splat variable. ([@rrosenblum][])
 * [#2292](https://github.com/bbatsov/rubocop/pull/2292): Results should not be stored in the cache if affected by errors (crashes). ([@jonas054][])
 * [#2280](https://github.com/bbatsov/rubocop/issues/2280): Avoid reporting space between hash literal keys and values in `Style/ExtraSpacing`. ([@jonas054][])
 * [#2284](https://github.com/bbatsov/rubocop/issues/2284): Fix result cache being shared between ruby versions. ([@miquella][])
@@ -1351,7 +1351,7 @@
 ### New features
 
 * [#2081](https://github.com/bbatsov/rubocop/pull/2081): New cop `Style/Send` checks for the use of `send` and instead encourages changing it to `BasicObject#__send__` or `Object#public_send` (disabled by default). ([@syndbg][])
-* [#2057](https://github.com/bbatsov/rubocop/pull/2057): New cop `Lint/FormatParameterMismatch` checks for a mismatch between the number of fields expected in format/sprintf/% and what was pased to it. ([@edmz][])
+* [#2057](https://github.com/bbatsov/rubocop/pull/2057): New cop `Lint/FormatParameterMismatch` checks for a mismatch between the number of fields expected in format/sprintf/% and what was passed to it. ([@edmz][])
 * [#2010](https://github.com/bbatsov/rubocop/pull/2010): Add `space` style for SpaceInsideStringInterpolation. ([@gotrevor][])
 * [#2007](https://github.com/bbatsov/rubocop/pull/2007): Allow any modifier before `def`, not only visibility modifiers. ([@fphilipe][])
 * [#1980](https://github.com/bbatsov/rubocop/pull/1980): `--auto-gen-config` now outputs an excluded files list for failed cops (up to a maxiumum of 15 files). ([@bmorrall][])
@@ -1699,7 +1699,7 @@
 * `AlignHash` no longer skips multiline hashes that contain some elements on the same line. ([@mvz][])
 * [#1349](https://github.com/bbatsov/rubocop/issues/1349): `BracesAroundHashParameters` no longer cleans up whitespace in autocorrect, as these extra corrections are likely to interfere with other cops' corrections. ([@jonas054][])
 * [#1350](https://github.com/bbatsov/rubocop/issues/1350): Guard against `Blocks` cop introducing syntax errors in auto-correct. ([@jonas054][])
-* [#1374](https://github.com/bbatsov/rubocop/issues/1374): To eliminate interference, auto-correction is now done by one cop at a time, with saving and re-parsing inbetween. ([@jonas054][])
+* [#1374](https://github.com/bbatsov/rubocop/issues/1374): To eliminate interference, auto-correction is now done by one cop at a time, with saving and re-parsing in between. ([@jonas054][])
 * [#1388](https://github.com/bbatsov/rubocop/issues/1388): Fix a false positive in `FormatString`. ([@bbatsov][])
 * [#1389](https://github.com/bbatsov/rubocop/issues/1389): Make `--out` to create parent directories. ([@yous][])
 * Refine HTML formatter. ([@yujinakayama][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -1600,7 +1600,7 @@ Rails/ReversibleMigration:
 
 Rails/SafeNavigation:
   # This will convert usages of `try` to use safe navigation as well as `try!`.
-  # `try` and `try!` work slighly differently. `try!` and safe navigation will
+  # `try` and `try!` work slightly differently. `try!` and safe navigation will
   # both raise a `NoMethodError` if the receiver of the method call does not
   # implement the intended method. `try` will not raise an exception for this.
   ConvertTry: false

--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -951,7 +951,7 @@ Style/RescueStandardError:
 Style/SafeNavigation:
   Description: >-
                   This cop transforms usages of a method call safeguarded by
-                  a check for the existance of the object to
+                  a check for the existence of the object to
                   safe navigation (`&.`).
   Enabled: true
 

--- a/lib/rubocop/ast/node/array_node.rb
+++ b/lib/rubocop/ast/node/array_node.rb
@@ -31,7 +31,7 @@ module RuboCop
       #   Check for any percent literal.
       #
       # @overload percent_literal?(type)
-      #   Check for percent literaly of type `type`.
+      #   Check for percent literal of type `type`.
       #
       #   @param type [Symbol] an optional percent literal type
       #

--- a/lib/rubocop/cop/layout/multiline_array_brace_layout.rb
+++ b/lib/rubocop/cop/layout/multiline_array_brace_layout.rb
@@ -103,7 +103,7 @@ module RuboCop
           'after the last array element.'.freeze
 
         ALWAYS_SAME_LINE_MESSAGE = 'Closing array brace must be on the same ' \
-          'line as teh last array element.'.freeze
+          'line as the last array element.'.freeze
 
         def on_array(node)
           check_brace_layout(node)

--- a/lib/rubocop/cop/mixin/documentation_comment.rb
+++ b/lib/rubocop/cop/mixin/documentation_comment.rb
@@ -24,7 +24,7 @@ module RuboCop
       end
 
       def preceding_comment?(n1, n2)
-        n1 && n2 && preceed?(n2, n1) &&
+        n1 && n2 && precede?(n2, n1) &&
           comment_line?(n2.loc.expression.source)
       end
 

--- a/lib/rubocop/cop/performance/hash_each_methods.rb
+++ b/lib/rubocop/cop/performance/hash_each_methods.rb
@@ -7,7 +7,7 @@ module RuboCop
       #
       # Note: If you have an array of two-element arrays, you can put
       #   parentheses around the block arguments to indicate that you're not
-      #   working with a hash, and supress RuboCop offenses.
+      #   working with a hash, and suppress RuboCop offenses.
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/style/block_delimiters.rb
+++ b/lib/rubocop/cop/style/block_delimiters.rb
@@ -16,13 +16,13 @@ module RuboCop
       #   # bad - multi-line block
       #   things.map { |thing|
       #     something = thing.some_method
-      #     proces(something)
+      #     process(something)
       #   }
       #
       #   # good - multi-line block
       #   things.map do |thing|
       #     something = thing.some_method
-      #     proces(something)
+      #     process(something)
       #   end
       #
       # @example EnforcedStyle: semantic

--- a/lib/rubocop/cop/style/trailing_method_end_statement.rb
+++ b/lib/rubocop/cop/style/trailing_method_end_statement.rb
@@ -36,7 +36,7 @@ module RuboCop
       class TrailingMethodEndStatement < Cop
         include AutocorrectAlignment
 
-        MSG = 'Place the end statment of a multi-line method on ' \
+        MSG = 'Place the end statement of a multi-line method on ' \
               'its own line.'.freeze
 
         def on_def(node)

--- a/lib/rubocop/cop/util.rb
+++ b/lib/rubocop/cop/util.rb
@@ -286,7 +286,7 @@ module RuboCop
         n2.loc.line - n1.loc.line
       end
 
-      def preceed?(n1, n2)
+      def precede?(n1, n2)
         line_distance(n1, n2) == 1
       end
 

--- a/lib/rubocop/runner.rb
+++ b/lib/rubocop/runner.rb
@@ -47,7 +47,7 @@ module RuboCop
     private
 
     # Warms up the RuboCop cache by forking a suitable number of rubocop
-    # instances that each inspects its alotted group of files.
+    # instances that each inspects its allotted group of files.
     def warm_cache(target_files)
       puts 'Running parallel inspection' if @options[:debug]
       Parallel.each(target_files, &method(:file_offenses))

--- a/manual/configuration.md
+++ b/manual/configuration.md
@@ -181,7 +181,7 @@ shadowed by the setting of `Include` and `Exclude` in other `.rubocop.yml`
 files in subdirectories. This is different from all other parameters, who
 follow RuboCop's general principle that configuration for an inspected file
 is taken from the nearest `.rubocop.yml`, searching upwards.  _This behavior
-will be overriden if you specify the `--ignore-parent-exclusion` command line
+will be overridden if you specify the `--ignore-parent-exclusion` command line
 argument_.
 
 Cops can be run only on specific sets of files when that's needed (for

--- a/manual/cops_performance.md
+++ b/manual/cops_performance.md
@@ -338,7 +338,7 @@ This cop checks for uses of `each_key` and `each_value` Hash methods.
 
 Note: If you have an array of two-element arrays, you can put
   parentheses around the block arguments to indicate that you're not
-  working with a hash, and supress RuboCop offenses.
+  working with a hash, and suppress RuboCop offenses.
 
 ### Example
 

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -291,13 +291,13 @@ items.each { |item| item / 5 }
 # bad - multi-line block
 things.map { |thing|
   something = thing.some_method
-  proces(something)
+  process(something)
 }
 
 # good - multi-line block
 things.map do |thing|
   something = thing.some_method
-  proces(something)
+  process(something)
 end
 ```
 ```ruby

--- a/relnotes/v0.27.0.md
+++ b/relnotes/v0.27.0.md
@@ -18,7 +18,7 @@
 * `AlignHash` no longer skips multiline hashes that contain some elements on the same line. ([@mvz][])
 * [#1349](https://github.com/bbatsov/rubocop/issues/1349): `BracesAroundHashParameters` no longer cleans up whitespace in autocorrect, as these extra corrections are likely to interfere with other cops' corrections. ([@jonas054][])
 * [#1350](https://github.com/bbatsov/rubocop/issues/1350): Guard against `Blocks` cop introducing syntax errors in auto-correct. ([@jonas054][])
-* [#1374](https://github.com/bbatsov/rubocop/issues/1374): To eliminate interference, auto-correction is now done by one cop at a time, with saving and re-parsing inbetween. ([@jonas054][])
+* [#1374](https://github.com/bbatsov/rubocop/issues/1374): To eliminate interference, auto-correction is now done by one cop at a time, with saving and re-parsing in between. ([@jonas054][])
 * [#1388](https://github.com/bbatsov/rubocop/issues/1388): Fix a false positive in `FormatString`. ([@bbatsov][])
 * [#1389](https://github.com/bbatsov/rubocop/issues/1389): Make `--out` to create parent directories. ([@yous][])
 * Refine HTML formatter. ([@yujinakayama][])

--- a/relnotes/v0.33.0.md
+++ b/relnotes/v0.33.0.md
@@ -1,7 +1,7 @@
 ### New features
 
 * [#2081](https://github.com/bbatsov/rubocop/pull/2081): New cop `Style/Send` checks for the use of `send` and instead encourages changing it to `BasicObject#__send__` or `Object#public_send` (disabled by default). ([@syndbg][])
-* [#2057](https://github.com/bbatsov/rubocop/pull/2057): New cop `Lint/FormatParameterMismatch` checks for a mismatch between the number of fields expected in format/sprintf/% and what was pased to it. ([@edmz][])
+* [#2057](https://github.com/bbatsov/rubocop/pull/2057): New cop `Lint/FormatParameterMismatch` checks for a mismatch between the number of fields expected in format/sprintf/% and what was passed to it. ([@edmz][])
 * [#2010](https://github.com/bbatsov/rubocop/pull/2010): Add `space` style for SpaceInsideStringInterpolation. ([@gotrevor][])
 * [#2007](https://github.com/bbatsov/rubocop/pull/2007): Allow any modifier before `def`, not only visibility modifiers. ([@fphilipe][])
 * [#1980](https://github.com/bbatsov/rubocop/pull/1980): `--auto-gen-config` now outputs an excluded files list for failed cops (up to a maxiumum of 15 files). ([@bmorrall][])

--- a/relnotes/v0.35.0.md
+++ b/relnotes/v0.35.0.md
@@ -8,7 +8,7 @@ This release is dedicated to her!
 ### New features
 
 * [#2028](https://github.com/bbatsov/rubocop/issues/2028): New config `ExtraDetails` supports addition of `Details` param to all cops to allow extra details on offense to be displayed. ([@tansaku][])
-* [#2036](https://github.com/bbatsov/rubocop/issues/2036): New cop `Style/StabbyLambdaParentheses` will find and correct cases where a stabby lambda's paramaters are not wrapped in parentheses. ([@hmadison][])
+* [#2036](https://github.com/bbatsov/rubocop/issues/2036): New cop `Style/StabbyLambdaParentheses` will find and correct cases where a stabby lambda's parameters are not wrapped in parentheses. ([@hmadison][])
 * [#2246](https://github.com/bbatsov/rubocop/pull/2246): `Style/TrailingUnderscoreVariable` will now register an offense for `*_`. ([@rrosenblum][])
 * [#2246](https://github.com/bbatsov/rubocop/pull/2246): `Style/TrailingUnderscoreVariable` now has a configuration to remove named underscore variables (Defaulted to false). ([@rrosenblum][])
 * [#2276](https://github.com/bbatsov/rubocop/pull/2276): New cop `Performance/FixedSize` will register an offense when calling `length`, `size`, or `count` on statically sized objected (strings, symbols, arrays, and hashes). ([@rrosenblum][])
@@ -44,7 +44,7 @@ This release is dedicated to her!
 * `Style/IfUnlessModifier` accepts blocks followed by a chained call. ([@lumeet][])
 * [#2261](https://github.com/bbatsov/rubocop/issues/2261): Make relative `Exclude` paths in `$HOME/.rubocop_todo.yml` be relative to current directory. ([@jonas054][])
 * [#2286](https://github.com/bbatsov/rubocop/issues/2286): Handle auto-correction of empty method when `AllowIfMethodIsEmpty` is `false` in `Style/SingleLineMethods`. ([@jonas054][])
-* [#2246](https://github.com/bbatsov/rubocop/pull/2246): Do not register an offense for `Style/TrailingUnderscoreVariable` when the underscore variable is preceeded by a splat variable. ([@rrosenblum][])
+* [#2246](https://github.com/bbatsov/rubocop/pull/2246): Do not register an offense for `Style/TrailingUnderscoreVariable` when the underscore variable is preceded by a splat variable. ([@rrosenblum][])
 * [#2292](https://github.com/bbatsov/rubocop/pull/2292): Results should not be stored in the cache if affected by errors (crashes). ([@jonas054][])
 * [#2280](https://github.com/bbatsov/rubocop/issues/2280): Avoid reporting space between hash literal keys and values in `Style/ExtraSpacing`. ([@jonas054][])
 * [#2284](https://github.com/bbatsov/rubocop/issues/2284): Fix result cache being shared between ruby versions. ([@miquella][])

--- a/relnotes/v0.37.0.md
+++ b/relnotes/v0.37.0.md
@@ -18,7 +18,7 @@
 * [#2614](https://github.com/bbatsov/rubocop/issues/2614): Check for zero return value from `casecmp` in `Performance/casecmp`. ([@segiddins][])
 * [#2647](https://github.com/bbatsov/rubocop/issues/2647): Allow `xstr` interpolations in `Lint/LiteralInInterpolation`. ([@segiddins][])
 * Report a violation when `freeze` is called on a frozen string literal in `Style/RedundantFreeze`. ([@segiddins][])
-* [#2641](https://github.com/bbatsov/rubocop/issues/2641): Fix crashing on empty methods with block args in `Perfomance/RedundantBlockCall`. ([@segiddins][])
+* [#2641](https://github.com/bbatsov/rubocop/issues/2641): Fix crashing on empty methods with block args in `Performance/RedundantBlockCall`. ([@segiddins][])
 * `Lint/DuplicateMethods` doesn't crash when `class_eval` is used with an implicit receiver. ([@lumeet][])
 * [#2654](https://github.com/bbatsov/rubocop/issues/2654): Fix handling of unary operations in `Style/RedundantParentheses`. ([@lumeet][])
 * [#2661](https://github.com/bbatsov/rubocop/issues/2661): `Style/Next` doesn't crash when auto-correcting modifier `if/unless`. ([@lumeet][])

--- a/relnotes/v0.46.0.md
+++ b/relnotes/v0.46.0.md
@@ -16,7 +16,7 @@
 * The offense range for `Performance/FlatMap` now includes any parameters that are passed to `flatten`. ([@rrosenblum][])
 * [#1747](https://github.com/bbatsov/rubocop/issues/1747): Update `Style/SpecialGlobalVars` messages with a reminder to `require 'English'`. ([@ivanovaleksey][])
 * Checks `binding.irb` call by `Lint/Debugger` cop. ([@pocke][])
-* [#3742](https://github.com/bbatsov/rubocop/pull/3742): Checks `min` and `max` call by `Perfomance/CompareWithBlock` cop. ([@pocke][])
+* [#3742](https://github.com/bbatsov/rubocop/pull/3742): Checks `min` and `max` call by `Performance/CompareWithBlock` cop. ([@pocke][])
 
 ### Bug fixes
 

--- a/relnotes/v0.47.0.md
+++ b/relnotes/v0.47.0.md
@@ -10,7 +10,7 @@
 * [#3804](https://github.com/bbatsov/rubocop/pull/3804): Add new `Lint/SafeNavigationChain` cop. ([@pocke][])
 * [#3670](https://github.com/bbatsov/rubocop/pull/3670): Add `CountBlocks` boolean option to `Metrics/BlockNesting`. It allows blocks to be counted towards the nesting limit. ([@georgyangelov][])
 * [#2992](https://github.com/bbatsov/rubocop/issues/2992): Add a configuration to `Style/ConditionalAssignment` to toggle offenses for ternary expressions. ([@rrosenblum][])
-* [#3824](https://github.com/bbatsov/rubocop/pull/3824): Add new `Perfomance/RegexpMatch` cop. ([@pocke][])
+* [#3824](https://github.com/bbatsov/rubocop/pull/3824): Add new `Performance/RegexpMatch` cop. ([@pocke][])
 * [#3825](https://github.com/bbatsov/rubocop/pull/3825): Add new `Rails/SkipsModelValidations` cop. ([@rahulcs][])
 * [#3737](https://github.com/bbatsov/rubocop/issues/3737): Add new `Style/MethodCallWithArgsParentheses` cop. ([@dominh][])
 * Renamed `MethodCallParentheses` to `MethodCallWithoutArgsParentheses`. ([@dominh][])

--- a/relnotes/v0.48.0.md
+++ b/relnotes/v0.48.0.md
@@ -37,7 +37,7 @@
 * [#4055](https://github.com/bbatsov/rubocop/pull/4055): Add parameters count to offense message for `Metrics/ParameterLists` cop. ([@pocke][])
 * [#4081](https://github.com/bbatsov/rubocop/pull/4081): Allow `Marshal.load` if argument is a `Marshal.dump` in `Security/MarshalLoad` cop. ([@droptheplot][])
 * [#4124](https://github.com/bbatsov/rubocop/issues/4124): Make `Style/SymbolArray` cop to enable by default. ([@pocke][])
-* [#3331](https://github.com/bbatsov/rubocop/issues/3331): Change `Style/MultilineMethodCallIndentation` `indented_relative_to_receiver` to indent relative to the reciever and not relative to the caller. ([@jfelchner][])
+* [#3331](https://github.com/bbatsov/rubocop/issues/3331): Change `Style/MultilineMethodCallIndentation` `indented_relative_to_receiver` to indent relative to the receiver and not relative to the caller. ([@jfelchner][])
 * [#4137](https://github.com/bbatsov/rubocop/pull/4137): Allow lines to be exempted from `IndentationWidth` by regex. ([@jfelchner][])
 
 ### Bug fixes

--- a/spec/rubocop/cli/cli_options_spec.rb
+++ b/spec/rubocop/cli/cli_options_spec.rb
@@ -1127,7 +1127,7 @@ describe RuboCop::CLI, :isolated_environment do
   end
 
   describe '--force-exclusion' do
-    context 'when explicitely excluded' do
+    context 'when explicitly excluded' do
       let(:target_file) { 'example.rb' }
 
       before do

--- a/spec/rubocop/cop/bundler/duplicated_gem_spec.rb
+++ b/spec/rubocop/cop/bundler/duplicated_gem_spec.rb
@@ -49,7 +49,7 @@ describe RuboCop::Cop::Bundler::DuplicatedGem, :config do
         expect(cop.offenses.size).to eq(1)
       end
 
-      it "references gem's first occurance in message" do
+      it "references gem's first occurrence in message" do
         inspect_gemfile(source)
         expect(cop.offenses.first.message).to include('2')
       end

--- a/spec/rubocop/cop/lint/percent_string_array_spec.rb
+++ b/spec/rubocop/cop/lint/percent_string_array_spec.rb
@@ -68,7 +68,7 @@ describe RuboCop::Cop::Lint::PercentStringArray do
       CORRECTED_SOURCE
     end
 
-    it 'removes undesireable characters' do
+    it 'removes undesirable characters' do
       expect(autocorrect_source(source)).to eq(expected_corrected_source)
     end
   end

--- a/spec/rubocop/cop/lint/percent_symbol_array_spec.rb
+++ b/spec/rubocop/cop/lint/percent_symbol_array_spec.rb
@@ -57,7 +57,7 @@ describe RuboCop::Cop::Lint::PercentSymbolArray do
       CORRECTED_SOURCE
     end
 
-    it 'removes undesireable characters' do
+    it 'removes undesirable characters' do
       expect(autocorrect_source(source)).to eq(expected_corrected_source)
     end
   end

--- a/spec/rubocop/cop/performance/redundant_block_call_spec.rb
+++ b/spec/rubocop/cop/performance/redundant_block_call_spec.rb
@@ -42,7 +42,7 @@ describe RuboCop::Cop::Performance::RedundantBlockCall do
     RUBY
   end
 
-  it 'autocorrects multiple occurances of block.call with arguments' do
+  it 'autocorrects multiple occurrences of block.call with arguments' do
     new_source = autocorrect_source(<<-RUBY.strip_indent)
       def method(&block)
         block.call 1
@@ -101,7 +101,7 @@ describe RuboCop::Cop::Performance::RedundantBlockCall do
     RUBY
   end
 
-  it 'accepts another block arg in at least one occurance of block.call' do
+  it 'accepts another block arg in at least one occurrence of block.call' do
     expect_no_offenses(<<-RUBY.strip_indent)
       def method(&block)
         block.call(1, &some_proc)

--- a/spec/rubocop/cop/rails/present_spec.rb
+++ b/spec/rubocop/cop/rails/present_spec.rb
@@ -37,7 +37,7 @@ describe RuboCop::Cop::Rails::Present, :config do
       expect_no_offenses('foo.nil? || bar.empty?')
     end
 
-    it 'accepts checking existance && not empty? on different objects' do
+    it 'accepts checking existence && not empty? on different objects' do
       expect_no_offenses('foo && !bar.empty?')
     end
 

--- a/spec/rubocop/cop/style/ascii_comments_spec.rb
+++ b/spec/rubocop/cop/style/ascii_comments_spec.rb
@@ -11,7 +11,7 @@ describe RuboCop::Cop::Style::AsciiComments do
     RUBY
   end
 
-  it 'registers an offense for commentes with mixed chars' do
+  it 'registers an offense for comments with mixed chars' do
     expect_offense(<<-RUBY.strip_indent)
       # encoding: utf-8
       # foo ∂ bar
@@ -32,7 +32,7 @@ describe RuboCop::Cop::Style::AsciiComments do
       expect_no_offenses('# foo ∂ bar')
     end
 
-    it 'registers an offense for commentes with non-allowed non-ascii chars' do
+    it 'registers an offense for comments with non-allowed non-ascii chars' do
       expect_offense(<<-RUBY.strip_indent)
         # encoding: utf-8
         # 这是什么？

--- a/spec/rubocop/cop/style/inverse_methods_spec.rb
+++ b/spec/rubocop/cop/style/inverse_methods_spec.rb
@@ -51,7 +51,7 @@ describe RuboCop::Cop::Style::InverseMethods do
   end
 
   context 'auto-correct' do
-    it 'corrects !.none? wiht a symbol proc to any?' do
+    it 'corrects !.none? with a symbol proc to any?' do
       new_source = autocorrect_source('!foo.none?(&:even?)')
 
       expect(new_source).to eq('foo.any?(&:even?)')

--- a/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
@@ -22,7 +22,7 @@ describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
     RUBY
   end
 
-  it 'register an offense for non-reciever method call without parens' do
+  it 'register an offense for non-receiver method call without parens' do
     expect_offense(<<-RUBY.strip_indent)
       def foo
         test a, b

--- a/spec/rubocop/cop/style/mixin_grouping_spec.rb
+++ b/spec/rubocop/cop/style/mixin_grouping_spec.rb
@@ -69,7 +69,7 @@ describe RuboCop::Cop::Style::MixinGrouping, :config do
                         'expect(foo).to include(bar, baz)'
       end
 
-      context 'with several mixins in seperate calls' do
+      context 'with several mixins in separate calls' do
         it_behaves_like 'code with offense',
                         ['class Foo',
                          '  include Bar, Baz',
@@ -193,7 +193,7 @@ describe RuboCop::Cop::Style::MixinGrouping, :config do
         RUBY
       end
 
-      context 'with several mixins in seperate calls' do
+      context 'with several mixins in separate calls' do
         let(:offenses) { 3 }
         let(:message) { 'Put `include` mixins in a single statement.' }
 
@@ -210,7 +210,7 @@ describe RuboCop::Cop::Style::MixinGrouping, :config do
     end
 
     context 'when using `extend`' do
-      context 'with single mixins in seperate calls' do
+      context 'with single mixins in separate calls' do
         let(:offenses) { 2 }
         let(:message) { 'Put `extend` mixins in a single statement.' }
 

--- a/spec/rubocop/cop/style/trailing_method_end_statement_spec.rb
+++ b/spec/rubocop/cop/style/trailing_method_end_statement_spec.rb
@@ -11,7 +11,7 @@ describe RuboCop::Cop::Style::TrailingMethodEndStatement do
     expect_offense(<<-RUBY.strip_indent)
       def some_method
       foo; end
-           ^^^ Place the end statment of a multi-line method on its own line.
+           ^^^ Place the end statement of a multi-line method on its own line.
     RUBY
   end
 
@@ -20,7 +20,7 @@ describe RuboCop::Cop::Style::TrailingMethodEndStatement do
       def a
         b
       { foo: bar }; end
-                    ^^^ Place the end statment of a multi-line method on its own line.
+                    ^^^ Place the end statement of a multi-line method on its own line.
     RUBY
   end
 
@@ -29,7 +29,7 @@ describe RuboCop::Cop::Style::TrailingMethodEndStatement do
       def c
         b = calculation
         [b] end # because b
-            ^^^ Place the end statment of a multi-line method on its own line.
+            ^^^ Place the end statement of a multi-line method on its own line.
     RUBY
   end
 
@@ -39,7 +39,7 @@ describe RuboCop::Cop::Style::TrailingMethodEndStatement do
         block do
           foo
         end end
-            ^^^ Place the end statment of a multi-line method on its own line.
+            ^^^ Place the end statement of a multi-line method on its own line.
     RUBY
   end
 


### PR DESCRIPTION
[Misspell](https://github.com/client9/misspell) is a typo checker.
It found and fixed many typos in our codebase automatically!

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ ] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
