### PR TITLE
[Fix #4932] Accept configuration for `Lint/Syntax`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@
 * [#4449](https://github.com/bbatsov/rubocop/issues/4449): Make `Layout/IndentHeredoc` aware of line length. ([@pocke][])
 * [#5146](https://github.com/bbatsov/rubocop/pull/5146): Make `--show-cops` option aware of `--force-default-config`. ([@pocke][])
 * [#3001](https://github.com/bbatsov/rubocop/issues/3001): Add configuration to `Lint/MissingCopEnableDirective` cop. ([@tdeo][])
+* [#4932](https://github.com/bbatsov/rubocop/issues/4932): Do not fail if configuration contains `Lint/Syntax` cop with the same settings as the default. ([@tdeo][])
 
 ## 0.51.0 (2017-10-18)
 

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -312,7 +312,7 @@ module RuboCop
       check_target_ruby
       validate_parameter_names(valid_cop_names)
       validate_enforced_styles(valid_cop_names)
-      validate_syntax_cop(valid_cop_names)
+      validate_syntax_cop
       reject_mutually_exclusive_defaults
     end
 
@@ -411,9 +411,12 @@ module RuboCop
       end
     end
 
-    def validate_syntax_cop(valid_cop_names)
-      return unless valid_cop_names.include?('Lint/Syntax') ||
-                    valid_cop_names.include?('Syntax')
+    def validate_syntax_cop
+      syntax_config = self['Lint/Syntax'] || self['Syntax']
+      default_config = ConfigLoader.default_configuration['Lint/Syntax']
+
+      return unless syntax_config && \
+                    default_config.merge(syntax_config) != default_config
 
       raise ValidationError,
             "configuration for Syntax cop found in #{smart_loaded_path}\n" \

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -412,7 +412,7 @@ module RuboCop
     end
 
     def validate_syntax_cop
-      syntax_config = self['Lint/Syntax'] || self['Syntax']
+      syntax_config = self['Lint/Syntax']
       default_config = ConfigLoader.default_configuration['Lint/Syntax']
 
       return unless syntax_config &&

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -415,7 +415,7 @@ module RuboCop
       syntax_config = self['Lint/Syntax'] || self['Syntax']
       default_config = ConfigLoader.default_configuration['Lint/Syntax']
 
-      return unless syntax_config && \
+      return unless syntax_config &&
                     default_config.merge(syntax_config) != default_config
 
       raise ValidationError,

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -420,7 +420,7 @@ module RuboCop
 
       raise ValidationError,
             "configuration for Syntax cop found in #{smart_loaded_path}\n" \
-            'This cop cannot be configured.'
+            'It\'s not possible to disable this cop.'
     end
 
     def validate_section_presence(name)

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -1152,7 +1152,9 @@ describe RuboCop::CLI, :isolated_environment do
       expect($stderr.string).to include(
         'Error: configuration for Syntax cop found'
       )
-      expect($stderr.string).to include('This cop cannot be configured.')
+      expect($stderr.string).to include(
+        'It\'s not possible to disable this cop.'
+      )
     end
 
     it 'can be configured to merge a parameter that is a hash' do

--- a/spec/rubocop/config_spec.rb
+++ b/spec/rubocop/config_spec.rb
@@ -266,6 +266,43 @@ describe RuboCop::Config do
           )
       end
     end
+
+    context 'when the configuration includes Lint/Syntax cop' do
+      before do
+        # Force reloading default configuration
+        RuboCop::ConfigLoader.default_configuration = nil
+      end
+
+      context 'when the configuration matches the default' do
+        before do
+          create_file(configuration_path, <<-YAML.strip_indent)
+            Lint/Syntax:
+              Enabled: true
+          YAML
+        end
+
+        it 'does not raise validation error' do
+          expect { configuration.validate }.not_to raise_error
+        end
+      end
+
+      context 'when the configuration does not match the default' do
+        before do
+          create_file(configuration_path, <<-YAML.strip_indent)
+            Lint/Syntax:
+              Enabled: false
+          YAML
+        end
+
+        it 'raises validation error' do
+          expect { configuration.validate }
+            .to raise_error(
+              RuboCop::ValidationError,
+              /configuration for Syntax cop found/
+            )
+        end
+      end
+    end
   end
 
   describe '#make_excludes_absolute' do


### PR DESCRIPTION
Rubocop forbids configuration the `Lint/Syntax` cop so it doesn't
get disabled. This is failing when loading the default rubocop
configuration from rubocop. This changes it to accept configuration
that doesn't differ from the default.

-----------------

Before submitting the PR make sure the following are checked:

* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Used the same coding conventions as the rest of the project.
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ ] All tests(`rake spec`) are passing.
* [ ] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [ ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
