### PR TITLE
Make new_cop task to modify `config/enabled.yml`

### DIFF
--- a/lib/rubocop/cop/generator.rb
+++ b/lib/rubocop/cop/generator.rb
@@ -97,6 +97,22 @@ module RuboCop
         RequireFileInjector.new(require_path).inject
       end
 
+      def inject_config(path = 'config/enabled.yml')
+        config = File.readlines(path)
+        content = <<-YAML.strip_indent
+          #{badge}:
+            Description: 'TODO: Write a description of the cop.'
+            Enabled: true
+
+        YAML
+        target_line = config.find.with_index(1) do |line, index|
+          next if line =~ /^[\s#]/
+          break index - 1 if badge.to_s < line
+        end
+        config.insert(target_line, content)
+        File.write(path, config.join)
+      end
+
       def todo
         <<-TODO.strip_indent
           Files created:
@@ -104,11 +120,13 @@ module RuboCop
             - #{spec_path}
           File modified:
             - `require_relative '#{require_path}'` added into lib/rubocop.rb
+            - A configuration for the cop is added into config/enabled.yml
+              - If you want to disable the cop by default, move the added config to config/disabled.yml
 
           Do 3 steps:
             1. Add an entry to the "New features" section in CHANGELOG.md,
                e.g. "Add new `#{badge}` cop. ([@your_id][])"
-            2. Add an entry into config/enabled.yml or config/disabled.yml
+            2. Modify the description of #{badge} in config/enabled.yml
             3. Implement your new cop in the generated file!
         TODO
       end

--- a/manual/development.md
+++ b/manual/development.md
@@ -8,12 +8,14 @@ Files created:
   - lib/rubocop/cop/department/name.rb
   - spec/rubocop/cop/department/name_spec.rb
 File modified:
-  - `require 'rubocop/cop/department/name_cop'` added into lib/rubocop.rb
+  - `require_relative 'rubocop/cop/department/name'` added into lib/rubocop.rb
+  - A configuration for the cop is added into config/enabled.yml
+    - If you want to disable the cop by default, move the added config to config/disabled.yml
 
 Do 3 steps:
   1. Add an entry to the "New features" section in CHANGELOG.md,
      e.g. "Add new `Department/Name` cop. ([@your_id][])"
-  2. Add an entry into config/enabled.yml or config/disabled.yml
+  2. Modify the description of Department/Name in config/enabled.yml
   3. Implement your new cop in the generated file!
 ```
 

--- a/spec/rubocop/cop/generator_spec.rb
+++ b/spec/rubocop/cop/generator_spec.rb
@@ -127,11 +127,13 @@ RSpec.describe RuboCop::Cop::Generator do
           - spec/rubocop/cop/style/fake_cop_spec.rb
         File modified:
           - `require_relative 'rubocop/cop/style/fake_cop'` added into lib/rubocop.rb
+          - A configuration for the cop is added into config/enabled.yml
+            - If you want to disable the cop by default, move the added config to config/disabled.yml
 
         Do 3 steps:
           1. Add an entry to the "New features" section in CHANGELOG.md,
              e.g. "Add new `Style/FakeCop` cop. ([@your_id][])"
-          2. Add an entry into config/enabled.yml or config/disabled.yml
+          2. Modify the description of Style/FakeCop in config/enabled.yml
           3. Implement your new cop in the generated file!
       TODO
     end
@@ -335,6 +337,48 @@ RSpec.describe RuboCop::Cop::Generator do
 
         expect(File).not_to have_received(:write)
       end
+    end
+  end
+
+  describe '#inject_config' do
+    let(:path) { @path } # rubocop:disable RSpec/InstanceVariable
+
+    around do |example|
+      Tempfile.create('rubocop-config.yml') do |file|
+        @path = file.path
+        example.run
+      end
+    end
+
+    before do
+      IO.write(path, <<-YAML.strip_indent)
+        Style/Alias:
+          Enabled: true
+
+        Style/Lambda:
+          Enabled: true
+
+        Style/SpecialGlobalVars:
+          Enabled: true
+      YAML
+    end
+
+    it 'inserts the cop in alphabetical' do
+      expect(File).to receive(:write).with(path, <<-YAML.strip_indent)
+        Style/Alias:
+          Enabled: true
+
+        Style/FakeCop:
+          Description: 'TODO: Write a description of the cop.'
+          Enabled: true
+
+        Style/Lambda:
+          Enabled: true
+
+        Style/SpecialGlobalVars:
+          Enabled: true
+      YAML
+      generator.inject_config(path)
     end
   end
 

--- a/tasks/new_cop.rake
+++ b/tasks/new_cop.rake
@@ -14,6 +14,7 @@ task :new_cop, [:cop] do |_task, args|
   generator.write_source
   generator.write_spec
   generator.inject_require
+  generator.inject_config
 
   puts generator.todo
 end


### PR DESCRIPTION
# Problem

Currently, new_cop task does not modify `config/enabled.yml`(or `config/disabled.yml`).
It is not good. We should edit `config/enabled.yml` manually when we add a new cop.

# Solution

Make new_cop task to modify `config/enabled.yml`.
By this change, we should edit only a description for an added cop in `config/enabled.yml`.
When we want to disable a cop by default, we need to move the added configuration to `config/disabled.yml`. But added cop is enabled by default in almost cases, so I think this will not be a problem.


For example:

```bash
$ bundle exec rake new_cop[Style/Foo]
Files created:
  - lib/rubocop/cop/style/foo.rb
  - spec/rubocop/cop/style/foo_spec.rb
File modified:
  - `require_relative 'rubocop/cop/style/foo'` added into lib/rubocop.rb
  - A configuration for the cop is added into config/enabled.yml
    - If you want to disable the cop by default, move the added config to config/disabled.yml

Do 3 steps:
  1. Add an entry to the "New features" section in CHANGELOG.md,
     e.g. "Add new `Style/Foo` cop. ([@your_id][])"
  2. Modify the description of Style/Foo in config/enabled.yml
  3. Implement your new cop in the generated file!
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
