### PR TITLE
[Fix #5128] Fix `Bundler/OrderedGems` on nil gems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,7 @@
 * [#5075](https://github.com/bbatsov/rubocop/issues/5075): Fix auto-correct for `Style/RedundantParentheses` cop when unspaced ternary is present. ([@tiagotex][])
 * [#5155](https://github.com/bbatsov/rubocop/issues/5155): Fix a false negative for `Naming/ConstantName` cop when using frozen object assignment. ([@koic][])
 * Fix a false positive in `Style/SafeNavigation` when the right hand side is negated. ([@rrosenblum][])
-* [#5128](https://github.com/bbatsov/rubocop/issues/5128): Fix `Bundler/OrderedGems` when a gem name evaluates to nil (from a variable). ([@tdeo][])
+* [#5128](https://github.com/bbatsov/rubocop/issues/5128): Fix `Bundler/OrderedGems` when gems are references from variables (ignores them in the sorting). ([@tdeo][])
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@
 * [#5075](https://github.com/bbatsov/rubocop/issues/5075): Fix auto-correct for `Style/RedundantParentheses` cop when unspaced ternary is present. ([@tiagotex][])
 * [#5155](https://github.com/bbatsov/rubocop/issues/5155): Fix a false negative for `Naming/ConstantName` cop when using frozen object assignment. ([@koic][])
 * Fix a false positive in `Style/SafeNavigation` when the right hand side is negated. ([@rrosenblum][])
+* [#5128](https://github.com/bbatsov/rubocop/issues/5128): Fix `Bundler/OrderedGems` when a gem name evaluates to nil (from a variable). ([@tdeo][])
 
 ### Changes
 

--- a/lib/rubocop/cop/bundler/ordered_gems.rb
+++ b/lib/rubocop/cop/bundler/ordered_gems.rb
@@ -54,7 +54,7 @@ module RuboCop
         end
 
         def_node_search :gem_declarations, <<-PATTERN
-          (:send nil? :gem ...)
+          (:send nil? :gem str ...)
         PATTERN
       end
     end

--- a/lib/rubocop/cop/mixin/ordered_gem_node.rb
+++ b/lib/rubocop/cop/mixin/ordered_gem_node.rb
@@ -37,7 +37,7 @@ module RuboCop
       end
 
       def gem_name(declaration_node)
-        declaration_node.first_argument.str_content
+        declaration_node.first_argument.str_content.to_s
       end
 
       def declaration_with_comment(node)

--- a/lib/rubocop/cop/mixin/ordered_gem_node.rb
+++ b/lib/rubocop/cop/mixin/ordered_gem_node.rb
@@ -37,7 +37,7 @@ module RuboCop
       end
 
       def gem_name(declaration_node)
-        declaration_node.first_argument.str_content.to_s
+        declaration_node.first_argument.str_content
       end
 
       def declaration_with_comment(node)

--- a/spec/rubocop/cop/bundler/ordered_gems_spec.rb
+++ b/spec/rubocop/cop/bundler/ordered_gems_spec.rb
@@ -22,6 +22,13 @@ describe RuboCop::Cop::Bundler::OrderedGems, :config do
         gem 'rubocop'
       RUBY
     end
+
+    it 'works if gem is referenced from an environment variable' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        gem ENV['env_key_not_defined'] if ENV.key?('env_key_not_defined')
+        gem ENV['env_key_undefined'] if ENV.key?('env_key_undefined')
+      RUBY
+    end
   end
 
   context 'When gems are not alphabetically sorted' do

--- a/spec/rubocop/cop/bundler/ordered_gems_spec.rb
+++ b/spec/rubocop/cop/bundler/ordered_gems_spec.rb
@@ -22,11 +22,22 @@ describe RuboCop::Cop::Bundler::OrderedGems, :config do
         gem 'rubocop'
       RUBY
     end
+  end
 
-    it 'works if gem is referenced from an environment variable' do
+  context 'when a gem is referenced from a variable' do
+    it 'ignores the line' do
       expect_no_offenses(<<-RUBY.strip_indent)
-        gem ENV['env_key_not_defined'] if ENV.key?('env_key_not_defined')
+        gem 'rspec'
         gem ENV['env_key_undefined'] if ENV.key?('env_key_undefined')
+        gem 'rubocop'
+      RUBY
+    end
+
+    it 'resets the sorting to a new block' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        gem 'rubocop'
+        gem ENV['env_key_undefined'] if ENV.key?('env_key_undefined')
+        gem 'ast'
       RUBY
     end
   end


### PR DESCRIPTION
If a gem name evaluates to nil because it comes from a variable, string comparison was failing as reported in issue https://github.com/bbatsov/rubocop/issues/5128

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
