### PR TITLE
Reduce checkboxes from the PULL_REQUEST_TEMPLATE

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,15 +7,12 @@ Before submitting the PR make sure the following are checked:
 
 * [ ] Wrote [good commit messages][1].
 * [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
-* [ ] Used the same coding conventions as the rest of the project.
 * [ ] Feature branch is up-to-date with `master` (if not - rebase it).
 * [ ] Squashed related commits together.
 * [ ] Added tests.
 * [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
-* [ ] All tests(`rake spec`) are passing.
-* [ ] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
 * [ ] The PR relates to *only* one subject with a clear title
   and description in grammatically correct, complete sentences.
-* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).
+* [ ] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.
 
 [1]: http://chris.beams.io/posts/git-commit/

--- a/Rakefile
+++ b/Rakefile
@@ -21,7 +21,11 @@ RSpec::Core::RakeTask.new(:spec) { |t| t.ruby_opts = '-E UTF-8' }
 RSpec::Core::RakeTask.new(:ascii_spec) { |t| t.ruby_opts = '-E ASCII' }
 
 desc 'Run test and RuboCop in parallel'
-task parallel: %i[parallel:spec parallel:ascii_spec internal_investigation]
+task parallel: %i[
+  parallel:spec parallel:ascii_spec
+  internal_investigation
+  documentation_syntax_check generate_cops_documentation
+]
 
 namespace :parallel do
   desc 'Run RSpec in parallel'
@@ -49,7 +53,11 @@ RuboCop::RakeTask.new(:internal_investigation).tap do |task|
   end
 end
 
-task default: %i[spec ascii_spec internal_investigation]
+task default: %i[
+  spec ascii_spec
+  internal_investigation
+  documentation_syntax_check generate_cops_documentation
+]
 
 require 'yard'
 YARD::Rake::YardocTask.new
@@ -119,6 +127,7 @@ task documentation_syntax_check: :yard_for_generate_documentation do
     # TODO: parser cannot parse the example, so skip it.
     #       https://github.com/whitequark/parser/issues/407
     next if cop == RuboCop::Cop::Layout::SpaceAroundKeyword
+    next if %i[RSpec Capybara FactoryBot].include?(cop.department)
     examples = YARD::Registry.all(:class).find do |code_object|
       next unless RuboCop::Cop::Badge.for(code_object.to_s) == cop.badge
       break code_object.tags('example')


### PR DESCRIPTION
I think checkboxes in the PULL_REQUEST_TEMPLATE are too many.
They are a barrier in sending a pull-request.
And attention to other important checkboxes are neglected by noisy checkboxes.
So I think we should reduce the checkboxes.

I describe reasons of I removed the checkboxes below.

> * [ ] Wrote [good commit messages][1].

It is mentioned in the CONTRIBUTING.md.
And I think we don't need to check it every time.

> * [ ] Used the same coding conventions as the rest of the project.

It is also mentioned in the CONTRIBUTING.md.
And I think RuboCop guards coding conventions itself. So I think it is
duplicated with `The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.`.

> * [ ] Squashed related commits together.

We can use the squash merge feature for a pull-request in GitHub.
So I think squashing is not absolutely necessary.

> * [ ] The PR relates to *only* one subject with a clear title
>   and description in grammatically correct, complete sentences.

It is also mentioned in the CONTRIBUTING.md.

-------

What do you think?

