### PR TITLE
[Refactor] Remove `Util#.block_length`

### DIFF
--- a/lib/rubocop/cop/layout/space_inside_block_braces.rb
+++ b/lib/rubocop/cop/layout/space_inside_block_braces.rb
@@ -118,7 +118,7 @@ module RuboCop
           args_delimiter = node.arguments.loc.begin # Can be ( | or nil.
 
           check_left_brace(inner, node.loc.begin, args_delimiter)
-          check_right_brace(inner, node.loc.end, block_length(node))
+          check_right_brace(inner, node.loc.end, node.single_line?)
         end
 
         def check_left_brace(inner, left_brace, args_delimiter)
@@ -129,8 +129,8 @@ module RuboCop
           end
         end
 
-        def check_right_brace(inner, right_brace, block_length)
-          if inner =~ /\S$/ && block_length.zero?
+        def check_right_brace(inner, right_brace, single_line)
+          if single_line && inner =~ /\S$/
             no_space(right_brace.begin_pos, right_brace.end_pos,
                      'Space missing inside }.')
           else

--- a/lib/rubocop/cop/style/block_delimiters.rb
+++ b/lib/rubocop/cop/style/block_delimiters.rb
@@ -97,7 +97,7 @@ module RuboCop
         private
 
         def line_count_based_message(node)
-          if block_length(node) > 0
+          if node.multiline?
             'Avoid using `{...}` for multi-line blocks.'
           else
             'Prefer `{...}` over `do...end` for single-line blocks.'
@@ -115,7 +115,7 @@ module RuboCop
         end
 
         def braces_for_chaining_message(node)
-          if block_length(node) > 0
+          if node.multiline?
             if return_value_chaining?(node)
               'Prefer `{...}` over `do...end` for multi-line chained blocks.'
             else
@@ -221,10 +221,9 @@ module RuboCop
         end
 
         def braces_for_chaining_style?(node)
-          block_length = block_length(node)
           block_begin = node.loc.begin.source
 
-          block_begin == if block_length > 0
+          block_begin == if node.multiline?
                            (return_value_chaining?(node) ? '{' : 'do')
                          else
                            '{'

--- a/lib/rubocop/cop/util.rb
+++ b/lib/rubocop/cop/util.rb
@@ -48,10 +48,6 @@ module RuboCop
         str
       end
 
-      def block_length(block_node)
-        block_node.loc.end.line - block_node.loc.begin.line
-      end
-
       def comment_line?(line_source)
         line_source =~ /^\s*#/
       end


### PR DESCRIPTION
`Util#.block_length` is used only to check a block has single/multi line.
But we have a better methods, that are `BlockNode#single_line?` and `BlockNode#multiline?`.
So this change will replace `block_length` with `single_line?` or `multiline?`.


-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
