### PR TITLE
[Fix #4444] Fix `Style/AutoResourceCleanup` shouldn't flag `File.open(...).close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * [#5228](https://github.com/bbatsov/rubocop/issues/5228): Handle overridden `Metrics/LineLength:Max` for `--auto-gen-config`. ([@jonas054][])
 * [#5238](https://github.com/bbatsov/rubocop/pull/5238): Fix error when #present? or #blank? is used in if or unless modifier. ([@eitoball][])
 * [#5261](https://github.com/bbatsov/rubocop/issues/5261): Fix a false positive for `Style/MixinUsage` when using inside class or module. ([@koic][])
+* [#4444](https://github.com/bbatsov/rubocop/issues/4444): Fix `Style/AutoResourceCleanup` shouldn't flag `File.open(...).close. ([@dpostorivo][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/auto_resource_cleanup.rb
+++ b/lib/rubocop/cop/style/auto_resource_cleanup.rb
@@ -29,14 +29,21 @@ module RuboCop
 
             next if node.receiver != target_receiver
             next if node.method_name != target_method
-            next if node.parent && node.parent.block_type?
-            next if node.block_argument?
+            next if cleanup?(node)
 
             add_offense(node,
                         message: format(MSG,
                                         class: target_class,
                                         method: target_method))
           end
+        end
+
+        private
+
+        def cleanup?(node)
+          parent = node.parent
+          node.block_argument? ||
+            (parent && (parent.block_type? || !parent.lvasgn_type?))
         end
       end
     end

--- a/spec/rubocop/cop/style/auto_resource_cleanup_spec.rb
+++ b/spec/rubocop/cop/style/auto_resource_cleanup_spec.rb
@@ -17,4 +17,8 @@ describe RuboCop::Cop::Style::AutoResourceCleanup do
   it 'does not register an offense for File.open with block-pass' do
     expect_no_offenses('File.open("file", &:read)')
   end
+
+  it 'does not register an offense for File.open with immediate close' do
+    expect_no_offenses('File.open("file", "w", 0o777).close')
+  end
 end


### PR DESCRIPTION
This commit addresses #4444 by checking if the function to clean up the resource is immediately cleaned up.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
