### PR TITLE
Add example names to generated manual

### DIFF
--- a/manual/cops_bundler.md
+++ b/manual/cops_bundler.md
@@ -8,7 +8,7 @@ Enabled | No
 
 A Gem's requirements should be listed only once in a Gemfile.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -58,7 +58,7 @@ For example, when specifying an internal gem server using HTTP on the
 intranet, a use case where HTTPS can not be specified was considered.
 Consider using HTTP only if you can not use HTTPS.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -85,7 +85,7 @@ Enabled | Yes
 
 Gems should be alphabetically sorted within groups.
 
-### Example
+### Examples
 
 ```ruby
 # bad

--- a/manual/cops_gemspec.md
+++ b/manual/cops_gemspec.md
@@ -14,7 +14,7 @@ an unintended usage. On the other hand, duplication of methods such
 as `spec.requirements`, `spec.add_runtime_dependency` and others are
 permitted because it is the intended use of appending values.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -55,7 +55,7 @@ Enabled | Yes
 
 Dependencies in the gemspec should be alphabetically sorted.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -122,7 +122,7 @@ of .rubocop.yml are equal.
 Thereby, RuboCop to perform static analysis working on the version
 required by gemspec.
 
-### Example
+### Examples
 
 ```ruby
 # When `TargetRubyVersion` of .rubocop.yml is `2.3`.

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -9,7 +9,9 @@ Enabled | Yes
 Modifiers should be indented as deep as method definitions, or as deep
 as the class/module keyword, depending on configuration.
 
-### Example
+### Examples
+
+#### EnforcedStyle: indent (default)
 
 ```ruby
 # bad
@@ -24,6 +26,8 @@ class Plumbus
   def smooth; end
 end
 ```
+#### EnforcedStyle: outdent
+
 ```ruby
 # bad
 class Plumbus
@@ -58,7 +62,7 @@ Enabled | Yes
 Here we check if the elements of a multi-line array literal are
 aligned.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -102,7 +106,7 @@ can also be configured. The options are:
   - ignore_implicit (without curly braces)
   - ignore_explicit (with curly braces)
 
-### Example
+### Examples
 
 ```ruby
 # EnforcedHashRocketStyle: key (default)
@@ -198,7 +202,9 @@ Enabled | Yes
 Here we check if the parameters on a multi-line method call or
 definition are aligned.
 
-### Example
+### Examples
+
+#### EnforcedStyle: with_first_parameter (default)
 
 ```ruby
 # good
@@ -211,6 +217,8 @@ foo :bar,
 foo :bar,
   :baz
 ```
+#### EnforcedStyle: with_fixed_indentation
+
 ```ruby
 # good
 
@@ -243,7 +251,7 @@ Enabled | Yes
 This cop checks whether the end statement of a do..end block
 is on its own line.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -276,7 +284,7 @@ are indented in relation to its *case* or *end* keyword.
 
 It will register a separate offense for each misaligned *when*.
 
-### Example
+### Examples
 
 ```ruby
 # If Layout/EndAlignment is set to keyword style (default)
@@ -300,6 +308,8 @@ else
   y / 3
 end
 ```
+#### EnforcedStyle: case (default)
+
 ```ruby
 # if EndAlignment is set to other style such as
 # start_of_line (as shown below), then *when* alignment
@@ -321,6 +331,8 @@ a = case n
       y / 3
 end
 ```
+#### EnforcedStyle: end
+
 ```ruby
 # bad
 a = case n
@@ -404,7 +416,9 @@ possible to group categories of macros.
        - attr_writer
 ```
 
-### Example
+### Examples
+
+#### bad code
 
 ```ruby
 # bad: Expect extend be before constant
@@ -416,6 +430,8 @@ class Person < ApplicationRecord
   include AnotherModule
 end
 ```
+#### of good code
+
 ```ruby
 class Person
   # extend and include go first
@@ -480,7 +496,7 @@ This cops checks the indentation of hanging closing parentheses in
 method calls, method definitions, and grouped expressions. A hanging
 closing parenthesis means `)` preceded by a line break.
 
-### Example
+### Examples
 
 ```ruby
 # good: when x is on its own line, indent this way
@@ -510,7 +526,7 @@ Enabled | Yes
 
 This cops checks the indentation of comments.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -548,7 +564,9 @@ Enabled | Yes
 
 This cop checks the . position in multi-line method calls.
 
-### Example
+### Examples
+
+#### EnforcedStyle: leading (default)
 
 ```ruby
 # bad
@@ -559,6 +577,8 @@ something.
 something
   .method
 ```
+#### EnforcedStyle: trailing
+
 ```ruby
 # bad
 something
@@ -590,7 +610,7 @@ be aligned with an if/unless/while/until/begin/def keyword, but there
 are special cases when they should follow the same rules as the
 alignment of end.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -623,7 +643,7 @@ Enabled | Yes
 
 Checks for a newline after the final magic comment.
 
-### Example
+### Examples
 
 ```ruby
 # good
@@ -662,7 +682,7 @@ empty lines.
 `AllowAdjacentOneLineDefs` can be used to configure is adjacent
 one line methods definitions are an offense
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -699,7 +719,7 @@ Enabled | Yes
 
 This cops checks for two or more consecutive blank lines.
 
-### Example
+### Examples
 
 ```ruby
 # bad - It has two empty lines.
@@ -726,7 +746,7 @@ Enabled | Yes
 
 Access modifiers should be surrounded by blank lines.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -759,7 +779,7 @@ Enabled | Yes
 This cops checks if empty lines exist around the bodies of begin-end
 blocks.
 
-### Example
+### Examples
 
 ```ruby
 # good
@@ -790,7 +810,9 @@ Enabled | Yes
 This cops checks if empty lines around the bodies of blocks match
 the configuration.
 
-### Example
+### Examples
+
+#### EnforcedStyle: empty_lines
 
 ```ruby
 # good
@@ -801,6 +823,8 @@ foo do |bar|
 
 end
 ```
+#### EnforcedStyle: no_empty_lines (default)
+
 ```ruby
 # good
 
@@ -828,7 +852,9 @@ Enabled | Yes
 This cops checks if empty lines around the bodies of classes match
 the configuration.
 
-### Example
+### Examples
+
+#### EnforcedStyle: empty_lines
 
 ```ruby
 # good
@@ -841,6 +867,8 @@ class Foo
 
 end
 ```
+#### EnforcedStyle: empty_lines_except_namespace
+
 ```ruby
 # good
 
@@ -852,6 +880,8 @@ class Foo
   end
 end
 ```
+#### EnforcedStyle: empty_lines_special
+
 ```ruby
 # good
 class Foo
@@ -860,6 +890,8 @@ class Foo
 
 end
 ```
+#### EnforcedStyle: no_empty_lines (default)
+
 ```ruby
 # good
 
@@ -892,7 +924,7 @@ beginning/end and around method definition body.
 `Style/EmptyLinesAroundBeginBody` or `Style/EmptyLinesAroundMethodBody`
 can be used for this purpose.
 
-### Example
+### Examples
 
 ```ruby
 # good
@@ -956,7 +988,7 @@ Enabled | Yes
 
 This cops checks if empty lines exist around the bodies of methods.
 
-### Example
+### Examples
 
 ```ruby
 # good
@@ -987,7 +1019,9 @@ Enabled | Yes
 This cops checks if empty lines around the bodies of modules match
 the configuration.
 
-### Example
+### Examples
+
+#### EnforcedStyle: empty_lines
 
 ```ruby
 # good
@@ -1000,6 +1034,8 @@ module Foo
 
 end
 ```
+#### EnforcedStyle: empty_lines_except_namespace
+
 ```ruby
 # good
 
@@ -1011,6 +1047,8 @@ module Foo
   end
 end
 ```
+#### EnforcedStyle: empty_lines_special
+
 ```ruby
 # good
 module Foo
@@ -1019,6 +1057,8 @@ module Foo
 
 end
 ```
+#### EnforcedStyle: no_empty_lines (default)
+
 ```ruby
 # good
 
@@ -1065,7 +1105,7 @@ Enabled | Yes
 
 This cop checks for extra/unnecessary whitespace.
 
-### Example
+### Examples
 
 ```ruby
 # good if AllowForAlignment is true
@@ -1096,7 +1136,7 @@ Disabled | Yes
 This cop checks for a line break before the first element in a
 multi-line array.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -1118,7 +1158,7 @@ Disabled | Yes
 This cop checks for a line break before the first element in a
 multi-line hash.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -1140,7 +1180,7 @@ Disabled | Yes
 This cop checks for a line break before the first argument in a
 multi-line method call.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -1166,7 +1206,7 @@ Disabled | Yes
 This cop checks for a line break before the first parameter in a
 multi-line method parameter definition.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -1199,7 +1239,7 @@ This cop checks the indentation of the first parameter in a method call.
 Parameters after the first one are checked by Style/AlignParameters, not
 by this cop.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -1242,7 +1282,9 @@ more than the start of the line where the opening square bracket is.
 This default style is called 'special_inside_parentheses'. Alternative
 styles are 'consistent' and 'align_brackets'. Here are examples:
 
-### Example
+### Examples
+
+#### EnforcedStyle: special_inside_parentheses
 
 ```ruby
 # The `special_inside_parentheses` style enforces that the first
@@ -1266,6 +1308,8 @@ but_in_a_method_call([
                        :its_like_this
                      ])
 ```
+#### EnforcedStyle: consistent
+
 ```ruby
 # The `consistent` style enforces that the first element in an array
 # literal where the opening bracket and the first element are on
@@ -1289,6 +1333,8 @@ and_in_a_method_call([
   :no_difference
 ])
 ```
+#### EnforcedStyle: align_brackets
+
 ```ruby
 # The `align_brackets` style enforces that the opening and closing
 # brackets are indented to the same position.
@@ -1325,7 +1371,7 @@ right-hand-side of a multi-line assignment.
 The indentation of the remaining lines can be corrected with
 other cops such as `IndentationConsistency` and `EndAlignment`.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -1369,7 +1415,9 @@ than the start of the line where the opening curly brace is.
 This default style is called 'special_inside_parentheses'. Alternative
 styles are 'consistent' and 'align_braces'. Here are examples:
 
-### Example
+### Examples
+
+#### EnforcedStyle: special_inside_parentheses
 
 ```ruby
 # The `special_inside_parentheses` style enforces that the first key
@@ -1394,6 +1442,8 @@ but_in_a_method_call({
                        its_like: :this
                      })
 ```
+#### EnforcedStyle: consistent
+
 ```ruby
 # The `consistent` style enforces that the first key in a hash
 # literal where the opening brace and the first key are on
@@ -1416,6 +1466,8 @@ and_in_a_method_call({
   no: :difference
 })
 ```
