### PR TITLE
Restyle example formatting for `Style/ClassAndModuleChildren` cop

### DIFF
--- a/lib/rubocop/cop/style/class_and_module_children.rb
+++ b/lib/rubocop/cop/style/class_and_module_children.rb
@@ -6,13 +6,17 @@ module RuboCop
       # This cop checks the style of children definitions at classes and
       # modules. Basically there are two different styles:
       #
-      # nested - have each child on its own line
+      # @example EnforcedStyle: nested (default)
+      #   # good
+      #   # have each child on its own line
       #   class Foo
       #     class Bar
       #     end
       #   end
       #
-      # compact - combine definitions as much as possible
+      # @example EnforcedStyle: compact
+      #   # good
+      #   # combine definitions as much as possible
       #   class Foo::Bar
       #   end
       #

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -484,17 +484,28 @@ Enabled | No
 This cop checks the style of children definitions at classes and
 modules. Basically there are two different styles:
 
-nested - have each child on its own line
-  class Foo
-    class Bar
-    end
-  end
-
-compact - combine definitions as much as possible
-  class Foo::Bar
-  end
-
 The compact style is only forced for classes/modules with one child.
+
+### Examples
+
+#### EnforcedStyle: nested (default)
+
+```ruby
+# good
+# have each child on its own line
+class Foo
+  class Bar
+  end
+end
+```
+#### EnforcedStyle: compact
+
+```ruby
+# good
+# combine definitions as much as possible
+class Foo::Bar
+end
+```
 
 ### Configurable attributes
 


### PR DESCRIPTION
Follow up of https://github.com/bbatsov/rubocop/pull/4880#issuecomment-338499947.

This commit is a change of document format for `Style/ClassAndModuleChildren` cop

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
