### PR TITLE
CLEANUP - Move node specific methods into `AST::Node`

### DIFF
--- a/lib/rubocop/ast/node.rb
+++ b/lib/rubocop/ast/node.rb
@@ -327,6 +327,18 @@ module RuboCop
         source_range.last_line - source_range.first_line + 1
       end
 
+      def nonempty_line_count
+        source.lines.grep(/\S/).size
+      end
+
+      def empty?
+        length.zero?
+      end
+
+      def length
+        source_range ? source_range.size : 0
+      end
+
       def asgn_method_call?
         !COMPARISON_OPERATORS.include?(method_name) &&
           method_name.to_s.end_with?('='.freeze)

--- a/lib/rubocop/cop/mixin/statement_modifier.rb
+++ b/lib/rubocop/cop/mixin/statement_modifier.rb
@@ -13,12 +13,15 @@ module RuboCop
       end
 
       def non_eligible_node?(node)
-        line_count(node) > 3 ||
+        node.nonempty_line_count > 3 ||
           !node.modifier_form? && commented?(node.loc.end)
       end
 
       def non_eligible_body?(body)
-        empty_body?(body) || body.begin_type? || commented?(body.source_range)
+        body.nil? ||
+          body.empty? ||
+          body.begin_type? ||
+          commented?(body.source_range)
       end
 
       def non_eligible_condition?(condition)
@@ -27,7 +30,7 @@ module RuboCop
 
       def modifier_fits_on_single_line?(node)
         modifier_length = length_in_modifier_form(node, node.condition,
-                                                  body_length(node.body))
+                                                  node.body.length)
 
         modifier_length <= max_line_length
       end
@@ -42,18 +45,6 @@ module RuboCop
 
       def max_line_length
         config.for_cop('Metrics/LineLength')['Max']
-      end
-
-      def line_count(node)
-        node.source.lines.grep(/\S/).size
-      end
-
-      def empty_body?(body)
-        !body || body_length(body).zero?
-      end
-
-      def body_length(body)
-        body.source_range ? body.source_range.size : 0
       end
 
       def commented?(source)


### PR DESCRIPTION
The `StatementModifier` mixin logic predates the addition of a `line_count` method added to `AST::Node`'s public API. When I noticed this, I thought perhaps the mixin method could be deleted, and attempted to swap it out.  However, the mixin `line_count(node)` method does not actually calculate all the lines of a node.  It calculates all the lines of a node that have content. It subtracts empty lines from the count it returns.

This tiny tweak makes this difference more obvious.

This change does highlight a smell in `StatementModifier` though.  [All three of these methods](https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/cop/mixin/statement_modifier.rb#L47-L57) operate solely on a node. Following good OO principles means these methods are not the concern of `StatementModifier`, but the responsibility of `AST::Node`.

Based on feedback, we could move them.

This:
```ruby
module StatementModifier
  def content_line_count(node)
    node.source.lines.grep(/\S/).size
  end

  def empty_body?(body)
    !body || body_length(body).zero?
  end

  def body_length(body)
    body.source_range ? body.source_range.size : 0
  end
end
```

could be refactored to:

```ruby
class Node < Parser::AST::Node
  def content_line_count
    source.lines.grep(/\S/).size
  end

  def empty?
    length.zero?
  end

  def length
    source_range ? source_range.size : 0
  end
end
```

-----------------

* [x] Wrote [good commit messages][1].
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