+#### EnforcedStyle: align_braces
+
 ```ruby
 # The `align_brackets` style enforces that the opening and closing
 # braces are indented to the same position.
@@ -1453,7 +1505,7 @@ Note: When `Metrics/LineLength`'s `AllowHeredoc` is false(not default),
       this cop does not add any offenses for long here documents to
       avoid `Metrics/LineLength`'s offenses.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -1494,7 +1546,7 @@ Enabled | Yes
 
 This cops checks for inconsistent indentation.
 
-### Example
+### Examples
 
 ```ruby
 class A
@@ -1527,7 +1579,7 @@ of spaces.
 See also the IndentationConsistency cop which is the companion to this
 one.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -1544,6 +1596,8 @@ class A
   end
 end
 ```
+#### IgnoredPatterns: ['^\s*module']
+
 ```ruby
 # bad
 module A
@@ -1596,7 +1650,7 @@ required for some RDoc special syntax, like `#++`, `#--`,
 `#:nodoc`, `=begin`- and `=end` comments, "shebang" directives,
 or rackup options.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -1639,7 +1693,9 @@ When using the `same_line` style:
 The closing brace of a multi-line array literal must be on the same
 line as the last element of the array.
 
-### Example
+### Examples
+
+#### EnforcedStyle: symmetrical (default)
 
 ```ruby
 # bad
@@ -1662,6 +1718,8 @@ line as the last element of the array.
   :b
 ]
 ```
+#### EnforcedStyle: new_line
+
 ```ruby
 # bad
 [
@@ -1683,6 +1741,8 @@ line as the last element of the array.
   :b
 ]
 ```
+#### EnforcedStyle: same_line
+
 ```ruby
 # bad
 [ :a,
@@ -1720,7 +1780,9 @@ Disabled | Yes
 This cop checks whether the multiline assignments have a newline
 after the assignment operator.
 
-### Example
+### Examples
+
+#### EnforcedStyle: new_line (default)
 
 ```ruby
 # bad
@@ -1742,6 +1804,8 @@ foo =
     nil
   end
 ```
+#### EnforcedStyle: same_line
+
 ```ruby
 # good
 foo = if expression
@@ -1769,7 +1833,7 @@ This cop checks whether the multiline do end blocks have a newline
 after the start of the block. Additionally, it checks whether the block
 arguments, if any, are on the same line as the start of the block.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -1830,7 +1894,9 @@ When using the `same_line` style:
 The closing brace of a multi-line hash literal must be on the same
 line as the last element of the hash.
 
-### Example
+### Examples
+
+#### EnforcedStyle: symmetrical (default)
 
 ```ruby
 # bad
@@ -1852,6 +1918,8 @@ line as the last element of the hash.
   b: 2
 }
 ```
+#### EnforcedStyle: new_line
+
 ```ruby
 # bad
 {
@@ -1873,6 +1941,8 @@ line as the last element of the hash.
   b: 2
 }
 ```
+#### EnforcedStyle: same_line
+
 ```ruby
 # bad
 { a: 1,
@@ -1930,7 +2000,7 @@ When using the `same_line` style:
 The closing brace of a multi-line method call must be on the same
 line as the last argument of the call.
 
-### Example
+### Examples
 
 ```ruby
 # symmetrical: bad
@@ -1977,7 +2047,9 @@ Enabled | Yes
 This cop checks the indentation of the method name part in method calls
 that span more than one line.
 
-### Example
+### Examples
+
+#### EnforcedStyle: aligned
 
 ```ruby
 # bad
@@ -1997,6 +2069,8 @@ Thing.a
      .b
      .c
 ```
+#### EnforcedStyle: indented
+
 ```ruby
 # good
 while myvariable
@@ -2005,6 +2079,8 @@ while myvariable
   # do something
 end
 ```
+#### EnforcedStyle: indented_relative_to_receiver
+
 ```ruby
 # good
 while myvariable
@@ -2057,7 +2133,7 @@ When using the `same_line` style:
 The closing brace of a multi-line method definition must be on the same
 line as the last parameter of the definition.
 
-### Example
+### Examples
 
 ```ruby
 # symmetrical: bad
@@ -2108,7 +2184,7 @@ Enabled | Yes
 This cop checks the indentation of the right hand side operand in
 binary operations that span more than one line.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -2140,7 +2216,7 @@ Enabled | Yes
 This cop checks whether the rescue and ensure keywords are aligned
 properly.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -2168,7 +2244,7 @@ Checks for colon (:) not followed by some kind of space.
 N.B. this cop does not handle spaces after a ternary operator, which are
 instead handled by Layout/SpaceAroundOperators.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -2190,7 +2266,7 @@ Enabled | Yes
 
 Checks for comma (,) not followed by some kind of space.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -2214,7 +2290,7 @@ Enabled | Yes
 
 Checks for space between a method name and a left parenthesis in defs.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -2238,7 +2314,7 @@ Enabled | Yes
 
 This cop checks for space after `!`.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -2260,7 +2336,7 @@ Enabled | Yes
 
 Checks for semicolon (;) not followed by some kind of space.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -2282,7 +2358,9 @@ Enabled | Yes
 
 Checks the spacing inside and after block parameters pipes.
 
-### Example
+### Examples
+
+#### EnforcedStyleInsidePipes: no_space (default)
 
 ```ruby
 # bad
@@ -2293,6 +2371,8 @@ Checks the spacing inside and after block parameters pipes.
 {}.each { |x, y| puts x }
 ->(x, y) { puts x }
 ```
+#### EnforcedStyleInsidePipes: space
+
 ```ruby
 # bad
 {}.each { |x,  y| puts x }
@@ -2318,7 +2398,7 @@ Enabled | Yes
 Checks that the equals signs in parameter default assignments
 have or don't have surrounding space depending on configuration.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -2350,7 +2430,7 @@ Enabled | Yes
 
 Checks the spacing around the keywords.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -2381,7 +2461,7 @@ Enabled | Yes
 Checks that operators have space around them, except for **
 which should not have surrounding space.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -2416,7 +2496,7 @@ Enabled | Yes
 Checks that block braces have or don't have a space before the opening
 brace depending on configuration.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -2445,7 +2525,7 @@ Enabled | Yes
 
 Checks for comma (,) preceded by space.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -2468,7 +2548,7 @@ Enabled | Yes
 This cop checks for missing space between a token and a comment on the
 same line.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -2491,7 +2571,7 @@ Alternatively, extra spaces can be added to align the argument with
 something on a preceding or following line, if the AllowForAlignment
 config parameter is true.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -2519,7 +2599,7 @@ Enabled | Yes
 
 Checks for semicolon (;) preceded by space.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -2538,7 +2618,9 @@ Enabled | Yes
 This cop checks for spaces between -> and opening parameter
 brace in lambda literals.
 
-### Example
+### Examples
+
+#### EnforcedStyle: require_no_space (default)
 
 ```ruby
 # bad
@@ -2547,6 +2629,8 @@ a = -> (x, y) { x + y }
 # good
 a = ->(x, y) { x + y }
 ```
+#### EnforcedStyle: require_space
+
 ```ruby
 # bad
 a = ->(x, y) { x + y }
@@ -2570,7 +2654,7 @@ Enabled | Yes
 Checks for unnecessary additional spaces inside array percent literals
 (i.e. %i/%w).
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -2590,7 +2674,9 @@ them on configuration. For blocks taking parameters, it checks that the
 left brace has or doesn't have trailing space depending on
 configuration.
 
-### Example
+### Examples
+
+#### EnforcedStyle: space (default)
 
 ```ruby
 # The `space` style enforces that block braces have
@@ -2602,6 +2688,8 @@ some_array.each {puts e}
 # good
 some_array.each { puts e }
 ```
+#### EnforcedStyle: no_space
+
 ```ruby
 # The `no_space` style enforces that block braces don't
 # have surrounding space.
@@ -2612,6 +2700,8 @@ some_array.each { puts e }
 # good
 some_array.each {puts e}
 ```
+#### EnforcedStyleForEmptyBraces: no_space (default)
+
 ```ruby
 # The `no_space` EnforcedStyleForEmptyBraces style enforces that
 # block braces don't have a space in between when empty.
@@ -2624,6 +2714,8 @@ some_array.each { }
 # good
 some_array.each {}
 ```
+#### EnforcedStyleForEmptyBraces: space
+
 ```ruby
 # The `space` EnforcedStyleForEmptyBraces style enforces that
 # block braces have at least a spece in between when empty.
@@ -2636,6 +2728,8 @@ some_array.each { }
 some_array.each {  }
 some_array.each {   }
 ```
