### PR TITLE
Relax version constraint on rainbow, allow 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,6 @@
 * [#5077](https://github.com/bbatsov/rubocop/pull/5077): Add new `Rails/CreateTableWithTimestamps` cop. ([@wata727][])
 * Add new `Style/ColonMethodDefinition` cop. ([@rrosenblum][])
 * Add new `Style/ExtendSelf` cop. ([@drenmi][])
-* Relax version constraint on rainbow, allow 3. ([@jaredbeck][])
 
 ### Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * [#5077](https://github.com/bbatsov/rubocop/pull/5077): Add new `Rails/CreateTableWithTimestamps` cop. ([@wata727][])
 * Add new `Style/ColonMethodDefinition` cop. ([@rrosenblum][])
 * Add new `Style/ExtendSelf` cop. ([@drenmi][])
+* Relax version constraint on rainbow, allow 3. ([@jaredbeck][])
 
 ### Bug fixes
 

--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('parallel', '~> 1.10')
   s.add_runtime_dependency('parser', '>= 2.4.0.2', '< 3.0')
   s.add_runtime_dependency('powerpack', '~> 0.1')
-  s.add_runtime_dependency('rainbow', '>= 2.2.2', '< 3.0')
+  s.add_runtime_dependency('rainbow', '>= 2.2.2', '< 4.0')
   s.add_runtime_dependency('ruby-progressbar', '~> 1.7')
   s.add_runtime_dependency('unicode-display_width', '~> 1.0', '>= 1.0.1')
 


### PR DESCRIPTION
There do not appear to be any breaking changes that
should concern rubocop.

https://github.com/sickill/rainbow/blob/master/Changelog.md

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests (N/A)
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
