### PR TITLE
CI against JRuby 9.1.15.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ cache: bundler
 language: ruby
 dist: trusty
 rvm:
-  - jruby-9.1.14.0
+  - jruby-9.1.15.0
   - jruby-head
   - 2.1.10
   - 2.2.8


### PR DESCRIPTION
JRuby 9.1.15.0 has been released.
http://jruby.org/2017/12/07/jruby-9-1-15-0.html
