### PR TITLE
Add examples to 4 Style cops

### DIFF
--- a/lib/rubocop/cop/style/parentheses_around_condition.rb
+++ b/lib/rubocop/cop/style/parentheses_around_condition.rb
@@ -5,6 +5,23 @@ module RuboCop
     module Style
       # This cop checks for the presence of superfluous parentheses around the
       # condition of if/unless/while/until.
+      #
+      # @example
+      #   # bad
+      #   x += 1 while (x < 10)
+      #   foo unless (bar || baz)
+      #
+      #   if (x > 10)
+      #   elsif (x < 3)
+      #   end
+      #
+      #   # good
+      #   x += 1 while x < 10
+      #   foo unless bar || baz
+      #
+      #   if x > 10
+      #   elsif x < 3
+      #   end
       class ParenthesesAroundCondition < Cop
         include SafeAssignment
         include Parentheses

--- a/lib/rubocop/cop/style/percent_q_literals.rb
+++ b/lib/rubocop/cop/style/percent_q_literals.rb
@@ -4,6 +4,27 @@ module RuboCop
   module Cop
     module Style
       # This cop checks for usage of the %Q() syntax when %q() would do.
+      #
+      # @example EnforcedStyle: lower_case_q (default)
+      #   # The `lower_case_q` style prefers `%q` unless
+      #   # interpolation is needed.
+      #   # bad
+      #   %Q[Mix the foo into the baz.]
+      #   %Q(They all said: 'Hooray!')
+      #
+      #   # good
+      #   %q[Mix the foo into the baz]
+      #   %q(They all said: 'Hooray!')
+      #
+      # @example EnforcedStyle: upper_case_q
+      #   # The `upper_case_q` style requires the sole use of `%Q`.
+      #   # bad
+      #   %q/Mix the foo into the baz./
+      #   %q{They all said: 'Hooray!'}
+      #
+      #   # good
+      #   %Q/Mix the foo into the baz./
+      #   %Q{They all said: 'Hooray!'}
       class PercentQLiterals < Cop
         include PercentLiteral
         include ConfigurableEnforcedStyle

--- a/lib/rubocop/cop/style/rescue_modifier.rb
+++ b/lib/rubocop/cop/style/rescue_modifier.rb
@@ -4,6 +4,17 @@ module RuboCop
   module Cop
     module Style
       # This cop checks for uses of rescue in its modifier form.
+      #
+      # @example
+      #   # bad
+      #   some_method rescue handle_error
+      #
+      #   # good
+      #   begin
+      #     some_method
+      #   rescue
+      #     handle_error
+      #   end
       class RescueModifier < Cop
         include AutocorrectAlignment
         include RescueNode

--- a/lib/rubocop/cop/style/send.rb
+++ b/lib/rubocop/cop/style/send.rb
@@ -4,6 +4,15 @@ module RuboCop
   module Cop
     module Style
       # This cop checks for the use of the send method.
+      #
+      # @example
+      #   # bad
+      #   Foo.send(:bar)
+      #   quuz.send(:fred)
+      #
+      #   # good
+      #   Foo.__send__(:bar)
+      #   quuz.public_send(:fred)
       class Send < Cop
         MSG = 'Prefer `Object#__send__` or `Object#public_send` to ' \
               '`send`.'.freeze

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -3592,6 +3592,26 @@ Enabled | Yes
 This cop checks for the presence of superfluous parentheses around the
 condition of if/unless/while/until.
 
+### Examples
+
+```ruby
+# bad
+x += 1 while (x < 10)
+foo unless (bar || baz)
+
+if (x > 10)
+elsif (x < 3)
+end
+
+# good
+x += 1 while x < 10
+foo unless bar || baz
+
+if x > 10
+elsif x < 3
+end
+```
+
 ### Configurable attributes
 
 Name | Default value | Configurable values

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -4466,6 +4466,18 @@ Disabled | No
 
 This cop checks for the use of the send method.
 
+### Examples
+
+```ruby
+# bad
+Foo.send(:bar)
+quuz.send(:fred)
+
+# good
+Foo.__send__(:bar)
+quuz.public_send(:fred)
+```
+
 ### References
 
 * [https://github.com/bbatsov/ruby-style-guide#prefer-public-send](https://github.com/bbatsov/ruby-style-guide#prefer-public-send)

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -4215,6 +4215,20 @@ Enabled | Yes
 
 This cop checks for uses of rescue in its modifier form.
 
+### Examples
+
+```ruby
+# bad
+some_method rescue handle_error
+
+# good
+begin
+  some_method
+rescue
+  handle_error
+end
+```
+
 ### References
 
 * [https://github.com/bbatsov/ruby-style-guide#no-rescue-modifiers](https://github.com/bbatsov/ruby-style-guide#no-rescue-modifiers)

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -3670,6 +3670,34 @@ Enabled | Yes
 
 This cop checks for usage of the %Q() syntax when %q() would do.
 
+### Examples
+
+#### EnforcedStyle: lower_case_q (default)
+
+```ruby
+# The `lower_case_q` style prefers `%q` unless
+# interpolation is needed.
+# bad
+%Q[Mix the foo into the baz.]
+%Q(They all said: 'Hooray!')
+
+# good
+%q[Mix the foo into the baz]
+%q(They all said: 'Hooray!')
+```
+#### EnforcedStyle: upper_case_q
+
+```ruby
+# The `upper_case_q` style requires the sole use of `%Q`.
+# bad
+%q/Mix the foo into the baz./
+%q{They all said: 'Hooray!'}
+
+# good
+%Q/Mix the foo into the baz./
+%Q{They all said: 'Hooray!'}
+```
+
 ### Configurable attributes
 
 Name | Default value | Configurable values


### PR DESCRIPTION
This PR adds examples to four Style Cops listed in the documentation issue #4910 .  Each example set is contained to one commit.

Those Cops are:

1. `Style/ParenthesesAroundCondition`
1. `Style/PercentQLiterals`
1. `Style/RescueModifier`
1. `Style/Send`

-----------------

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
