### PR TITLE
Restyle example formatting for `Layout/MultilineHashBraceLayout`

### DIFF
--- a/lib/rubocop/cop/layout/multiline_hash_brace_layout.rb
+++ b/lib/rubocop/cop/layout/multiline_hash_brace_layout.rb
@@ -26,35 +26,68 @@ module RuboCop
       # The closing brace of a multi-line hash literal must be on the same
       # line as the last element of the hash.
       #
-      # @example
+      # @example EnforcedStyle: symmetrical (default)
       #
-      #     # symmetrical: bad
-      #     # new_line: good
-      #     # same_line: bad
+      #     # bad
       #     { a: 1,
       #       b: 2
       #     }
-      #
-      #     # symmetrical: bad
-      #     # new_line: bad
-      #     # same_line: good
+      #     # bad
       #     {
       #       a: 1,
       #       b: 2 }
       #
-      #     # symmetrical: good
-      #     # new_line: bad
-      #     # same_line: good
+      #     # good
       #     { a: 1,
       #       b: 2 }
       #
-      #     # symmetrical: good
-      #     # new_line: good
-      #     # same_line: bad
+      #     # good
       #     {
       #       a: 1,
       #       b: 2
       #     }
+      #
+      # @example EnforcedStyle: new_line
+      #     # bad
+      #     {
+      #       a: 1,
+      #       b: 2 }
+      #
+      #     # bad
+      #     { a: 1,
+      #       b: 2 }
+      #
+      #     # good
+      #     { a: 1,
+      #       b: 2
+      #     }
+      #
+      #     # good
+      #     {
+      #       a: 1,
+      #       b: 2
+      #     }
+      #
+      # @example EnforcedStyle: same_line
+      #     # bad
+      #     { a: 1,
+      #       b: 2
+      #     }
+      #
+      #     # bad
+      #     {
+      #       a: 1,
+      #       b: 2
+      #     }
+      #
+      #     # good
+      #     {
+      #       a: 1,
+      #       b: 2 }
+      #
+      #     # good
+      #     { a: 1,
+      #       b: 2 }
       class MultilineHashBraceLayout < Cop
         include MultilineLiteralBraceLayout
 

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -1787,33 +1787,66 @@ line as the last element of the hash.
 ### Example
 
 ```ruby
-# symmetrical: bad
-# new_line: good
-# same_line: bad
+# bad
 { a: 1,
   b: 2
 }
-
-# symmetrical: bad
-# new_line: bad
-# same_line: good
+# bad
 {
   a: 1,
   b: 2 }
 
-# symmetrical: good
-# new_line: bad
-# same_line: good
+# good
 { a: 1,
   b: 2 }
 
-# symmetrical: good
-# new_line: good
-# same_line: bad
+# good
 {
   a: 1,
   b: 2
 }
+```
+```ruby
+# bad
+{
+  a: 1,
+  b: 2 }
+
+# bad
+{ a: 1,
+  b: 2 }
+
+# good
+{ a: 1,
+  b: 2
+}
+
+# good
+{
+  a: 1,
+  b: 2
+}
+```
+```ruby
+# bad
+{ a: 1,
+  b: 2
+}
+
+# bad
+{
+  a: 1,
+  b: 2
+}
+
+# good
+{
+  a: 1,
+  b: 2 }
+
+# good
+{ a: 1,
+  b: 2 }
 ```
 
 ### Configurable attributes


### PR DESCRIPTION
Follow up of https://github.com/bbatsov/rubocop/pull/4880#issuecomment-338499947.

This commit is a change of document format for `Layout/MultilineHashBraceLayout` cop.
This is a similar change to #5123.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
