### PR TITLE
Prevent `SendNode#stabby_lambda?` from breaking with `a.() {}`

### DIFF
--- a/lib/rubocop/ast/node/send_node.rb
+++ b/lib/rubocop/ast/node/send_node.rb
@@ -37,7 +37,8 @@ module RuboCop
       #
       # @return [Boolean] whether this method is a staby lambda
       def stabby_lambda?
-        loc.selector.source == ARROW
+        selector = loc.selector
+        selector && selector.source == ARROW
       end
     end
   end

--- a/spec/rubocop/ast/send_node_spec.rb
+++ b/spec/rubocop/ast/send_node_spec.rb
@@ -882,12 +882,50 @@ describe RuboCop::AST::SendNode do
   describe '#lambda?' do
     context 'with a lambda method' do
       let(:source) { 'lambda { |foo| bar(foo) }' }
+      let(:send_node) { parse_source(source).ast.send_node }
+
+      it { expect(send_node.lambda?).to be_truthy }
+    end
+
+    context 'with a stabby lambda method' do
+      let(:source) { '-> (foo) { do_something(foo) }' }
+      let(:send_node) { parse_source(source).ast.send_node }
 
       it { expect(send_node.lambda?).to be_truthy }
     end
 
     context 'with a non-lambda method' do
       let(:source) { 'foo.bar' }
+
+      it { expect(send_node.lambda?).to be_falsey }
+    end
+  end
+
+  describe '#stabby_lambda?' do
+    context 'with a stabby lambda' do
+      let(:send_node) { parse_source(source).ast.send_node }
+      let(:source) { '-> (foo) { do_something(foo) }' }
+
+      it { expect(send_node.stabby_lambda?).to be(true) }
+    end
+
+    context 'with a lambda method' do
+      let(:send_node) { parse_source(source).ast.send_node }
+      let(:source) { 'lambda { |foo| bar(foo) }' }
+
+      it { expect(send_node.stabby_lambda?).to be(false) }
+    end
+
+    context 'with a non-lambda method' do
+      let(:source) { 'foo.bar' }
+
+      it { expect(send_node.lambda?).to be_falsey }
+    end
+
+    # Regression test https://github.com/bbatsov/rubocop/pull/5194
+    context 'with `a.() {}` style method' do
+      let(:send_node) { parse_source(source).ast.send_node }
+      let(:source) { 'a.() {}' }
 
       it { expect(send_node.lambda?).to be_falsey }
     end


### PR DESCRIPTION
Problem
=====

`Style/StabbyLambdaParentheses`, `Style/EmptyBlockParameter` and `Style/EmptyLambdaParameter` raise an error with `a.() {}`.

```ruby
a.() {}
```

