### PR TITLE
TOOLING - Require 'pry' for use while testing

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,7 @@ require 'rubocop/cop/internal_affairs'
 require 'webmock/rspec'
 
 require 'powerpack/string/strip_margin'
+require 'pry'
 
 # Require supporting files exposed for testing.
 require 'rubocop/rspec/support'


### PR DESCRIPTION
It appears we already have `pry` installed into `Rubocop`.  However, when it is not required in the spec_helper, it means every time one drops in a `pry`, they have to manually add a require statement.  Adding it into the `spec_helper.rb` makes developing/testing across multiple files a lot easier.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
