### PR TITLE
Make Style/RedundantBegin aware of do-end block in Ruby 2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@
 * [#5146](https://github.com/bbatsov/rubocop/pull/5146): Make `--show-cops` option aware of `--force-default-config`. ([@pocke][])
 * [#3001](https://github.com/bbatsov/rubocop/issues/3001): Add configuration to `Lint/MissingCopEnableDirective` cop. ([@tdeo][])
 * [#4932](https://github.com/bbatsov/rubocop/issues/4932): Do not fail if configuration contains `Lint/Syntax` cop with the same settings as the default. ([@tdeo][])
+* [#5175](https://github.com/bbatsov/rubocop/pull/5175): Make Style/RedundantBegin aware of do-end block in Ruby 2.5. ([@pocke][])
 
 ## 0.51.0 (2017-10-18)
 

--- a/lib/rubocop/cop/style/redundant_begin.rb
+++ b/lib/rubocop/cop/style/redundant_begin.rb
@@ -28,13 +28,23 @@ module RuboCop
         MSG = 'Redundant `begin` block detected.'.freeze
 
         def on_def(node)
+          check(node)
+        end
+        alias on_defs on_def
+
+        def on_block(node)
+          return if target_ruby_version < 2.5
+          return if node.braces?
+          check(node)
+        end
+
+        private
+
+        def check(node)
           return unless node.body && node.body.kwbegin_type?
 
           add_offense(node.body, location: :begin)
         end
-        alias on_defs on_def
-
-        private
 
         def autocorrect(node)
           lambda do |corrector|

--- a/lib/rubocop/rspec/shared_contexts.rb
+++ b/lib/rubocop/rspec/shared_contexts.rb
@@ -73,6 +73,10 @@ shared_context 'ruby 2.4', :ruby24 do
   let(:ruby_version) { 2.4 }
 end
 
+shared_context 'ruby 2.5', :ruby25 do
+  let(:ruby_version) { 2.5 }
+end
+
 shared_context 'with Rails', :enabled_rails do
   let(:enabled_rails) { true }
 end


### PR DESCRIPTION
We can omit `begin` in `do-end` block since Ruby 2.5.
https://bugs.ruby-lang.org/projects/ruby-trunk/repository/revisions/57376
For example, this code is correct in Ruby 2.5.

```ruby
do_something do
  something
rescue => ex
  anything
end
```

This change will make Style/RedundantBegin aware of do-end block in Ruby 2.5.



-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
