### PR TITLE
Prevent failing syntax check for the documentation with UTF-8 invalid string

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -135,15 +135,15 @@ task documentation_syntax_check: :yard_for_generate_documentation do
 
     examples.each do |example|
       begin
-        # Parser output syntax errors to stderr, but it is not needed.
-        $stderr = StringIO.new(''.dup)
-        Parser::Ruby24.parse(example.text)
+        buffer = Parser::Source::Buffer.new('<code>', 1)
+        buffer.source = example.text
+        parser = Parser::Ruby24.new(RuboCop::AST::Builder.new)
+        parser.diagnostics.all_errors_are_fatal = true
+        parser.parse(buffer)
       rescue Parser::SyntaxError => ex
         path = example.object.file
         puts "#{path}: Syntax Error in an example. #{ex}"
         ok = false
-      ensure
-        $stderr = STDERR
       end
     end
   end


### PR DESCRIPTION
See #5198

We can fix the problem by using `RuboCop::AST::Builder`.


-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
