### PR TITLE
CLEANUP - Remove unused CONSTANTS in CaseWhenSplat

### DIFF
--- a/lib/rubocop/cop/performance/case_when_splat.rb
+++ b/lib/rubocop/cop/performance/case_when_splat.rb
@@ -56,10 +56,6 @@ module RuboCop
         MSG = 'Place `when` conditions with a splat ' \
               'at the end of the `when` branches.'.freeze
         ARRAY_MSG = 'Do not expand array literals in `when` conditions.'.freeze
-        PERCENT_W = '%w'.freeze
-        PERCENT_CAPITAL_W = '%W'.freeze
-        PERCENT_I = '%i'.freeze
-        PERCENT_CAPITAL_I = '%I'.freeze
 
         def on_case(case_node)
           when_conditions = case_node.when_branches.flat_map(&:conditions)


### PR DESCRIPTION
These `PERCENT` constants appear to no longer be used.  They were added & used 2 years ago - right here - https://github.com/bbatsov/rubocop/commit/8eedad3c05c3eecfe520e4640aca12e8b40750c2#diff-88d81d6507579a295b8fa0f3043df7d2R142 .  But there is now no reference to them, and everything works properly without them.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
