### PR TITLE
[Fix #5155] Fix a false negative for `Naming/ConstantName` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 * [#5099](https://github.com/bbatsov/rubocop/pull/5099): Prevent `Style/MinMax` from breaking on implicit receivers. ([@drenmi][])
 * [#5079](https://github.com/bbatsov/rubocop/issues/5079): Fix false positive for `Style/SafeNavigation` when safe guarding comparisons. ([@tiagotex][])
 * [#5075](https://github.com/bbatsov/rubocop/issues/5075): Fix auto-correct for `Style/RedundantParentheses` cop when unspaced ternary is present. ([@tiagotex][])
+* [#5155](https://github.com/bbatsov/rubocop/issues/5155): Fix a false negative for `Naming/ConstantName` cop when using frozen object assignment. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/layout/indent_heredoc.rb
+++ b/lib/rubocop/cop/layout/indent_heredoc.rb
@@ -42,7 +42,7 @@ module RuboCop
                      '`%<current_indent_type>s`.'.freeze
         LIBRARY_MSG = 'Use %<indentation_width>d spaces for indentation in a ' \
                       'heredoc by using %<method>s.'.freeze
-        StripMethods = {
+        STRIP_METHODS = {
           unindent: 'unindent',
           active_support: 'strip_heredoc',
           powerpack: 'strip_indent'
@@ -98,7 +98,7 @@ module RuboCop
             method = "some library(e.g. ActiveSupport's `String#strip_heredoc`)"
             library_message(indentation_width, method)
           else
-            method = "`String##{StripMethods[style]}`"
+            method = "`String##{STRIP_METHODS[style]}`"
             library_message(indentation_width, method)
           end
         end
@@ -152,7 +152,7 @@ module RuboCop
         def correct_by_library(node)
           lambda do |corrector|
             corrector.replace(node.loc.heredoc_body, indented_body(node))
-            corrected = ".#{StripMethods[style]}"
+            corrected = ".#{STRIP_METHODS[style]}"
             corrector.insert_after(node.loc.expression, corrected)
           end
         end

--- a/lib/rubocop/cop/naming/constant_name.rb
+++ b/lib/rubocop/cop/naming/constant_name.rb
@@ -21,17 +21,34 @@ module RuboCop
         MSG = 'Use SCREAMING_SNAKE_CASE for constants.'.freeze
         SNAKE_CASE = /^[\dA-Z_]+$/
 
+        def_node_matcher :class_or_struct_return_method?, <<-PATTERN
+          (send
+            (const _ {:Class :Struct}) :new
+            ...)
+        PATTERN
+
         def on_casgn(node)
           _scope, const_name, value = *node
 
           # We cannot know the result of method calls like
           # NewClass = something_that_returns_a_class
-          # It's also ok to assign a class constant another class constant
+          # It's also ok to assign a class constant another class constant,
+          # `Class.new(...)` or `Struct.new(...)`
           # SomeClass = SomeOtherClass
-          return if value && (%i[block const casgn].include?(value.type) ||
-                    value.send_type? && value.method_name != :freeze)
+          # SomeClass = Class.new(...)
+          # SomeClass = Struct.new(...)
+          return if value && %i[block const casgn].include?(value.type) ||
+                    allowed_method_call_on_rhs?(value) ||
+                    class_or_struct_return_method?(value)
 
           add_offense(node, location: :name) if const_name !~ SNAKE_CASE
+        end
+
+        private
+
+        def allowed_method_call_on_rhs?(node)
+          node && node.send_type? &&
+            (node.receiver.nil? || !node.receiver.literal?)
         end
       end
     end

--- a/lib/rubocop/cop/naming/constant_name.rb
+++ b/lib/rubocop/cop/naming/constant_name.rb
@@ -28,7 +28,8 @@ module RuboCop
           # NewClass = something_that_returns_a_class
           # It's also ok to assign a class constant another class constant
           # SomeClass = SomeOtherClass
-          return if value && %i[send block const casgn].include?(value.type)
+          return if value && (%i[block const casgn].include?(value.type) ||
+                    value.send_type? && value.method_name != :freeze)
 
           add_offense(node, location: :name) if const_name !~ SNAKE_CASE
         end

--- a/spec/rubocop/cop/naming/constant_name_spec.rb
+++ b/spec/rubocop/cop/naming/constant_name_spec.rb
@@ -10,6 +10,14 @@ describe RuboCop::Cop::Naming::ConstantName do
     RUBY
   end
 
+  it 'registers an offense for camel case in const name' \
+     'when using frozen object assignment' do
+    expect_offense(<<-RUBY.strip_indent)
+      TopCase = 5.freeze
+      ^^^^^^^ Use SCREAMING_SNAKE_CASE for constants.
+    RUBY
+  end
+
   it 'registers offenses for camel case in multiple const assignment' do
     expect_offense(<<-RUBY.strip_indent)
       TopCase, Test2, TEST_3 = 5, 6, 7

--- a/spec/rubocop/cop/naming/constant_name_spec.rb
+++ b/spec/rubocop/cop/naming/constant_name_spec.rb
@@ -52,6 +52,14 @@ describe RuboCop::Cop::Naming::ConstantName do
     expect_no_offenses('AnythingGoes = test')
   end
 
+  it 'does not check names if rhs is a `Class.new`' do
+    expect_no_offenses('Invalid = Class.new(StandardError)')
+  end
+
+  it 'does not check names if rhs is a `Struct.new`' do
+    expect_no_offenses('Investigation = Struct.new(:offenses, :errors)')
+  end
+
   it 'does not check names if rhs is a method call with block' do
     expect_no_offenses(<<-RUBY.strip_indent)
       AnythingGoes = test do


### PR DESCRIPTION
Fixes #5155.

This PR fixes a false negative for `Naming/ConstantName` cop when
using frozen object assignment.

It also fixed the offenses that occurred in RuboCop itself.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
