### PR TITLE
Restyle example formatting for `Style/AndOr` cop

### DIFF
--- a/lib/rubocop/cop/style/and_or.rb
+++ b/lib/rubocop/cop/style/and_or.rb
@@ -7,32 +7,34 @@ module RuboCop
       # `|| instead`. It can be configured to check only in conditions, or in
       # all contexts.
       #
-      # @example
-      #
-      #   # EnforcedStyle: always (default)
-      #
-      #   # good
-      #   foo.save && return
-      #   if foo && bar
-      #   end
-      #
+      # @example EnforcedStyle: always (default)
       #   # bad
       #   foo.save and return
-      #   if foo and bar
-      #   end
-      #
-      # @example
-      #
-      #   # EnforcedStyle: conditionals
-      #
-      #   # good
-      #   foo.save && return
-      #   foo.save and return
-      #   if foo && bar
-      #   end
       #
       #   # bad
       #   if foo and bar
+      #   end
+      #
+      #   # good
+      #   foo.save && return
+      #
+      #   # good
+      #   if foo && bar
+      #   end
+      #
+      # @example EnforcedStyle: conditionals
+      #   # bad
+      #   if foo and bar
+      #   end
+      #
+      #   # good
+      #   foo.save && return
+      #
+      #   # good
+      #   foo.save and return
+      #
+      #   # good
+      #   if foo && bar
       #   end
       class AndOr < Cop
         include ConfigurableEnforcedStyle

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -55,30 +55,38 @@ all contexts.
 
 ### Examples
 
+#### EnforcedStyle: always (default)
+
 ```ruby
-# EnforcedStyle: always (default)
+# bad
+foo.save and return
+
+# bad
+if foo and bar
+end
 
 # good
 foo.save && return
-if foo && bar
-end
 
-# bad
-foo.save and return
-if foo and bar
+# good
+if foo && bar
 end
 ```
+#### EnforcedStyle: conditionals
+
 ```ruby
-# EnforcedStyle: conditionals
+# bad
+if foo and bar
+end
 
 # good
 foo.save && return
-foo.save and return
-if foo && bar
-end
 
-# bad
-if foo and bar
+# good
+foo.save and return
+
+# good
+if foo && bar
 end
 ```
 


### PR DESCRIPTION
This commit is a change of document format for `Style/AndOr` cop.

This is a similar change to #5156.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
