### PR TITLE
Fix a false positive in SafeNavigation when the right hand side is negated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@
 * [#5079](https://github.com/bbatsov/rubocop/issues/5079): Fix false positive for `Style/SafeNavigation` when safe guarding comparisons. ([@tiagotex][])
 * [#5075](https://github.com/bbatsov/rubocop/issues/5075): Fix auto-correct for `Style/RedundantParentheses` cop when unspaced ternary is present. ([@tiagotex][])
 * [#5155](https://github.com/bbatsov/rubocop/issues/5155): Fix a false negative for `Naming/ConstantName` cop when using frozen object assignment. ([@koic][])
+* Fix a false positive in `Style/SafeNavigation` when the right hand side is negated. ([@rrosenblum][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/safe_navigation.rb
+++ b/lib/rubocop/cop/style/safe_navigation.rb
@@ -175,7 +175,11 @@ module RuboCop
         end
 
         def negated?(send_node)
-          send_node.parent.send_type? && send_node.parent.method?(:!)
+          if send_node.parent && send_node.parent.send_type?
+            negated?(send_node.parent)
+          else
+            send_node.send_type? && send_node.method?(:!)
+          end
         end
 
         def begin_range(node, method_call)

--- a/spec/rubocop/cop/style/safe_navigation_spec.rb
+++ b/spec/rubocop/cop/style/safe_navigation_spec.rb
@@ -40,6 +40,10 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
       expect_no_offenses('foo && !foo.bar?')
     end
 
+    it 'allows an object check before a negated predicate method chain' do
+      expect_no_offenses('foo && !foo.bar.baz?')
+    end
+
     it 'allows method call that are used in a comparison safe guarded by ' \
       'an object check' do
       expect_no_offenses('foo.bar > 2 if foo')


### PR DESCRIPTION
`foo && !foo.bar?` will not produce an offense because the correction `!foo.bar?` will return `true` if `foo` is `nil`. We were not properly checking for method chains so `foo && !foo.bar.baz?` would produce an offense even though it should not.