### PR TITLE
Restyle example formatting for `Style/EmptyElse` cop

### DIFF
--- a/lib/rubocop/cop/style/empty_else.rb
+++ b/lib/rubocop/cop/style/empty_else.rb
@@ -6,24 +6,8 @@ module RuboCop
       # Checks for empty else-clauses, possibly including comments and/or an
       # explicit `nil` depending on the EnforcedStyle.
       #
-      # SupportedStyles:
-      #
-      # @example
-      #   # good for all styles
-      #
-      #   if condition
-      #     statement
-      #   else
-      #     statement
-      #   end
-      #
-      #   # good for all styles
-      #   if condition
-      #     statement
-      #   end
-      #
-      # @example
-      #   # empty - warn only on empty else
+      # @example EnforcedStyle: empty
+      #   # warn only on empty else
       #
       #   # bad
       #   if condition
@@ -38,8 +22,20 @@ module RuboCop
       #     nil
       #   end
       #
-      # @example
-      #   # nil - warn on else with nil in it
+      #   # good
+      #   if condition
+      #     statement
+      #   else
+      #     statement
+      #   end
+      #
+      #   # good
+      #   if condition
+      #     statement
+      #   end
+      #
+      # @example EnforcedStyle: nil
+      #   # warn on else with nil in it
       #
       #   # bad
       #   if condition
@@ -54,8 +50,20 @@ module RuboCop
       #   else
       #   end
       #
-      # @example
-      #   # both - warn on empty else and else with nil in it
+      #   # good
+      #   if condition
+      #     statement
+      #   else
+      #     statement
+      #   end
+      #
+      #   # good
+      #   if condition
+      #     statement
+      #   end
+      #
+      # @example EnforcedStyle: both (default)
+      #   # warn on empty else and else with nil in it
       #
       #   # bad
       #   if condition
@@ -68,6 +76,18 @@ module RuboCop
       #   if condition
       #     statement
       #   else
+      #   end
+      #
+      #   # good
+      #   if condition
+      #     statement
+      #   else
+      #     statement
+      #   end
+      #
+      #   # good
+      #   if condition
+      #     statement
       #   end
       class EmptyElse < Cop
         include OnNormalIfUnless

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -1350,26 +1350,12 @@ Enabled | Yes
 Checks for empty else-clauses, possibly including comments and/or an
 explicit `nil` depending on the EnforcedStyle.
 
-SupportedStyles:
-
 ### Examples
 
-```ruby
-# good for all styles
+#### EnforcedStyle: empty
 
-if condition
-  statement
-else
-  statement
-end
-
-# good for all styles
-if condition
-  statement
-end
-```
 ```ruby
-# empty - warn only on empty else
+# warn only on empty else
 
 # bad
 if condition
@@ -1383,9 +1369,23 @@ if condition
 else
   nil
 end
+
+# good
+if condition
+  statement
+else
+  statement
+end
+
+# good
+if condition
+  statement
+end
 ```
+#### EnforcedStyle: nil
+
 ```ruby
-# nil - warn on else with nil in it
+# warn on else with nil in it
 
 # bad
 if condition
@@ -1399,9 +1399,23 @@ if condition
   statement
 else
 end
+
+# good
+if condition
+  statement
+else
+  statement
+end
+
+# good
+if condition
+  statement
+end
 ```
+#### EnforcedStyle: both (default)
+
 ```ruby
-# both - warn on empty else and else with nil in it
+# warn on empty else and else with nil in it
 
 # bad
 if condition
@@ -1414,6 +1428,18 @@ end
 if condition
   statement
 else
+end
+
+# good
+if condition
+  statement
+else
+  statement
+end
+
+# good
+if condition
+  statement
 end
 ```
 


### PR DESCRIPTION
Follow up of https://github.com/bbatsov/rubocop/pull/4880#issuecomment-338499947.

This commit is a change of document format for `Style/EmptyElse` cop.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