```
$ rubocop -d --cache false
For /tmp/tmp.AYL3jCqcQ7: configuration from /home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/config/default.yml
Inheriting configuration from /home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/config/enabled.yml
Inheriting configuration from /home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/config/disabled.yml
Inspecting 1 file
Scanning /tmp/tmp.AYL3jCqcQ7/test.rb
undefined method `source' for nil:NilClass
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/ast/node/send_node.rb:40:in `stabby_lambda?'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/cop/style/empty_block_parameter.rb:31:in `on_block'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/cop/commissioner.rb:44:in `block (2 levels) in on_block'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/cop/commissioner.rb:109:in `with_cop_error_handling'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/cop/commissioner.rb:43:in `block in on_block'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/cop/commissioner.rb:42:in `each'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/cop/commissioner.rb:42:in `on_block'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/ast/traversal.rb:12:in `walk'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/cop/commissioner.rb:60:in `investigate'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/cop/team.rb:114:in `investigate'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/cop/team.rb:102:in `offenses'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/cop/team.rb:44:in `inspect_file'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/runner.rb:258:in `inspect_file'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/runner.rb:205:in `block in do_inspection_loop'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/runner.rb:237:in `block in iterate_until_no_changes'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/runner.rb:230:in `loop'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/runner.rb:230:in `iterate_until_no_changes'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/runner.rb:201:in `do_inspection_loop'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/runner.rb:111:in `block in file_offenses'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/runner.rb:121:in `file_offense_cache'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/runner.rb:109:in `file_offenses'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/runner.rb:100:in `process_file'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/runner.rb:78:in `block in each_inspected_file'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/runner.rb:75:in `each'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/runner.rb:75:in `reduce'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/runner.rb:75:in `each_inspected_file'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/runner.rb:67:in `inspect_files'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/runner.rb:39:in `run'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/cli.rb:128:in `execute_runner'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/cli.rb:60:in `execute_runners'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/cli.rb:31:in `run'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/bin/rubocop:13:in `block in <top (required)>'
/usr/lib/ruby/2.4.0/benchmark.rb:308:in `realtime'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/bin/rubocop:12:in `<top (required)>'
/home/pocke/.gem/ruby/2.4.0/bin/rubocop:23:in `load'
/home/pocke/.gem/ruby/2.4.0/bin/rubocop:23:in `<main>'
undefined method `source' for nil:NilClass
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/ast/node/send_node.rb:40:in `stabby_lambda?'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/cop/style/empty_lambda_parameter.rb:27:in `on_block'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/cop/commissioner.rb:44:in `block (2 levels) in on_block'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/cop/commissioner.rb:109:in `with_cop_error_handling'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/cop/commissioner.rb:43:in `block in on_block'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/cop/commissioner.rb:42:in `each'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/cop/commissioner.rb:42:in `on_block'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/ast/traversal.rb:12:in `walk'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/cop/commissioner.rb:60:in `investigate'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/cop/team.rb:114:in `investigate'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/cop/team.rb:102:in `offenses'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/cop/team.rb:44:in `inspect_file'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/runner.rb:258:in `inspect_file'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/runner.rb:205:in `block in do_inspection_loop'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/runner.rb:237:in `block in iterate_until_no_changes'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/runner.rb:230:in `loop'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/runner.rb:230:in `iterate_until_no_changes'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/runner.rb:201:in `do_inspection_loop'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/runner.rb:111:in `block in file_offenses'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/runner.rb:121:in `file_offense_cache'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/runner.rb:109:in `file_offenses'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/runner.rb:100:in `process_file'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/runner.rb:78:in `block in each_inspected_file'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/runner.rb:75:in `each'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/runner.rb:75:in `reduce'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/runner.rb:75:in `each_inspected_file'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/runner.rb:67:in `inspect_files'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/runner.rb:39:in `run'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/cli.rb:128:in `execute_runner'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/cli.rb:60:in `execute_runners'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/cli.rb:31:in `run'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/bin/rubocop:13:in `block in <top (required)>'
/usr/lib/ruby/2.4.0/benchmark.rb:308:in `realtime'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/bin/rubocop:12:in `<top (required)>'
/home/pocke/.gem/ruby/2.4.0/bin/rubocop:23:in `load'
/home/pocke/.gem/ruby/2.4.0/bin/rubocop:23:in `<main>'
undefined method `source' for nil:NilClass
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/ast/node/send_node.rb:40:in `stabby_lambda?'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/cop/style/stabby_lambda_parentheses.rb:77:in `stabby_lambda_with_args?'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/cop/style/stabby_lambda_parentheses.rb:29:in `on_send'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/cop/commissioner.rb:44:in `block (2 levels) in on_send'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/cop/commissioner.rb:109:in `with_cop_error_handling'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/cop/commissioner.rb:43:in `block in on_send'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/cop/commissioner.rb:42:in `each'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/cop/commissioner.rb:42:in `on_send'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/ast/traversal.rb:151:in `on_block'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/cop/commissioner.rb:48:in `on_block'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/ast/traversal.rb:12:in `walk'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/cop/commissioner.rb:60:in `investigate'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/cop/team.rb:114:in `investigate'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/cop/team.rb:102:in `offenses'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/cop/team.rb:44:in `inspect_file'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/runner.rb:258:in `inspect_file'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/runner.rb:205:in `block in do_inspection_loop'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/runner.rb:237:in `block in iterate_until_no_changes'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/runner.rb:230:in `loop'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/runner.rb:230:in `iterate_until_no_changes'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/runner.rb:201:in `do_inspection_loop'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/runner.rb:111:in `block in file_offenses'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/runner.rb:121:in `file_offense_cache'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/runner.rb:109:in `file_offenses'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/runner.rb:100:in `process_file'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/runner.rb:78:in `block in each_inspected_file'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/runner.rb:75:in `each'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/runner.rb:75:in `reduce'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/runner.rb:75:in `each_inspected_file'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/runner.rb:67:in `inspect_files'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/runner.rb:39:in `run'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/cli.rb:128:in `execute_runner'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/cli.rb:60:in `execute_runners'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/lib/rubocop/cli.rb:31:in `run'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/bin/rubocop:13:in `block in <top (required)>'
/usr/lib/ruby/2.4.0/benchmark.rb:308:in `realtime'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.51.0/bin/rubocop:12:in `<top (required)>'
/home/pocke/.gem/ruby/2.4.0/bin/rubocop:23:in `load'
/home/pocke/.gem/ruby/2.4.0/bin/rubocop:23:in `<main>'
C

Offenses:

test.rb:1:1: C: Style/LambdaCall: Prefer the use of lambda.call(...) over lambda.(...).
a.() {}
^^^^
test.rb:1:5: C: Layout/SpaceBeforeBlockBraces: Space detected to the left of {.
a.() {}
    ^

1 file inspected, 2 offenses detected
Finished in 0.05691312800627202 seconds
```

Cause
====

`a.() {}` does not has `selector` location.

```
[6] pry(#<RuboCop::AST::BlockNode>)> send_node.source
=> "a.()"
[7] pry(#<RuboCop::AST::BlockNode>)> send_node.loc
=> #<Parser::Source::Map::Send:0x000056535c801370 @begin=#<Parser::Source::Range (string) 2...3>, @dot=#<Parser::Source::Range (string) 1...2>, @end=#<Parser::Source::Range (string) 3...4>, @expression=#<Parser::Source::Range (string) 0...4>, @node=s(:send,
  s(:send, nil, :a), :call), @selector=nil>
[8] pry(#<RuboCop::AST::BlockNode>)> send_node.loc.selector
=> nil
```

Solution
====

Add a `nil` check into `SendNode#stabby_lambda?`.

Note
===

This bug hasn't been shipped to user yet. So I didn't add an entry to CHANGELOG for this bug.

**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
