### PR TITLE
Indent end squiggly heredoc

### DIFF
--- a/lib/rubocop/cop/layout/indent_heredoc.rb
+++ b/lib/rubocop/cop/layout/indent_heredoc.rb
@@ -8,7 +8,7 @@ module RuboCop
       # In Ruby 2.3 or newer, squiggly heredocs (`<<~`) should be used. If you
       # use the older rubies, you should introduce some library to your project
       # (e.g. ActiveSupport, Powerpack or Unindent).
-      # Note: When `Metrics/LineLength`'s `AllowHeredoc` is false(not default),
+      # Note: When `Metrics/LineLength`'s `AllowHeredoc` is false (not default),
       #       this cop does not add any offenses for long here documents to
       #       avoid `Metrics/LineLength`'s offenses.
       #

--- a/lib/rubocop/cop/layout/indent_heredoc.rb
+++ b/lib/rubocop/cop/layout/indent_heredoc.rb
@@ -141,6 +141,7 @@ module RuboCop
           lambda do |corrector|
             if heredoc_indent_type(node) == '~'
               corrector.replace(node.loc.heredoc_body, indented_body(node))
+              corrector.replace(node.loc.heredoc_end, indented_end(node))
             else
               heredoc_beginning = node.loc.expression.source
               corrected = heredoc_beginning.sub(/<<-?/, '<<~')
@@ -177,6 +178,18 @@ module RuboCop
           body.gsub(/^\s{#{body_indent_level}}/, ' ' * correct_indent_level)
         end
 
+        def indented_end(node)
+          end_ = heredoc_end(node)
+          end_indent_level = indent_level(end_)
+          correct_indent_level = base_indent_level(node)
+          # Necessary?
+          if end_indent_level < correct_indent_level
+            end_.gsub(/^\s{#{end_indent_level}}/, ' ' * correct_indent_level)
+          else
+            end_
+          end
+        end
+
         def base_indent_level(node)
           base_line_num = node.loc.expression.line
           base_line = processed_source.lines[base_line_num - 1]
@@ -201,6 +214,10 @@ module RuboCop
 
         def heredoc_body(node)
           node.loc.heredoc_body.source.scrub
+        end
+
+        def heredoc_end(node)
+          node.loc.heredoc_end.source.scrub
         end
       end
     end

--- a/spec/rubocop/cop/layout/indent_heredoc_spec.rb
+++ b/spec/rubocop/cop/layout/indent_heredoc_spec.rb
@@ -270,7 +270,7 @@ describe RuboCop::Cop::Layout::IndentHeredoc, :config do
           RUBY2
         CORRECTION
 
-        include_examples :accept, 'indentaed, with `~`', <<-RUBY
+        include_examples :accept, 'indented, with `~`', <<-RUBY
           <<~#{quote}RUBY2#{quote}
             something
           RUBY2

--- a/spec/rubocop/cop/layout/indent_heredoc_spec.rb
+++ b/spec/rubocop/cop/layout/indent_heredoc_spec.rb
@@ -269,19 +269,19 @@ describe RuboCop::Cop::Layout::IndentHeredoc, :config do
             foo
           RUBY2
         CORRECTION
-        include_examples :offense, 'not indented, with `-`',
+        include_examples :offense, 'first line minus-level indented, with `-`',
                          <<-RUBY, <<-CORRECTION
-          puts <<-#{quote}RUBY2#{quote}
-def foo
-  bar
-end
-RUBY2
-        RUBY
-          puts <<~#{quote}RUBY2#{quote}
-            def foo
-              bar
-            end
+              puts <<-#{quote}RUBY2#{quote}
+          def foo
+            bar
+          end
           RUBY2
+        RUBY
+              puts <<~#{quote}RUBY2#{quote}
+                def foo
+                  bar
+                end
+              RUBY2
         CORRECTION
 
         include_examples :accept, 'indented, with `~`', <<-RUBY

--- a/spec/rubocop/cop/layout/indent_heredoc_spec.rb
+++ b/spec/rubocop/cop/layout/indent_heredoc_spec.rb
@@ -269,6 +269,20 @@ describe RuboCop::Cop::Layout::IndentHeredoc, :config do
             foo
           RUBY2
         CORRECTION
+        include_examples :offense, 'not indented, with `-`',
+                         <<-RUBY, <<-CORRECTION
+          puts <<-#{quote}RUBY2#{quote}
+def foo
+  bar
+end
+RUBY2
+        RUBY
+          puts <<~#{quote}RUBY2#{quote}
+            def foo
+              bar
+            end
+          RUBY2
+        CORRECTION
 
         include_examples :accept, 'indented, with `~`', <<-RUBY
           <<~#{quote}RUBY2#{quote}


### PR DESCRIPTION
As a part of updating the Hanami codebase to use Ruby 2.3's squiggly heredoc `<<~`, I used rubocop's auto-correct feature. It mostly worked perfectly, but it left the end heredoc delimiters where they were. In our case, this was with 0 spaces. See [this commit](https://github.com/hanami/hanami/pull/864/commits/f989eb9f9c924601033edf291f430573fa6eaf5b).

I've confirmed that this PR fixes the problem above, but I can't figure out how to write a passing spec. The trouble is that the `shared_example` calls `strip_indent` on both the `code` and the`correction`. If I remove those, this spec passes, but others fail. I'm not sure if I can write a passing spec with the indents being stripped. 

Happy to do more work on this, just looking for some direction. 
(And I'll clean up this PR/commits to fit with the project, once this is ready to merge)

Here's the Rspec output:
```ruby
Failures:

  1) RuboCop::Cop::Layout::IndentHeredoc quoted by  EnforcedStyle is `squiggly` autocorrects for first line minus-level indented, with `-`
     Failure/Error: expect(corrected).to eq(correction.strip_indent)

       expected: "puts <<~RUBY2\n  def foo\n    bar\n  end\nRUBY2\n"
            got: "    puts <<~RUBY2\n      def foo\n        bar\n      end\n    RUBY2\n"

       (compared using ==)

       Diff:
       @@ -1,6 +1,6 @@
       -puts <<~RUBY2
       -  def foo
       -    bar
       -  end
       -RUBY2
       +    puts <<~RUBY2
       +      def foo
       +        bar
       +      end
       +    RUBY2

     Shared Example Group: :offense called from ./spec/rubocop/cop/layout/indent_heredoc_spec.rb:272
     Shared Example Group: :all_heredoc_type called from ./spec/rubocop/cop/layout/indent_heredoc_spec.rb:339
     # ./spec/rubocop/cop/layout/indent_heredoc_spec.rb:21:in `block (3 levels) in <top (required)>'

```