### PR TITLE
Make `--show-cops` option aware of `--force-default-config`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@
 * [#4633](https://github.com/bbatsov/rubocop/issues/4633): Make metrics cops aware of `define_method`. ([@pocke][])
 * [#5037](https://github.com/bbatsov/rubocop/pull/5037): Make display cop names to enable by default. ([@pocke][])
 * [#4449](https://github.com/bbatsov/rubocop/issues/4449): Make `Layout/IndentHeredoc` aware of line length. ([@pocke][])
+* [#5146](https://github.com/bbatsov/rubocop/pull/5146): Make `--show-cops` option aware of `--force-default-config`. ([@pocke][])
 
 ## 0.51.0 (2017-10-18)
 

--- a/lib/rubocop/cli.rb
+++ b/lib/rubocop/cli.rb
@@ -103,14 +103,14 @@ module RuboCop
     end
 
     def act_on_options
-      handle_exiting_options
-
       ConfigLoader.debug = @options[:debug]
       ConfigLoader.auto_gen_config = @options[:auto_gen_config]
       ConfigLoader.ignore_parent_exclusion = @options[:ignore_parent_exclusion]
 
       @config_store.options_config = @options[:config] if @options[:config]
       @config_store.force_default_config! if @options[:force_default_config]
+
+      handle_exiting_options
 
       if @options[:color]
         # color output explicitly forced on

--- a/spec/rubocop/cli/cli_options_spec.rb
+++ b/spec/rubocop/cli/cli_options_spec.rb
@@ -623,7 +623,7 @@ describe RuboCop::CLI, :isolated_environment do
       it 'prints the current configuration' do
         out = stdout.lines.to_a
         printed_config = YAML.load(out.join) # rubocop:disable Security/YAMLLoad
-        cop_names = (cop_list[0] || '').split(',')
+        cop_names = (arguments[0] || '').split(',')
         cop_names.each do |cop_name|
           global_conf[cop_name].each do |key, value|
             printed_value = printed_config[cop_name][key]
@@ -649,12 +649,12 @@ describe RuboCop::CLI, :isolated_environment do
         Metrics/LineLength:
           Max: 110
       YAML
-      # expect(cli.run(['--show-cops'] + cop_list)).to eq(0)
-      cli.run(['--show-cops'] + cop_list)
+      # expect(cli.run(['--show-cops'] + arguments)).to eq(0)
+      cli.run(['--show-cops'] + arguments)
     end
 
     context 'with no args' do
-      let(:cop_list) { [] }
+      let(:arguments) { [] }
 
       # Extracts the first line out of the description
       def short_description_of_cop(cop)
@@ -707,7 +707,7 @@ describe RuboCop::CLI, :isolated_environment do
     end
 
     context 'with one cop given' do
-      let(:cop_list) { ['Layout/Tab'] }
+      let(:arguments) { ['Layout/Tab'] }
 
       it 'prints that cop and nothing else' do
         expect(stdout).to match(
@@ -724,13 +724,13 @@ describe RuboCop::CLI, :isolated_environment do
     end
 
     context 'with two cops given' do
-      let(:cop_list) { ['Layout/Tab,Metrics/LineLength'] }
+      let(:arguments) { ['Layout/Tab,Metrics/LineLength'] }
 
       include_examples :prints_config
     end
 
     context 'with one of the cops misspelled' do
-      let(:cop_list) { ['Layout/Tab,Lint/X123'] }
+      let(:arguments) { ['Layout/Tab,Lint/X123'] }
 
       it 'skips the unknown cop' do
         expect(stdout).to match(
@@ -740,6 +740,14 @@ describe RuboCop::CLI, :isolated_environment do
            /^  StyleGuide: ('|")#spaces-indentation('|")$/,
            '  Enabled: true'].join("\n")
         )
+      end
+    end
+
+    context 'with --force-default-config' do
+      let(:arguments) { ['Metrics/LineLength', '--force-default-config'] }
+
+      it 'prioritizes default config' do
+        expect(YAML.safe_load(stdout)['Metrics/LineLength']['Max']).to eq(80)
       end
     end
   end


### PR DESCRIPTION
Problem
===

Currently, `--show-cops` option is not aware of `--force-default-config` option. It always print a configuration for current directory.
So we need chdir to get a default configuration with --show-cops.

For example
---

```bash
$ cat .rubocop.yml
Layout/Tab:
  Enabled: false

$ rubocop --show-cops Layout/Tab --force-default-config
Layout/Tab:
  Description: No hard tabs.
  StyleGuide: "#spaces-indentation"
  Enabled: false
  IndentationWidth:
```

Solution
=====

This change will make `--show-cops` option aware of `--force-default-config`.



-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
