### PR TITLE
Prevent to generate rubocop-rspec's documentation

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -22,9 +22,9 @@ RSpec::Core::RakeTask.new(:ascii_spec) { |t| t.ruby_opts = '-E ASCII' }
 
 desc 'Run test and RuboCop in parallel'
 task parallel: %i[
+  documentation_syntax_check generate_cops_documentation
   parallel:spec parallel:ascii_spec
   internal_investigation
-  documentation_syntax_check generate_cops_documentation
 ]
 
 namespace :parallel do
@@ -54,9 +54,9 @@ RuboCop::RakeTask.new(:internal_investigation).tap do |task|
 end
 
 task default: %i[
+  documentation_syntax_check generate_cops_documentation
   spec ascii_spec
   internal_investigation
-  documentation_syntax_check generate_cops_documentation
 ]
 
 require 'yard'

--- a/tasks/cops_documentation.rake
+++ b/tasks/cops_documentation.rake
@@ -223,16 +223,22 @@ task generate_cops_documentation: :yard_for_generate_documentation do
     end
   end
 
-  cops   = RuboCop::Cop::Cop.registry
-  config = RuboCop::ConfigLoader.default_configuration
-  config['Rails']['Enabled'] = true
+  def main
+    cops   = RuboCop::Cop::Cop.registry
+    config = RuboCop::ConfigLoader.default_configuration
+    config['Rails']['Enabled'] = true
 
-  YARD::Registry.load!
-  cops.departments.sort!.each do |department|
-    print_cops_of_department(cops, department, config)
+    YARD::Registry.load!
+    cops.departments.sort!.each do |department|
+      print_cops_of_department(cops, department, config)
+    end
+
+    print_table_of_contents(cops)
+
+    assert_manual_synchronized if ENV['CI'] == 'true'
+  ensure
+    RuboCop::ConfigLoader.default_configuration = nil
   end
 
-  print_table_of_contents(cops)
-
-  assert_manual_synchronized if ENV['CI'] == 'true'
+  main
 end


### PR DESCRIPTION
Currently, `rake parallel` and `rake default` generate `rubocop-rspec`'s documentation. Because the generation task runs after internal investigation, and internal investigation task load rubocop-rspec.
This change fixes the problem. I think it is a workaround. I think we need refactoring the Registry and Cop class to resolve this problem, but the refactoring looks hard.

This bug is introduced by #5176 🙇 

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