+#### SpaceBeforeBlockParameters: true (default)
+
 ```ruby
 # The SpaceBeforeBlockParameters style set to `true` enforces that
 # there is a space between `{` and `|`. Overrides `EnforcedStyle`
@@ -2647,6 +2741,8 @@ some_array.each {   }
 # good
 [1, 2, 3].each { |n| n * 2 }
 ```
+#### SpaceBeforeBlockParameters: true
+
 ```ruby
 # The SpaceBeforeBlockParameters style set to `false` enforces that
 # there is no space between `{` and `|`. Overrides `EnforcedStyle`
@@ -2675,7 +2771,7 @@ Enabled | Yes
 
 Checks for spaces inside square brackets.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -2698,7 +2794,9 @@ Enabled | Yes
 Checks that braces used for hash literals have or don't have
 surrounding space depending on configuration.
 
-### Example
+### Examples
+
+#### EnforcedStyle: space
 
 ```ruby
 # The `space` style enforces that hash literals have
@@ -2710,6 +2808,8 @@ h = {a: 1, b: 2}
 # good
 h = { a: 1, b: 2 }
 ```
+#### EnforcedStyle: no_space
+
 ```ruby
 # The `no_space` style enforces that hash literals have
 # no surrounding space.
@@ -2720,6 +2820,8 @@ h = { a: 1, b: 2 }
 # good
 h = {a: 1, b: 2}
 ```
+#### EnforcedStyle: compact
+
 ```ruby
 # The `compact` style normally requires a space inside
 # hash braces, with the exception that successive left
@@ -2751,7 +2853,7 @@ Enabled | Yes
 
 Checks for spaces inside ordinary round parentheses.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -2776,7 +2878,7 @@ Enabled | Yes
 Checks for unnecessary additional spaces inside the delimiters of
 %i/%w/%x literals.
 
-### Example
+### Examples
 
 ```ruby
 # good
@@ -2797,7 +2899,7 @@ Enabled | Yes
 
 Checks for spaces inside range literals.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -2825,7 +2927,9 @@ Enabled | Yes
 
 This cop checks for whitespace within string interpolations.
 
-### Example
+### Examples
+
+#### EnforcedStyle: no_space (default)
 
 ```ruby
 # bad
@@ -2834,6 +2938,8 @@ This cop checks for whitespace within string interpolations.
 # good
    var = "This is the #{no_space} example"
 ```
+#### EnforcedStyle: space
+
 ```ruby
 # bad
    var = "This is the #{no_space} example"

--- a/manual/cops_lint.md
+++ b/manual/cops_lint.md
@@ -9,7 +9,7 @@ Enabled | No
 This cop checks for ambiguous block association with method
 when param passed without parentheses.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -42,7 +42,7 @@ Enabled | No
 This cop checks for ambiguous operators in the first argument of a
 method invocation without parentheses.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -71,7 +71,7 @@ Enabled | No
 This cop checks for ambiguous regexp literals in the first argument of
 a method invocation without parentheses.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -97,7 +97,7 @@ Enabled | No
 This cop checks for assignments in the conditions of
 if/while/until.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -145,7 +145,9 @@ start of the line where the expression started.
 `either` (which is the default) : the `end` is allowed to be in either
 location. The autofixer will default to `start_of_line`.
 
-### Example
+### Examples
+
+#### EnforcedStyleAlignWith: either (default)
 
 ```ruby
 # bad
@@ -161,6 +163,8 @@ variable = lambda do |i|
   i
 end
 ```
+#### EnforcedStyleAlignWith: start_of_block
+
 ```ruby
 # bad
 
@@ -176,6 +180,8 @@ foo.bar
      baz
    end
 ```
+#### EnforcedStyleAlignWith: start_of_line
+
 ```ruby
 # bad
 
@@ -207,7 +213,7 @@ Enabled | No
 This cop checks for `:true` and `:false` symbols.
 In most cases it would be a typo.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -235,7 +241,7 @@ arguments and optional ordinal arguments.
 
 This cop mirrors a warning produced by MRI since 2.2.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -282,7 +288,7 @@ Enabled | No
 This cop checks for conditions that are not on the same line as
 if/while/until.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -312,7 +318,7 @@ Enabled | No
 
 This cop checks for calls to debugger or pry.
 
-### Example
+### Examples
 
 ```ruby
 # bad (ok during development)
@@ -355,7 +361,9 @@ parameter. If it's set to `start_of_line` (which is the default), the
 keyword is. If it's set to `def`, the `end` shall be aligned with the
 `def` keyword.
 
-### Example
+### Examples
+
+#### EnforcedStyleAlignWith: start_of_line (default)
 
 ```ruby
 # bad
@@ -368,6 +376,8 @@ private def foo
 private def foo
 end
 ```
+#### EnforcedStyleAlignWith: def
+
 ```ruby
 # bad
 
@@ -395,7 +405,7 @@ Enabled | Yes
 
 This cop checks for uses of the deprecated class method usages.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -417,7 +427,7 @@ Enabled | No
 This cop checks that there are no repeated conditions
 used in case 'when' expressions.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -449,7 +459,7 @@ Enabled | No
 This cop checks for duplicated instance (or singleton) method
 definitions.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -493,7 +503,7 @@ This cop checks for duplicated keys in hash literals.
 
 This cop mirrors a warning in Ruby 2.2.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -518,7 +528,7 @@ make calls on to build something based on the enumerable that
 each_with_object iterates over, an immutable argument makes no sense.
 It's definitely a bug.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -542,7 +552,7 @@ This cop checks for odd else block layout - like
 having an expression on the same line as the else keyword,
 which is usually a mistake.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -572,7 +582,7 @@ Enabled | Yes
 
 This cop checks for empty `ensure` blocks
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -623,7 +633,7 @@ Enabled | No
 
 This cop checks for the presence of empty expressions.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -650,7 +660,7 @@ Enabled | Yes
 
 This cop checks for empty interpolation.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -671,7 +681,7 @@ Enabled | No
 
 This cop checks for the presence of `when` branches without a body.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -710,7 +720,7 @@ left-hand-side of the variable assignment, if there is one.
 If it's set to `start_of_line`, the `end` shall be aligned with the
 start of the line where the matching keyword appears.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -718,6 +728,8 @@ start of the line where the matching keyword appears.
 variable = if true
     end
 ```
+#### EnforcedStyleAlignWith: keyword (default)
+
 ```ruby
 # bad
 
@@ -729,6 +741,8 @@ variable = if true
 variable = if true
            end
 ```
+#### EnforcedStyleAlignWith: variable
+
 ```ruby
 # bad
 
@@ -740,6 +754,8 @@ variable = if true
 variable = if true
 end
 ```
+#### EnforcedStyleAlignWith: start_of_line
+
 ```ruby
 # bad
 
@@ -767,7 +783,7 @@ Enabled | No
 
 This cop checks for END blocks in method definitions.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -798,7 +814,7 @@ Enabled | No
 
 This cop checks for *return* from an *ensure* block.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -834,7 +850,7 @@ This cop identifies Float literals which are, like, really really really
 really really really really really big. Too big. No-one needs Floats
 that big. If you need a float that big, something is wrong with you.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -857,7 +873,7 @@ This lint sees if there is a mismatch between the number of
 expected fields for format/sprintf/#% and what is actually
 passed as arguments.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -878,7 +894,7 @@ Enabled | No
 
 This cop checks for *rescue* blocks with no body.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -930,7 +946,7 @@ Enabled | No
 This cop checks for implicit string concatenation of string literals
 which are on the same line.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -959,7 +975,7 @@ applied to a singleton method. These access modifiers do not make
 singleton methods private/protected. `private_class_method` can be
 used for that.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -1008,7 +1024,9 @@ and its standard library subclasses, excluding subclasses of
 `StandardError`. It is configurable to suggest using either
 `RuntimeError` (default) or `StandardError` instead.
 
-### Example
+### Examples
+
+#### EnforcedStyle: runtime_error (default)
 
 ```ruby
 # bad
@@ -1019,6 +1037,8 @@ class C < Exception; end
 
 class C < RuntimeError; end
 ```
+#### EnforcedStyle: standard_error
+
 ```ruby
 # bad
 
@@ -1043,7 +1063,7 @@ Enabled | No
 
 This cop checks for interpolation in a single quoted string.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -1066,7 +1086,7 @@ This cop checks for literals used as the conditions or as
 operands in and/or expressions serving as the conditions of
 if/while/until.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -1098,7 +1118,7 @@ Enabled | Yes
 
 This cop checks for interpolated literals.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -1119,7 +1139,7 @@ Enabled | No
 
 This cop checks for uses of *begin...end while/until something*.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -1169,7 +1189,7 @@ after a `# rubocop:disable ...` statement. This will prevent leaving
 cop disables on wide ranges of code, that latter contributors to
 a file wouldn't be aware of.
 
-### Example
+### Examples
 
 ```ruby
 # Lint/MissingCopEnableDirective:
@@ -1222,7 +1242,7 @@ multiple value. However, we can't use the comparison in Ruby. However,
 the comparison is not syntax error. This cop checks the bad usage of
 comparison operators.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -1245,7 +1265,7 @@ Enabled | No
 
 This cop checks for nested method definitions.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -1306,7 +1326,7 @@ Enabled | No
 
 This cop checks for nested percent literals.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -1327,7 +1347,7 @@ Enabled | No
 
 Don't omit the accumulator when calling `next` in a `reduce` block.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -1363,7 +1383,7 @@ value. It registers an offense under these conditions:
  - the return is not contained in an inner scope, e.g. a lambda or a
    method definition.
 
-### Example
+### Examples
 
 ```ruby
 class ItemApi
@@ -1398,7 +1418,7 @@ Enabled | No
 Checks for space between the name of a called method and a left
 parenthesis.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -1427,7 +1447,7 @@ It is more likely that the additional characters are unintended (for
 example, mistranslating an array of literals to percent string notation)
 rather than meant to be part of the resulting strings.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -1452,7 +1472,7 @@ It is more likely that the additional characters are unintended (for
 example, mistranslating an array of literals to percent string notation)
 rather than meant to be part of the resulting symbols.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -1474,7 +1494,7 @@ Enabled | No
 This cop checks for `rand(1)` calls.
 Such calls always return `0`.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -1498,7 +1518,7 @@ Enabled | Yes
 
 This cop checks for redundant `with_index`.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -1530,7 +1550,7 @@ Enabled | Yes
 
 This cop checks for redundant `with_object`.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -1563,7 +1583,7 @@ Enabled | No
 This cop checks for regexp literals used as `match-current-line`.
 If a regexp literal is in condition, the regexp matches `$_` implicitly.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -1592,7 +1612,7 @@ The idea behind warning for these constructs is that the user might
 be under the impression that the return value from the method call is
 an operand of &&/||.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -1617,7 +1637,7 @@ Enabled | No
 
 This cop checks for *rescue* blocks targeting the Exception class.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -1651,7 +1671,7 @@ Enabled | Yes
 Check for arguments to `rescue` that will result in a `TypeError`
 if an exception is raised.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -1692,7 +1712,7 @@ Enabled | No
 This cop checks for the use of a return with a value in a context
 where the value will be ignored. (initialize and setter methods)
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -1731,7 +1751,7 @@ navigation operator, it raises NoMethodError.  We should use a
 safe navigation operator after a safe navigation operator.
 This cop checks for the problem outlined above.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -1770,7 +1790,7 @@ Enabled | No
 
 This cop checks for shadowed arguments.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -1819,7 +1839,7 @@ This cop checks for a rescued exception that get shadowed by a
 less specific exception being rescued before a more specific
 exception is rescued.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -1868,7 +1888,7 @@ for block arguments or block local variables.
 This is a mimic of the warning
 "shadowing outer local variable - foo" from `ruby -cw`.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -1902,7 +1922,7 @@ Enabled | Yes
 This cop checks for string conversion in string interpolation,
 which is redundant.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -1937,7 +1957,7 @@ Enabled | No
 This cop checks for underscore-prefixed variables that are actually
 used.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -1969,7 +1989,7 @@ Enabled | Yes
 
 This cop checks for using Fixnum or Bignum constant.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -2016,7 +2036,7 @@ ruby 2.2.8p477 (2017-09-14 revision 59906) [x86_64-darwin13]
 
 This cop targets Ruby 2.2 or higher containing these 4 features.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -2035,7 +2055,7 @@ Enabled | Yes
 
 This cop checks for unneeded usages of splat expansion
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -2091,7 +2111,7 @@ This cop checks for unreachable code.
 The check are based on the presence of flow of control
 statement in non-final position in *begin*(implicit) blocks.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -2128,7 +2148,7 @@ Enabled | Yes
 
 This cop checks for unused block arguments.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -2180,7 +2200,7 @@ Enabled | Yes
 
 This cop checks for unused method arguments.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -2221,7 +2241,7 @@ Also this cop identifies places where `URI.unescape` can be replaced by
 `CGI.unescape`, `URI.decode_www_form` or `URI.decode_www_form_component`
 depending on your specific use case.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -2252,7 +2272,7 @@ Enabled | Yes
 This cop identifies places where `URI.regexp` is obsolete and should
 not be used. Instead, use `URI::DEFAULT_PARSER.make_regexp`.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -2274,7 +2294,7 @@ class or module body. Conditionally-defined methods are considered as
 always being defined, and thus access modifiers guarding such methods
 are not redundant.
 
-### Example
+### Examples
 
 ```ruby
 class Foo
@@ -2380,7 +2400,7 @@ Currently this cop has advanced logic that detects unreferenced
 reassignments and properly handles varied cases such as branch, loop,
 rescue, ensure, etc.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -2411,7 +2431,7 @@ Enabled | No
 
 This cop checks for comparison of something with itself.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -2427,7 +2447,7 @@ Enabled | No
 
 This cop checks for useless `else` in `begin..end` without `rescue`.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -2459,7 +2479,7 @@ Enabled | No
 This cop checks for setter call to local variable as the final
 expression of a function definition.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -2488,7 +2508,7 @@ Enabled | No
 This cop checks for operators, variables and literals used
 in void context.
 
-### Example
+### Examples
 
 ```ruby
 # bad

--- a/manual/cops_metrics.md
+++ b/manual/cops_metrics.md
@@ -203,7 +203,7 @@ the cop treats it as an `if`/`elsif`/`elsif`... and lets all the `when`
 nodes count. In contrast to the CyclomaticComplexity cop, this cop
 considers `else` nodes as adding complexity.
 
-### Example
+### Examples
 
 ```ruby
 def my_method                   # 1

--- a/manual/cops_naming.md
+++ b/manual/cops_naming.md
@@ -8,7 +8,7 @@ Enabled | No
 
 This cop makes sure that accessor methods are named properly.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -40,7 +40,7 @@ Enabled | No
 
 This cop checks for non-ascii characters in identifier names.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -85,7 +85,7 @@ Enabled | No
 This cop makes sure that certain binary operator methods have their
 sole  parameter named `other`.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -108,7 +108,7 @@ Enabled | No
 This cops checks for class and module names with
 an underscore in them.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -140,7 +140,7 @@ SCREAMING_SNAKE_CASE.
 To avoid false positives, it ignores cases in which we cannot know
 for certain the type of value that would be assigned to a constant.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -166,7 +166,7 @@ This cop makes sure that Ruby source files have snake_case
 names. Ruby scripts (i.e. source files with a shebang in the
 first line) are ignored.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -203,7 +203,9 @@ Enabled | No
 This cop checks that your heredocs are using the configured case.
 By default it is configured to enforce uppercase heredocs.
 
-### Example
+### Examples
+
+#### EnforcedStyle: uppercase (default)
 
 ```ruby
 # bad
@@ -216,6 +218,8 @@ sql
   SELECT * FROM foo
 SQL
 ```
+#### EnforcedStyle: lowercase
+
 ```ruby
 # bad
 <<-SQL
@@ -248,7 +252,7 @@ This cop checks that your heredocs are using meaningful delimiters.
 By default it disallows `END` and `EO*`, and can be configured through
 blacklisting additional delimiters.
 
-### Example
+### Examples
 
 ```ruby
 # good
@@ -286,7 +290,9 @@ Enabled | No
 This cop makes sure that all methods use the configured style,
 snake_case or camelCase, for their names.
 
-### Example
+### Examples
+
+#### EnforcedStyle: snake_case (default)
 
 ```ruby
 # bad
@@ -295,6 +301,8 @@ def fooBar; end
 # good
 def foo_bar; end
 ```
+#### EnforcedStyle: camelCase
+
 ```ruby
 # bad
 def foo_bar; end
@@ -321,7 +329,7 @@ Enabled | No
 
 This cop makes sure that predicates are named properly.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -364,7 +372,9 @@ Enabled | No
 This cop makes sure that all variables use the configured style,
 snake_case or camelCase, for their names.
 
-### Example
+### Examples
+
+#### EnforcedStyle: snake_case (default)
 
 ```ruby
 # bad
@@ -373,6 +383,8 @@ fooBar = 1
 # good
 foo_bar = 1
 ```
+#### EnforcedStyle: camelCase
+
 ```ruby
 # bad
 foo_bar = 1
@@ -401,7 +413,9 @@ This cop makes sure that all numbered variables use the
 configured style, snake_case, normalcase or non_integer,
 for their numbering.
 
-### Example
+### Examples
+
+#### EnforcedStyle: snake_case
 
 ```ruby
 # bad
@@ -412,6 +426,8 @@ variable1 = 1
 
 variable_1 = 1
 ```
+#### EnforcedStyle: normalcase (default)
+
 ```ruby
 # bad
 
@@ -421,6 +437,8 @@ variable_1 = 1
 
 variable1 = 1
 ```
+#### EnforcedStyle: non_integer
+
 ```ruby
 # bad
 

--- a/manual/cops_performance.md
+++ b/manual/cops_performance.md
@@ -9,7 +9,7 @@ Enabled | No
 This cop identifies places where `caller[n]`
 can be replaced by `caller(n..n).first`.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -48,7 +48,7 @@ hitting a condition in the splat expansion, it is possible that
 moving the splat condition to the end will use more memory,
 and run slightly slower.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -91,7 +91,7 @@ Enabled | Yes
 This cop identifies places where a case-insensitive string comparison
 can better be implemented using `casecmp`.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -120,7 +120,7 @@ This cop identifies places where `sort { |a, b| a.foo <=> b.foo }`
 can be replaced by `sort_by(&:foo)`.
 This cop also checks `max` and `min` methods.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -163,7 +163,7 @@ Example:
 
   Model.where(id: [1, 2, 3]).to_a.count { |m| m.method == true }
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -205,7 +205,7 @@ and change them to use `detect` instead.
 own meaning. Correcting ActiveRecord methods with this cop should be
 considered unsafe.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -239,7 +239,7 @@ This cop checks for double `#start_with?` or `#end_with?` calls
 separated by `||`. In some cases such calls can be replaced
 with an single `#start_with?`/`#end_with?` call.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -268,7 +268,7 @@ Enabled | Yes
 This cop identifies unnecessary use of a regex where `String#end_with?`
 would suffice.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -305,7 +305,7 @@ Enabled | Yes
 
 This cop is used to identify usages of
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -340,7 +340,7 @@ Note: If you have an array of two-element arrays, you can put
   parentheses around the block arguments to indicate that you're not
   working with a hash, and suppress RuboCop offenses.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -373,7 +373,7 @@ Enabled | Yes
 This cop identifies places where `lstrip.rstrip` can be replaced by
 `strip`.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -414,7 +414,7 @@ Enabled | Yes
 This cop identifies the use of a `&block` parameter and `block.call`
 where `yield` would do just as well.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -448,7 +448,7 @@ This cop identifies the use of `Regexp#match` or `String#match`, which
 returns `#<MatchData>`/`nil`. The return value of `=~` is an integral
 index/`nil` and is more performant.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -471,7 +471,7 @@ Enabled | Yes
 This cop identifies places where `Hash#merge!` can be replaced by
 `Hash#[]=`.
 
-### Example
+### Examples
 
 ```ruby
 hash.merge!(a: 1)
@@ -498,7 +498,7 @@ Enabled | Yes
 This cop identifies places where `sort_by { ... }` can be replaced by
 `sort`.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -523,7 +523,7 @@ Because the methods avoid creating a `MatchData` object or saving
 backref.
 So, when `MatchData` is not used, use `match?` instead of `match`.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -585,7 +585,7 @@ Enabled | Yes
 This cop is used to identify usages of `reverse.each` and
 change them to use `reverse_each` instead.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -608,7 +608,7 @@ Enabled | Yes
 This cop is used to identify usages of `shuffle.first`, `shuffle.last`
 and `shuffle[]` and change them to use `sample` instead.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -646,7 +646,7 @@ This cop is used to identify usages of `count` on an
 TODO: Add advanced detection of variables that could
 have been assigned to an array or a hash.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -678,7 +678,7 @@ Enabled | Yes
 This cop identifies unnecessary use of a regex where
 `String#start_with?` would suffice.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -708,7 +708,7 @@ Enabled | Yes
 This cop identifies places where `gsub` can be replaced by
 `tr` or `delete`.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -738,7 +738,7 @@ This cop checks for .times.map calls.
 In most cases such calls can be replaced
 with an explicit array creation.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -773,7 +773,7 @@ These differ in encoding. `String.new.encoding` is always `ASCII-8BIT`.
 However, `(+'').encoding` is the same as script encoding(e.g. `UTF-8`).
 So, if you expect `ASCII-8BIT` encoding, disable this cop.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -797,7 +797,7 @@ Enabled | Yes
 This cop identifies places where `URI::Parser.new`
 can be replaced by `URI::DEFAULT_PARSER`.
 
-### Example
+### Examples
 
 ```ruby
 # bad

--- a/manual/cops_rails.md
+++ b/manual/cops_rails.md
@@ -14,7 +14,7 @@ something_filter methods or the newer something_action methods.
 If the TargetRailsVersion is set to less than 4.0, the cop will enforce
 the use of filter methods.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -44,7 +44,7 @@ Enabled | Yes
 This cop checks that ActiveSupport aliases to core ruby methods
 are not used.
 
-### Example
+### Examples
 
 ```ruby
 # good
@@ -68,7 +68,7 @@ Enabled | Yes
 
 This cop checks that jobs subclass ApplicationJob with Rails 5.0.
 
-### Example
+### Examples
 
 ```ruby
 # good
@@ -90,7 +90,7 @@ Enabled | Yes
 
 This cop checks that models subclass ApplicationRecord with Rails 5.0.
 
-### Example
+### Examples
 
 ```ruby
 # good
@@ -116,7 +116,7 @@ Settings:
   NotPresent: Convert usages of not `present?` to `blank?`
   UnlessPresent: Convert usages of `unless` `present?` to `blank?`
 
-### Example
+### Examples
 
 ```ruby
 # NilOrEmpty: true
@@ -166,7 +166,7 @@ This cop checks the migration for which timestamps are not included
 when creating a new table.
 In many cases, timestamps are useful information and should be added.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -232,7 +232,7 @@ and 'to_time_in_current_zone' is reported as warning.
 When EnforcedStyle is 'flexible' then only 'Date.today' is prohibited
 and only 'to_time' is reported as warning.
 
-### Example
+### Examples
 
 ```ruby
 # no offense
@@ -275,7 +275,7 @@ using the target object as a prefix of the method name
 without using the `delegate` method will be a violation.
 When set to `false`, this case is legal.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -332,7 +332,7 @@ This cop looks for delegations that pass :allow_blank as an option
 instead of :allow_nil. :allow_blank is not a valid option to pass
 to ActiveSupport#delegate.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -352,7 +352,7 @@ This cop checks dynamic `find_by_*` methods.
 Use `find_by` instead of dynamic method.
 See. https://github.com/bbatsov/rails-style-guide#find_by
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -392,7 +392,7 @@ Enabled | No
 
 This cop looks for duplicate values in enum declarations.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -423,7 +423,7 @@ Enabled | Yes
 This cop checks that Rails.env is compared using `.production?`-like
 methods instead of equality against a string or symbol.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -456,7 +456,7 @@ is used.)
 the program exiting, which could result in the code failing to run and
 do its job.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -482,7 +482,7 @@ Enabled | No
 This cop is used to identify usages of file path joining process
 to use `Rails.root.join` clause.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -503,7 +503,7 @@ Enabled | Yes
 This cop is used to identify usages of `where.first` and
 change them to use `find_by` instead.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -533,7 +533,7 @@ Enabled | Yes
 This cop is used to identify usages of `all.each` and
 change them to use `all.find_each` instead.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -561,7 +561,7 @@ Enabled | No
 
 This cop checks for the use of the has_and_belongs_to_many macro.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -591,7 +591,7 @@ This cop looks for `has_many` or `has_one` associations that don't
 specify a `:dependent` option.
 It doesn't register an offense if `:through` option was specified.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -631,7 +631,7 @@ If you are running Rails < 5 you should disable the
 Rails/HttpPositionalArguments cop or set your TargetRailsVersion in your
 .rubocop.yml file to 4.0, etc.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -659,7 +659,7 @@ because of a scope or the options used. This can result in unnecessary
 queries in some circumstances. `:inverse_of` must be manually specified
 for associations to work in both ways, or set to `false` to opt-out.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -691,7 +691,7 @@ Enabled | No
 This cop checks for add_column call with NOT NULL constraint
 in migration file.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -719,7 +719,7 @@ Enabled | No
 
 This cop checks for the use of output calls like puts and print
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -749,7 +749,7 @@ simply return a SafeBuffer containing the content as is. Instead,
 use safe_join to join content and escape it and concat to
 concatenate content and escape it, ensuring its safety.
 
-### Example
+### Examples
 
 ```ruby
 user_content = "<b>hi</b>"
@@ -815,7 +815,7 @@ Enabled | Yes
 This cop checks for correct grammar when using ActiveSupport's
 core extensions to the numeric classes.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -840,7 +840,7 @@ Settings:
   NotBlank: Convert usages of not `blank?` to `present?`
   UnlessBlank: Convert usages of `unless` `blank?` to `if` `present?`
 
-### Example
+### Examples
 
 ```ruby
 # NotNilAndNotEmpty: true
@@ -885,7 +885,7 @@ Enabled | Yes
 This cop checks for the use of the read_attribute or
 write_attribute methods.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -916,7 +916,7 @@ Enabled | Yes
 This cop checks whether constant value isn't relative date.
 Because the relative date will be evaluated only once.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -941,7 +941,7 @@ Enabled | Yes
 This cop checks for consistent uses of `request.referer` or
 `request.referrer`, depending on the cop's configuration.
 
-### Example
+### Examples
 
 ```ruby
 # EnforcedStyle: referer
@@ -974,7 +974,7 @@ Enabled | No
 This cop checks whether the change method of the migration file is
 reversible.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -1116,7 +1116,7 @@ This cop converts usages of `try!` to `&.`. It can also be configured
 to convert `try`. It will convert code to use safe navigation if the
 target Ruby version is set to 2.3+
 
-### Example
+### Examples
 
 ```ruby
 # ConvertTry: false
@@ -1174,7 +1174,7 @@ variable that has a call to `persisted?`. Finally, it will ignore any
 call with more than 2 arguments as that is likely not an Active Record
 call or a Model.update(id, attributes) call.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -1211,7 +1211,7 @@ Enabled | No
 This cop checks for scope calls where it was passed
 a method (usually a scope) instead of a lambda/proc.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -1237,7 +1237,7 @@ This cop checks for the use of methods which skip
 validations which are listed in
 http://guides.rubyonrails.org/active_record_validations.html#skipping-validations
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -1284,7 +1284,7 @@ then only use of Time.zone is allowed.
 When EnforcedStyle is 'flexible' then it's also allowed
 to use Time.in_time_zone.
 
-### Example
+### Examples
 
 ```ruby
 # always offense
@@ -1335,7 +1335,7 @@ vs a call to pluck on an ActiveRecord::Associations::CollectionProxy.
 Autocorrect is disabled by default for this cop since it may generate
 false positives.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -1368,7 +1368,7 @@ Enabled | No
 This cop checks that environments called with `Rails.env` predicates
 exist.
 
-### Example
+### Examples
 
 ```ruby
 # bad

--- a/manual/cops_security.md
+++ b/manual/cops_security.md
@@ -8,7 +8,7 @@ Enabled | No
 
 This cop checks for the use of `Kernel#eval` and `Binding#eval`.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -34,7 +34,7 @@ If reading single values (rather than proper JSON objects), like
 option, like `JSON.parse('false', quirks_mode: true)`.
 Other similar issues may apply.
 
-### Example
+### Examples
 
 ```ruby
 # always offense
@@ -65,7 +65,7 @@ This cop checks for the use of Marshal class methods which have
 potential security issues leading to remote code execution when
 loading from an untrusted source.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -93,7 +93,7 @@ This cop checks for the use of YAML class methods which have
 potential security issues leading to remote code execution when
 loading from an untrusted source.
 
-### Example
+### Examples
 
 ```ruby
 # bad

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -10,7 +10,9 @@ This cop enforces the use of either `#alias` or `#alias_method`
 depending on configuration.
 It also flags uses of `alias :symbol` rather than `alias bareword`.
 
-### Example
+### Examples
+
+#### EnforcedStyle: prefer_alias (default)
 
 ```ruby
 # bad
@@ -20,6 +22,8 @@ alias :bar :foo
 # good
 alias bar foo
 ```
+#### EnforcedStyle: prefer_alias_method
+
 ```ruby
 # bad
 alias :bar :foo
@@ -49,7 +53,7 @@ This cop checks for uses of `and` and `or`, and suggests using `&&` and
 `|| instead`. It can be configured to check only in conditions, or in
 all contexts.
 
-### Example
+### Examples
 
 ```ruby
 # EnforcedStyle: always (default)
@@ -100,7 +104,7 @@ Not all cases can reliably checked, due to Ruby's dynamic
 types, so we consider only cases when the first argument is an
 array literal or the second is a string literal.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -124,7 +128,7 @@ This cop checks for non-ascii (non-English) characters
 in comments. You could set an array of allowed non-ascii chars in
 AllowedChars attribute (empty by default).
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -152,7 +156,7 @@ Enabled | Yes
 
 This cop checks for uses of Module#attr.
 
-### Example
+### Examples
 
 ```ruby
 # bad - creates a single attribute accessor (deprecated in Ruby 1.9)
@@ -178,7 +182,7 @@ This cop checks for cases when you could use a block
 accepting version of a method that does automatic
 resource cleanup.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -198,7 +202,9 @@ Enabled | Yes
 
 This cop checks if usage of %() or %Q() matches configuration.
 
-### Example
+### Examples
+
+#### EnforcedStyle: bare_percent (default)
 
 ```ruby
 # bad
@@ -209,6 +215,8 @@ This cop checks if usage of %() or %Q() matches configuration.
 %(He said: "#{greeting}")
 %{She said: 'Hi'}
 ```
+#### EnforcedStyle: percent_q
+
 ```ruby
 # bad
 %|He said: "#{greeting}"|
@@ -249,7 +257,7 @@ Enabled | Yes
 
 This cop looks for uses of block comments (=begin...=end).
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -276,7 +284,9 @@ Enabled | Yes
 Check for uses of braces or do/end around single line or
 multi-line blocks.
 
-### Example
+### Examples
+
+#### EnforcedStyle: line_count_based (default)
 
 ```ruby
 # bad - single line block
@@ -297,6 +307,8 @@ things.map do |thing|
   process(something)
 end
 ```
+#### EnforcedStyle: semantic
+
 ```ruby
 # Prefer `do...end` over `{...}` for procedural blocks.
 
@@ -332,6 +344,8 @@ map { |x|
   x
 }.inspect
 ```
+#### EnforcedStyle: braces_for_chaining
+
 ```ruby
 # bad
 words.each do |word|
@@ -367,7 +381,9 @@ This cop checks for braces around the last parameter in a method call
 if the last parameter is a hash.
 It supports `braces`, `no_braces` and `context_dependent` styles.
 
-### Example
+### Examples
+
+#### EnforcedStyle: braces
 
 ```ruby
 # The `braces` style enforces braces around all method
@@ -379,6 +395,8 @@ some_method(x, y, a: 1, b: 2)
 # good
 some_method(x, y, {a: 1, b: 2})
 ```
+#### EnforcedStyle: no_braces (default)
+
 ```ruby
 # The `no_braces` style checks that the last parameter doesn't
 # have braces around it.
@@ -389,6 +407,8 @@ some_method(x, y, {a: 1, b: 2})
 # good
 some_method(x, y, a: 1, b: 2)
 ```
+#### EnforcedStyle: context_dependent
+
 ```ruby
 # The `context_dependent` style checks that the last parameter
 # doesn't have braces around it, but requires braces if the
@@ -417,7 +437,7 @@ Enabled | No
 
 This cop checks for uses of the case equality operator(===).
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -486,7 +506,9 @@ Enabled | Yes
 
 This cop enforces consistent use of `Object#is_a?` or `Object#kind_of?`.
 
-### Example
+### Examples
+
+#### EnforcedStyle: is_a? (default)
 
 ```ruby
 # bad
@@ -497,6 +519,8 @@ var.kind_of?(Integer)
 var.is_a?(Date)
 var.is_a?(Integer)
 ```
+#### EnforcedStyle: kind_of?
+
 ```ruby
 # bad
 var.is_a?(Time)
@@ -522,7 +546,7 @@ Enabled | Yes
 This cop checks for uses of the class/module name instead of
 self, when defining class/module methods.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -590,7 +614,7 @@ Enabled | Yes
 This cop checks for methods invoked via the :: operator instead
 of the . operator (like FileUtils::rmdir instead of FileUtils.rmdir).
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -617,7 +641,7 @@ Enabled | Yes
 This cop checks for class methods that are defined using the `::`
 operator instead of the `.` operator.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -645,7 +669,9 @@ Enabled | Yes
 
 This cop enforces using `` or %x around command literals.
 
-### Example
+### Examples
+
+#### EnforcedStyle: backticks (default)
 
 ```ruby
 # bad
@@ -666,6 +692,8 @@ folders = `find . -type d`.split
   ln -s bar.example.yml bar.example
 `
 ```
+#### EnforcedStyle: mixed
+
 ```ruby
 # bad
 folders = %x(find . -type d).split
@@ -685,6 +713,8 @@ folders = `find . -type d`.split
   ln -s bar.example.yml bar.example
 )
 ```
+#### EnforcedStyle: percent_x
+
 ```ruby
 # bad
 folders = `find . -type d`.split
@@ -704,6 +734,8 @@ folders = %x(find . -type d).split
   ln -s bar.example.yml bar.example
 )
 ```
+#### AllowInnerBackticks: false (default)
+
 ```ruby
 # If `false`, the cop will always recommend using `%x` if one or more
 # backticks are found in the command string.
@@ -714,6 +746,8 @@ folders = %x(find . -type d).split
 # good
 %x(echo `ls`)
 ```
+#### AllowInnerBackticks: true
+
 ```ruby
 # good
 `echo \`ls\``
@@ -739,7 +773,7 @@ Enabled | Yes
 This cop checks that comment annotation keywords are written according
 to guidelines.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -789,7 +823,7 @@ These keywords are: `begin`, `class`, `def`, `end`, `module`.
 Note that some comments (such as `:nodoc:` and `rubocop:disable`) are
 allowed.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -826,7 +860,9 @@ Check for `if` and `case` statements where each branch is used for
 assignment to the same variable when using the return of the
 condition can be used instead.
 
-### Example
+### Examples
+
+#### EnforcedStyle: assign_to_condition (default)
 
 ```ruby
 # bad
@@ -873,6 +909,8 @@ bar << if foo
          2
        end
 ```
+#### EnforcedStyle: assign_inside_condition
+
 ```ruby
 # bad
 bar = if foo
@@ -961,7 +999,7 @@ Enabled | No
 This cop checks for uses of `DateTime` that should be replaced by
 `Date` or `Time`.
 
-### Example
+### Examples
 
 ```ruby
 # bad - uses `DateTime` for current time
@@ -994,7 +1032,7 @@ This cop checks for parentheses in the definition of a method,
 that does not take any arguments. Both instance and
 class/singleton methods are checked.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -1036,7 +1074,7 @@ This cop checks for places where the `#__dir__` method can replace more
 complex constructs to retrieve a canonicalized absolute path to the
 current file.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -1064,7 +1102,7 @@ The documentation requirement is annulled if the class or module has
 a "#:nodoc:" comment next to it. Likewise, "#:nodoc: all" does the
 same for all its children.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -1095,7 +1133,7 @@ This cop checks for missing documentation comment for public methods.
 It can optionally be configured to also require documentation for
 non-public methods.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -1160,7 +1198,7 @@ Please, note that when something is a boolean value
 As you're unlikely to write code that can accept values of any type
 this is rarely a problem in practice.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -1186,7 +1224,7 @@ using a Range literal and `#each`. This can be done more readably using
 
 This check only applies if the block takes no parameters.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -1216,7 +1254,7 @@ the need to return the object at the end.
 However, we can't replace with each_with_object if the accumulator
 parameter is assigned to within the block.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -1235,7 +1273,7 @@ Enabled | Yes
 This cop checks for pipes for empty block parameters. Pipes for empty
 block parameters do not cause syntax errors, but they are redundant.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -1262,7 +1300,7 @@ Enabled | Yes
 
 This cop checks for case statements with an empty condition.
 
-### Example
+### Examples
 
 ```ruby
 # bad:
@@ -1306,7 +1344,7 @@ explicit `nil` depending on the EnforcedStyle.
 
 SupportedStyles:
 
-### Example
+### Examples
 
 ```ruby
 # good for all styles
@@ -1387,7 +1425,7 @@ This cop checks for parentheses for empty lambda parameters. Parentheses
 for empty lambda parameters do not cause syntax errors, but they are
 redundant.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -1409,7 +1447,7 @@ Enabled | Yes
 This cop checks for the use of a method, the result of which
 would be a literal, like an empty array, hash or string.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -1441,7 +1479,9 @@ to go on its own line (expanded style).
 Note: A method definition is not considered empty if it contains
       comments.
 
-### Example
+### Examples
+
+#### EnforcedStyle: compact (default)
 
 ```ruby
 # bad
@@ -1460,6 +1500,8 @@ end
 
 def self.foo(bar); end
 ```
+#### EnforcedStyle: expanded
+
 ```ruby
 # bad
 def foo(bar); end
@@ -1517,7 +1559,7 @@ Enabled | Yes
 This cop checks for places where Integer#even? or Integer#odd?
 should have been used.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -1541,7 +1583,9 @@ Enabled | Yes
 
 This cop checks that `#module_function` is used over `extend self`.
 
-### Example
+### Examples
+
+#### EnforcedStyle: module_function (default)
 
 ```ruby
 # bad
@@ -1554,6 +1598,8 @@ module Foo
   module_function
 end
 ```
+#### EnforcedStyle: extend_self
+
 ```ruby
 # bad
 module Foo
@@ -1585,7 +1631,7 @@ Enabled | No
 
 This cop looks for uses of flip flop operator
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -1638,7 +1684,9 @@ manner for all cases, so only two scenarios are considered -
 if the first argument is a string literal and if the second
 argument is an array literal.
 
-### Example
+### Examples
+
+#### EnforcedStyle: format(default)
 
 ```ruby
 # bad
@@ -1648,6 +1696,8 @@ puts '%10s' % 'hoge'
 # good
 puts format('%10s', 'hoge')
 ```
+#### EnforcedStyle: sprintf
+
 ```ruby
 # bad
 puts format('%10s', 'hoge')
@@ -1656,6 +1706,8 @@ puts '%10s' % 'hoge'
 # good
 puts sprintf('%10s', 'hoge')
 ```
+#### EnforcedStyle: percent
+
 ```ruby
 # bad
 puts format('%10s', 'hoge')
@@ -1683,7 +1735,9 @@ Enabled | No
 
 Use a consistent style for named format string tokens.
 
-### Example
+### Examples
+
+#### EnforcedStyle: annotated (default)
 
 ```ruby
 # bad
@@ -1693,6 +1747,8 @@ format('%s', 'Hello')
 # good
 format('%<greeting>s', greeting: 'Hello')
 ```
+#### EnforcedStyle: template
+
 ```ruby
 # bad
 format('%<greeting>s', greeting: 'Hello')
@@ -1701,6 +1757,8 @@ format('%s', 'Hello')
 # good
 format('%{greeting}', greeting: 'Hello')
 ```
+#### EnforcedStyle: unannotated
+
 ```ruby
 # bad
 format('%<greeting>s', greeting: 'Hello')
@@ -1747,7 +1805,7 @@ users can allow additional variables via the AllowedVariables option.
 
 Note that backreferences like $1, $2, etc are not global variables.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -1780,7 +1838,7 @@ Enabled | No
 Use a guard clause instead of wrapping the code inside a conditional
 expression
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -1845,7 +1903,9 @@ The supported styles are:
 * ruby19_no_mixed_keys - forces use of ruby 1.9 syntax and forbids mixed
   syntax hashes
 
-### Example
+### Examples
+
+#### EnforcedStyle: ruby19 (default)
 
 ```ruby
 # bad
@@ -1857,6 +1917,8 @@ The supported styles are:
 {:c => 2, 'd' => 2} # acceptable since 'd' isn't a symbol
 {d: 1, 'e' => 2} # technically not forbidden
 ```
+#### EnforcedStyle: hash_rockets
+
 ```ruby
 # bad
 {a: 1, b: 2}
@@ -1865,6 +1927,8 @@ The supported styles are:
 # good
 {:a => 1, :b => 2}
 ```
+#### EnforcedStyle: no_mixed_keys
+
 ```ruby
 # bad
 {:a => 1, b: 2}
@@ -1874,6 +1938,8 @@ The supported styles are:
 {:a => 1, :b => 2}
 {c: 1, d: 2}
 ```
+#### EnforcedStyle: ruby19_no_mixed_keys
+
 ```ruby
 # bad
 {:a => 1, :b => 2}
@@ -1905,7 +1971,7 @@ Enabled | No
 This cop checks for identical lines at the beginning or end of
 each branch of a conditional statement.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -1975,7 +2041,7 @@ If the `else` branch of a conditional consists solely of an `if` node,
 it can be combined with the `else` to become an `elsif`.
 This helps to keep the nesting level from getting too deep.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -2022,7 +2088,7 @@ Enabled | No
 Checks for if and unless statements used as modifiers of other if or
 unless statements.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -2049,7 +2115,7 @@ Enabled | No
 
 Checks for uses of semicolon in if statements.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -2074,7 +2140,7 @@ explicit exception class. (This raises a `RuntimeError`. Some projects
 might prefer to use exception classes which more precisely identify the
 nature of the error.)
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -2092,7 +2158,7 @@ Enabled | Yes
 
 Use `Kernel#loop` for infinite loops.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -2118,7 +2184,7 @@ Disabled | No
 
 This cop checks for trailing inline comments.
 
-### Example
+### Examples
 
 ```ruby
 # good
@@ -2147,7 +2213,7 @@ Methods that are inverted by inverting the return
 of the block that is passed to the method should be defined in
 `InverseBlocks`
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -2185,7 +2251,9 @@ single line lambdas, and the method call syntax for multiline lambdas.
 It is configurable to enforce one of the styles for both single line
 and multiline lambdas as well.
 
-### Example
+### Examples
+
+#### EnforcedStyle: line_count_dependent (default)
 
 ```ruby
 # bad
@@ -2200,6 +2268,8 @@ f = lambda do |x|
       x
     end
 ```
+#### EnforcedStyle: lambda
+
 ```ruby
 # bad
 f = ->(x) { x }
@@ -2213,6 +2283,8 @@ f = lambda do |x|
       x
     end
 ```
+#### EnforcedStyle: literal
+
 ```ruby
 # bad
 f = lambda { |x| x }
@@ -2245,7 +2317,9 @@ Enabled | Yes
 
 This cop checks for use of the lambda.(args) syntax.
 
-### Example
+### Examples
+
+#### EnforcedStyle: call (default)
 
 ```ruby
 # bad
@@ -2254,6 +2328,8 @@ lambda.(x, y)
 # good
 lambda.call(x, y)
 ```
+#### EnforcedStyle: braces
+
 ```ruby
 # bad
 lambda.call(x, y)
@@ -2281,7 +2357,7 @@ Enabled | Yes
 This cop checks for string literal concatenation at
 the end of a line.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -2306,7 +2382,7 @@ This cop checks presence of parentheses in method calls containing
 parameters. By default, macro methods are ignored. Additional methods
 can be added to the `IgnoredMethods` list.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -2360,7 +2436,7 @@ Enabled | Yes
 
 This cop checks for unwanted parentheses in parameterless method calls.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -2384,7 +2460,7 @@ This cop checks for methods called on a do...end block. The point of
 this check is that it's easy to miss the call tacked on to the block
 when reading code.
 
-### Example
+### Examples
 
 ```ruby
 a do
@@ -2424,7 +2500,7 @@ Enabled | No
 This cop checks for the presence of `method_missing` without also
 defining `respond_to_missing?` and falling back on `super`.
 
-### Example
+### Examples
 
 ```ruby
 #bad
@@ -2455,7 +2531,7 @@ Enabled | Yes
 
 This cop checks for potential uses of `Enumerable#minmax`.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -2479,7 +2555,7 @@ SupportedStyles
 if
 case
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -2519,7 +2595,9 @@ This cop checks for grouping of mixins in `class` and `module` bodies.
 By default it enforces mixins to be placed in separate declarations,
 but it can be configured to enforce grouping them in one declaration.
 
-### Example
+### Examples
+
+#### EnforcedStyle: separated (default)
 
 ```ruby
 # bad
@@ -2533,6 +2611,8 @@ class Foo
   include Bar
 end
 ```
+#### EnforcedStyle: grouped
+
 ```ruby
 # bad
 class Foo
@@ -2568,7 +2648,7 @@ Using these at the top level affects the behavior of `Object`.
 There will not be using `include`, `extend` and `prepend` at
 the top level. Let's use it inside `class` or `module`.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -2619,7 +2699,9 @@ Supported styles are: module_function, extend_self.
 These offenses are not auto-corrected since there are different
 implications to each approach.
 
-### Example
+### Examples
+
+#### EnforcedStyle: module_function (default)
 
 ```ruby
 # bad
@@ -2634,6 +2716,8 @@ module Test
   # ...
 end
 ```
+#### EnforcedStyle: extend_self
+
 ```ruby
 # bad
 module Test
@@ -2667,7 +2751,7 @@ Enabled | No
 This cop checks for chaining of a block after another block that spans
 multiple lines.
 
-### Example
+### Examples
 
 ```ruby
 Thread.list.find_all do |t|
@@ -2689,7 +2773,7 @@ Enabled | Yes
 
 Checks for uses of if/unless modifiers with multiple-lines bodies.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -2713,7 +2797,7 @@ Enabled | Yes
 
 Checks for uses of the `then` keyword in multi-line if statements.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -2740,7 +2824,9 @@ Enabled | Yes
 
 This cop checks expressions wrapping styles for multiline memoization.
 
-### Example
+### Examples
+
+#### EnforcedStyle: keyword (default)
 
 ```ruby
 # bad
@@ -2755,6 +2841,8 @@ foo ||= begin
   baz
 end
 ```
+#### EnforcedStyle: braces
+
 ```ruby
 # bad
 foo ||= begin
@@ -2796,7 +2884,7 @@ Enabled | No
 This cop checks against comparing a variable with multiple items, where
 `Array#include?` could be used instead to avoid code repetition.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -2817,7 +2905,7 @@ Enabled | Yes
 This cop checks whether some constant value isn't a
 mutable literal (e.g. array or hash).
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -2840,7 +2928,9 @@ without else are considered. There are three different styles:
   - prefix
   - postfix
 
-### Example
+### Examples
+
+#### EnforcedStyle: both (default)
 
 ```ruby
 # enforces `unless` for `prefix` and `postfix` conditionals
@@ -2865,6 +2955,8 @@ bar if !foo
 
 bar unless foo
 ```
+#### EnforcedStyle: prefix
+
 ```ruby
 # enforces `unless` for just `prefix` conditionals
 
@@ -2884,6 +2976,8 @@ end
 
 bar if !foo
 ```
+#### EnforcedStyle: postfix
+
 ```ruby
 # enforces `unless` for just `postfix` conditionals
 
@@ -2933,7 +3027,7 @@ Enabled | Yes
 This cop checks for nested use of if, unless, while and until in their
 modifier form.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -2956,7 +3050,7 @@ Enabled | Yes
 This cop checks for unparenthesized method calls in the argument list
 of a parenthesized method call.
 
-### Example
+### Examples
 
 ```ruby
 # good
@@ -2992,7 +3086,9 @@ Enabled | Yes
 
 Use `next` to skip iteration instead of a condition at the end.
 
-### Example
+### Examples
+
+#### EnforcedStyle: skip_modifier_ifs (default)
 
 ```ruby
 # bad
@@ -3013,6 +3109,8 @@ end
   puts o unless o == 1
 end
 ```
+#### EnforcedStyle: always
+
 ```ruby
 # With `always` all conditions at the end of an iteration needs to be
 # replaced by next - with `skip_modifier_ifs` the modifier if like
@@ -3056,7 +3154,7 @@ Enabled | Yes
 
 This cop checks for comparison of something with nil using ==.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -3087,7 +3185,7 @@ Non-nil checks are allowed if they are the final nodes of predicate.
     !current_user.nil?
   end
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -3122,7 +3220,7 @@ Enabled | Yes
 
 This cop checks for uses of the keyword `not` instead of `!`.
 
-### Example
+### Examples
 
 ```ruby
 # bad - parentheses are required because of op precedence
@@ -3169,7 +3267,7 @@ Enabled | Yes
 This cop checks for big numeric literals without _ between groups
 of digits in them.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -3218,7 +3316,9 @@ The cop ignores comparisons to global variables, since they are often
 populated with objects which can be compared with integers, but are
 not themselves `Interger` polymorphic.
 
-### Example
+### Examples
+
+#### EnforcedStyle: predicate (default)
 
 ```ruby
 # bad
@@ -3233,6 +3333,8 @@ foo.zero?
 foo.negative?
 bar.baz.positive?
 ```
+#### EnforcedStyle: comparison
+
 ```ruby
 # bad
 
@@ -3281,7 +3383,7 @@ Disabled | No
 This cop checks for options hashes and discourages them if the
 current Ruby version supports keyword arguments.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -3311,7 +3413,7 @@ Enabled | No
 This cop checks for optional arguments to methods
 that do not come at the end of the argument list
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -3338,7 +3440,7 @@ Enabled | Yes
 
 This cop checks for potential usage of the `||=` operator.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -3377,7 +3479,7 @@ Checks for simple usages of parallel assignment.
 This will only complain when the number of variables
 being assigned matched the number of assigning variables.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -3429,7 +3531,7 @@ Specify the 'default' key to set all preferred delimiters at once. You
 can continue to specify individual preferred delimiters to override the
 default.
 
-### Example
+### Examples
 
 ```ruby
 # Style/PercentLiteralDelimiters:
@@ -3480,7 +3582,7 @@ Enabled | Yes
 This cop looks for uses of Perl-style regexp match
 backreferences like $1, $2, etc.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -3505,7 +3607,9 @@ Hash#has_value? where it enforces Hash#key? and Hash#value?
 It is configurable to enforce the inverse, using `verbose` method
 names also.
 
-### Example
+### Examples
+
+#### EnforcedStyle: short (default)
 
 ```ruby
 # bad
@@ -3516,6 +3620,8 @@ Hash#has_value?
 Hash#key?
 Hash#value?
 ```
+#### EnforcedStyle: verbose
+
 ```ruby
 # bad
 Hash#key?
@@ -3545,7 +3651,7 @@ Enabled | Yes
 This cops checks for uses of Proc.new where Kernel#proc
 would be more appropriate.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -3575,7 +3681,9 @@ The exploded style works identically, but with the addition that it
 will also suggest constructing error objects when the exception is
 passed multiple arguments.
 
-### Example
+### Examples
+
+#### EnforcedStyle: exploded (default)
 
 ```ruby
 # bad
@@ -3587,6 +3695,8 @@ fail "message"
 raise MyCustomError.new(arg1, arg2, arg3)
 raise MyKwArgError.new(key1: val1, key2: val2)
 ```
+#### EnforcedStyle: compact
+
 ```ruby
 # bad
 raise StandardError, "message"
@@ -3619,7 +3729,7 @@ added/subtracted with integer literals, as well as those with
 Integer#succ and Integer#pred methods. Prefer using ranges instead,
 as it clearly states the intentions.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -3652,7 +3762,7 @@ This cop checks for redundant `begin` blocks.
 
 Currently it checks for code like this:
 
-### Example
+### Examples
 
 ```ruby
 def redundant
@@ -3684,7 +3794,7 @@ Enabled | Yes
 
 This cop checks for redundant returning of true/false in conditionals.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -3717,7 +3827,7 @@ This cop checks for RuntimeError as the argument of raise/fail.
 
 It checks for code like this:
 
-### Example
+### Examples
 
 ```ruby
 # Bad
@@ -3742,7 +3852,7 @@ Enabled | Yes
 
 This cop check for uses of Object#freeze on immutable objects.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -3760,7 +3870,7 @@ Enabled | Yes
 
 This cop checks for redundant parentheses.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -3781,7 +3891,7 @@ This cop checks for redundant `return` expressions.
 It should be extended to handle methods whose body is if/else
 or a case expression with a default branch.
 
-### Example
+### Examples
 
 ```ruby
 def test
@@ -3828,7 +3938,7 @@ protected scope, you cannot send private messages this way.
 Note we allow uses of `self` with operators because it would be awkward
 otherwise.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -3865,7 +3975,9 @@ Enabled | Yes
 
 This cop enforces using // or %r around regular expressions.
 
-### Example
+### Examples
+
+#### EnforcedStyle: slashes (default)
 
 ```ruby
 # bad
@@ -3888,6 +4000,8 @@ regex = /
   (baz)
 /x
 ```
+#### EnforcedStyle: percent_r
+
 ```ruby
 # bad
 snake_case = /^[\dA-Z_]+$/
@@ -3909,6 +4023,8 @@ regex = %r{
   (baz)
 }x
 ```
+#### EnforcedStyle: mixed
+
 ```ruby
 # bad
 snake_case = %r{^[\dA-Z_]+$}
@@ -3930,6 +4046,8 @@ regex = %r{
   (baz)
 }x
 ```
+#### AllowInnerSlashes: false (default)
+
 ```ruby
 # If `false`, the cop will always recommend using `%r` if one or more
 # slashes are found in the regexp string.
@@ -3940,6 +4058,8 @@ x =~ /home\//
 # good
 x =~ %r{home/}
 ```
+#### AllowInnerSlashes: true
+
 ```ruby
 # good
 x =~ /home\//
@@ -3984,7 +4104,7 @@ if any error other than `StandardError` is specified.
 `explicit` will enforce using `rescue StandardError`
 instead of `rescue`.
 
-### Example
+### Examples
 
 ```ruby
 # good
@@ -4048,7 +4168,9 @@ This cop enforces consistency between 'return nil' and 'return'.
 
 Supported styles are: return, return_nil.
 
-### Example
+### Examples
+
+#### EnforcedStyle: return (default)
 
 ```ruby
 # bad
@@ -4061,6 +4183,8 @@ def foo(arg)
   return if arg
 end
 ```
+#### EnforcedStyle: return_nil
+
 ```ruby
 # bad
 def foo(arg)
@@ -4097,7 +4221,7 @@ of the method is. If this is converted to safe navigation,
 `foo&.bar` can start returning `nil` as well as what the method
 returns.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -4143,7 +4267,7 @@ Enabled | Yes
 
 This cop enforces the use the shorthand for self-assignment.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -4166,7 +4290,7 @@ Enabled | Yes
 This cop checks for multiple expressions placed on the same line.
 It also checks for lines terminated with a semicolon.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -4209,7 +4333,9 @@ Enabled | Yes
 
 This cop checks for uses of `fail` and `raise`.
 
-### Example
+### Examples
+
+#### EnforcedStyle: only_raise (default)
 
 ```ruby
 # The `only_raise` style enforces the sole use of `raise`.
@@ -4243,6 +4369,8 @@ end
 
 Kernel.raise
 ```
+#### EnforcedStyle: only_fail
+
 ```ruby
 # The `only_fail` style enforces the sole use of `fail`.
 # bad
@@ -4275,6 +4403,8 @@ end
 
 Kernel.fail
 ```
+#### EnforcedStyle: semantic
+
 ```ruby
 # The `semantic` style enforces the use of `fail` to signal an
 # exception, then will use `raise` to trigger an offense after
@@ -4349,7 +4479,7 @@ Enabled | Yes
 This cop checks for single-line method definitions that contain a body.
 It will accept single-line methods with no body.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -4400,7 +4530,9 @@ Enabled | Yes
 Check for parentheses around stabby lambda arguments.
 There are two different styles. Defaults to `require_parentheses`.
 
-### Example
+### Examples
+
+#### EnforcedStyle: require_parentheses (default)
 
 ```ruby
 # bad
@@ -4409,6 +4541,8 @@ There are two different styles. Defaults to `require_parentheses`.
 # good
 ->(a,b,c) { a + b + c}
 ```
+#### EnforcedStyle: require_no_parentheses
+
 ```ruby
 # bad
 ->(a,b,c) { a + b + c }
@@ -4437,7 +4571,7 @@ This cop identifies places where `$stderr.puts` can be replaced by
 `warn`. The latter has the advantage of easily being disabled by,
 e.g. the -W0 interpreter flag, or setting $VERBOSE to nil.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -4460,7 +4594,7 @@ Disabled | Yes
 This cop checks for the use of strings as keys in hashes. The use of
 symbols is preferred instead.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -4482,7 +4616,9 @@ Enabled | Yes
 
 Checks if uses of quotes match the configured preference.
 
-### Example
+### Examples
+
+#### EnforcedStyle: single_quotes (default)
 
 ```ruby
 # bad
@@ -4496,6 +4632,8 @@ Checks if uses of quotes match the configured preference.
 'Just text'
 "Wait! What's #{this}!"
 ```
+#### EnforcedStyle: double_quotes
+
 ```ruby
 # bad
 'Just some text'
@@ -4527,7 +4665,9 @@ Enabled | Yes
 This cop checks that quotes inside the string interpolation
 match the configured preference.
 
-### Example
+### Examples
+
+#### EnforcedStyle: single_quotes (default)
 
 ```ruby
 # bad
@@ -4536,6 +4676,8 @@ result = "Tests #{success ? "PASS" : "FAIL"}"
 # good
 result = "Tests #{success ? 'PASS' : 'FAIL'}"
 ```
+#### EnforcedStyle: double_quotes
+
 ```ruby
 # bad
 result = "Tests #{success ? 'PASS' : 'FAIL'}"
@@ -4559,7 +4701,7 @@ Disabled | Yes
 This cop enforces the use of consistent method names
 from the String class.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -4585,7 +4727,7 @@ Enabled | No
 
 This cop checks for inheritance from Struct.new.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -4617,7 +4759,9 @@ If set, arrays with fewer elements than this value will not trigger the
 cop. For example, a `MinSize of `3` will not enforce a style on an array
 of 2 or fewer elements.
 
-### Example
+### Examples
+
+#### EnforcedStyle: percent (default)
 
 ```ruby
 # good
@@ -4626,6 +4770,8 @@ of 2 or fewer elements.
 # bad
 [:foo, :bar, :baz]
 ```
+#### EnforcedStyle: brackets
+
 ```ruby
 # good
 [:foo, :bar, :baz]
@@ -4653,7 +4799,7 @@ Enabled | Yes
 
 This cop checks symbol literal syntax.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -4671,7 +4817,7 @@ Enabled | Yes
 
 Use symbols as procs when possible.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -4698,7 +4844,9 @@ conditions. It is configurable to enforce inclusion or omission of
 parentheses using `EnforcedStyle`. Omission is only enforced when
 removing the parentheses won't cause a different behavior.
 
-### Example
+### Examples
+
+#### EnforcedStyle: require_no_parentheses (default)
 
 ```ruby
 # bad
@@ -4711,6 +4859,8 @@ foo = bar? ? a : b
 foo = bar.baz? ? a : b
 foo = bar && baz ? a : b
 ```
+#### EnforcedStyle: require_parentheses
+
 ```ruby
 # bad
 foo = bar? ? a : b
@@ -4722,6 +4872,8 @@ foo = (bar?) ? a : b
 foo = (bar.baz?) ? a : b
 foo = (bar && baz) ? a : b
 ```
+#### EnforcedStyle: require_parentheses_when_complex
+
 ```ruby
 # bad
 foo = (bar?) ? a : b
@@ -4749,7 +4901,7 @@ Enabled | Yes
 
 This cop checks for trailing code after the method definition.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -4779,7 +4931,9 @@ Enabled | Yes
 
 This cop checks for trailing comma in argument lists.
 
-### Example
+### Examples
+
+#### EnforcedStyleForMultiline: consistent_comma
 
 ```ruby
 # bad
@@ -4797,6 +4951,8 @@ method(
   2,
 )
 ```
+#### EnforcedStyleForMultiline: comma
+
 ```ruby
 # bad
 method(1, 2,)
@@ -4807,6 +4963,8 @@ method(
   2,
 )
 ```
+#### EnforcedStyleForMultiline: no_comma (default)
+
 ```ruby
 # bad
 method(1, 2,)
@@ -4836,7 +4994,9 @@ Enabled | Yes
 
 This cop checks for trailing comma in array and hash literals.
 
-### Example
+### Examples
+
+#### EnforcedStyleForMultiline: consistent_comma
 
 ```ruby
 # bad
@@ -4854,6 +5014,8 @@ a = [
   2,
 ]
 ```
+#### EnforcedStyleForMultiline: comma
+
 ```ruby
 # bad
 a = [1, 2,]
@@ -4864,6 +5026,8 @@ a = [
   2,
 ]
 ```
+#### EnforcedStyleForMultiline: no_comma (default)
+
 ```ruby
 # bad
 a = [1, 2,]
@@ -4893,7 +5057,7 @@ Enabled | Yes
 
 This cop checks for trailing code after the method definition.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -4932,7 +5096,7 @@ Enabled | Yes
 
 This cop checks for extra underscores in variable assignment.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -4968,7 +5132,7 @@ Enabled | Yes
 This cop looks for trivial reader/writer methods, that could
 have been created with the attr_* family of functions automatically.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -5015,7 +5179,7 @@ Enabled | Yes
 
 This cop looks for *unless* expressions with *else* clauses.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -5045,7 +5209,7 @@ Enabled | Yes
 
 This cop checks for usage of the %W() syntax when %w() would do.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -5066,7 +5230,7 @@ Enabled | Yes
 
 This cop checks for strings that are just an interpolated expression.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -5099,7 +5263,7 @@ Enabled | Yes
 
 This cop checks for variable interpolation (like "#@ivar").
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -5125,7 +5289,7 @@ Enabled | Yes
 
 This cop checks for *when;* uses in *case* expressions.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -5153,7 +5317,7 @@ Enabled | Yes
 
 Checks for uses of `do` in multi-line `while/until` statements.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -5192,7 +5356,7 @@ Checks for while and until statements that would fit on one line
 if written as a modifier while/until. The maximum line length is
 configured in the `Metrics/LineLength` cop.
 
-### Example
+### Examples
 
 ```ruby
 # bad
@@ -5234,7 +5398,9 @@ If set, arrays with fewer elements than this value will not trigger the
 cop. For example, a `MinSize` of `3` will not enforce a style on an
 array of 2 or fewer elements.
 
-### Example
+### Examples
+
+#### EnforcedStyle: percent (default)
 
 ```ruby
 # good
@@ -5243,6 +5409,8 @@ array of 2 or fewer elements.
 # bad
 ['foo', 'bar', 'baz']
 ```
+#### EnforcedStyle: brackets
+
 ```ruby
 # good
 ['foo', 'bar', 'baz']
@@ -5273,7 +5441,9 @@ This cop checks for Yoda conditions, i.e. comparison operations where
 readability is reduced because the operands are not ordered the same
 way as they would be ordered in spoken English.
 
-### Example
+### Examples
+
+#### EnforcedStyle: all_comparison_operators (default)
 
 ```ruby
 # bad
@@ -5288,6 +5458,8 @@ foo == "bar"
 foo <= 42
 bar > 10
 ```
+#### EnforcedStyle: equality_operators_only
+
 ```ruby
 # bad
 99 == foo
@@ -5320,7 +5492,7 @@ receiver.length > 0, receiver.length != 0,
 receiver.length < 1 and receiver.size == 0 that can be
 replaced by receiver.empty? and !receiver.empty.
 
-### Example
+### Examples
 
 ```ruby
 # bad

--- a/tasks/cops_documentation.rake
+++ b/tasks/cops_documentation.rake
@@ -25,9 +25,10 @@ task generate_cops_documentation: :yard_for_generate_documentation do
   end
 
   def examples(examples_object)
-    content = h3('Example')
-    content += examples_object.map { |e| code_example(e) }.join
-    content
+    examples_object.each_with_object(h3('Examples').dup) do |example, content|
+      content << h4(example.name) unless example.name == ''
+      content << code_example(example)
+    end
   end
 
   def properties(config, cop)
@@ -50,6 +51,12 @@ task generate_cops_documentation: :yard_for_generate_documentation do
   def h3(title)
     content = "\n".dup
     content << "### #{title}\n"
+    content << "\n"
+    content
+  end
+
+  def h4(title)
+    content = "#### #{title}\n".dup
     content << "\n"
     content
   end


### PR DESCRIPTION
Follow up of https://github.com/bbatsov/rubocop/pull/5156#issuecomment-347517326.

This commits adds an example names to `Example` uniformly.
And this change will also output all `Example` with no example name.

What do you think of this?

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
