### PR TITLE
Restyle example formatting for `Style/Alias` cop

### DIFF
--- a/lib/rubocop/cop/style/alias.rb
+++ b/lib/rubocop/cop/style/alias.rb
@@ -7,26 +7,21 @@ module RuboCop
       # depending on configuration.
       # It also flags uses of `alias :symbol` rather than `alias bareword`.
       #
-      # @example
-      #
-      #   # EnforcedStyle: prefer_alias
-      #
-      #   # good
-      #   alias bar foo
-      #
+      # @example EnforcedStyle: prefer_alias (default)
       #   # bad
       #   alias_method :bar, :foo
       #   alias :bar :foo
       #
-      # @example
+      #   # good
+      #   alias bar foo
       #
-      #   # EnforcedStyle: prefer_alias_method
+      # @example EnforcedStyle: prefer_alias_method
+      #   # bad
+      #   alias :bar :foo
+      #   alias bar foo
       #
       #   # good
       #   alias_method :bar, :foo
-      #
-      #   # bad
-      #   alias bar foo
       class Alias < Cop
         include ConfigurableEnforcedStyle
 

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -13,23 +13,20 @@ It also flags uses of `alias :symbol` rather than `alias bareword`.
 ### Example
 
 ```ruby
-# EnforcedStyle: prefer_alias
-
-# good
-alias bar foo
-
 # bad
 alias_method :bar, :foo
 alias :bar :foo
+
+# good
+alias bar foo
 ```
 ```ruby
-# EnforcedStyle: prefer_alias_method
+# bad
+alias :bar :foo
+alias bar foo
 
 # good
 alias_method :bar, :foo
-
-# bad
-alias bar foo
 ```
 
 ### Configurable attributes


### PR DESCRIPTION
Follow up of https://github.com/bbatsov/rubocop/pull/4880#issuecomment-338499947.

This commit is a change of document format for `Style/Alias` cop.

Since this example was the opposite of bad and good, it was rearranged
for unification. Also this commit adds one sample which was not mentioned.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
