### PR TITLE
[Fix #5206] Cop 'autocorrect' methods are public

### DIFF
--- a/lib/rubocop/cop/autocorrect_logic.rb
+++ b/lib/rubocop/cop/autocorrect_logic.rb
@@ -13,7 +13,7 @@ module RuboCop
       end
 
       def support_autocorrect?
-        respond_to?(:autocorrect, true)
+        respond_to?(:autocorrect)
       end
 
       def autocorrect_enabled?

--- a/lib/rubocop/cop/internal_affairs/offense_location_keyword.rb
+++ b/lib/rubocop/cop/internal_affairs/offense_location_keyword.rb
@@ -25,6 +25,12 @@ module RuboCop
           end
         end
 
+        def autocorrect(node)
+          (*, keyword) = offending_location_argument(node.parent)
+
+          ->(corrector) { corrector.replace(node.source_range, ":#{keyword}") }
+        end
+
         private
 
         def_node_matcher :node_type_check, <<-PATTERN
@@ -34,12 +40,6 @@ module RuboCop
         def_node_matcher :offending_location_argument, <<-PATTERN
           (pair (sym :location) $(send (send $_node :loc) $_keyword))
         PATTERN
-
-        def autocorrect(node)
-          (*, keyword) = offending_location_argument(node.parent)
-
-          ->(corrector) { corrector.replace(node.source_range, ":#{keyword}") }
-        end
 
         def find_offending_argument(searched_node, kwargs)
           kwargs.pairs.each do |pair|

--- a/lib/rubocop/cop/layout/align_hash.rb
+++ b/lib/rubocop/cop/layout/align_hash.rb
@@ -124,6 +124,21 @@ module RuboCop
           check_pairs(node)
         end
 
+        def autocorrect(node)
+          # We can't use the instance variable inside the lambda. That would
+          # just give each lambda the same reference and they would all get the
+          # last value of each. A local variable fixes the problem.
+          key_delta = column_deltas[:key] || 0
+
+          if !node.value
+            correct_no_value(key_delta, node.source_range)
+          else
+            correct_key_value(key_delta, node.key.source_range,
+                              node.value.source_range,
+                              node.loc.operator)
+          end
+        end
+
         private
 
         attr_accessor :column_deltas
@@ -170,21 +185,6 @@ module RuboCop
         def alignment_for_colons
           @alignment_for_colons ||=
             new_alignment('EnforcedColonStyle')
-        end
-
-        def autocorrect(node)
-          # We can't use the instance variable inside the lambda. That would
-          # just give each lambda the same reference and they would all get the
-          # last value of each. A local variable fixes the problem.
-          key_delta = column_deltas[:key] || 0
-
-          if !node.value
-            correct_no_value(key_delta, node.source_range)
-          else
-            correct_key_value(key_delta, node.key.source_range,
-                              node.value.source_range,
-                              node.loc.operator)
-          end
         end
 
         def correct_no_value(key_delta, key)

--- a/lib/rubocop/cop/layout/block_end_newline.rb
+++ b/lib/rubocop/cop/layout/block_end_newline.rb
@@ -39,8 +39,6 @@ module RuboCop
           add_offense(node, location: end_loc)
         end
 
-        private
-
         def autocorrect(node)
           lambda do |corrector|
             indentation = indentation_of_block_start_line(node)
@@ -48,6 +46,8 @@ module RuboCop
             corrector.replace(delimiter_range(node), new_block_end)
           end
         end
+
+        private
 
         def message(node)
           format(MSG, line: node.loc.end.line, column: node.loc.end.column + 1)

--- a/lib/rubocop/cop/layout/case_indentation.rb
+++ b/lib/rubocop/cop/layout/case_indentation.rb
@@ -81,6 +81,16 @@ module RuboCop
           end
         end
 
+        def autocorrect(node)
+          whitespace = whitespace_range(node)
+
+          return false unless whitespace.source.strip.empty?
+
+          lambda do |corrector|
+            corrector.replace(whitespace, replacement(node))
+          end
+        end
+
         private
 
         def check_when(when_node)
@@ -125,16 +135,6 @@ module RuboCop
           case base
           when :case then case_node.location.keyword.column
           when :end  then case_node.location.end.column
-          end
-        end
-
-        def autocorrect(node)
-          whitespace = whitespace_range(node)
-
-          return false unless whitespace.source.strip.empty?
-
-          lambda do |corrector|
-            corrector.replace(whitespace, replacement(node))
           end
         end
 

--- a/lib/rubocop/cop/layout/dot_position.rb
+++ b/lib/rubocop/cop/layout/dot_position.rb
@@ -35,6 +35,18 @@ module RuboCop
           end
         end
 
+        def autocorrect(node)
+          lambda do |corrector|
+            corrector.remove(node.loc.dot)
+            case style
+            when :leading
+              corrector.insert_before(selector_range(node), '.')
+            when :trailing
+              corrector.insert_after(node.receiver.source_range, '.')
+            end
+          end
+        end
+
         private
 
         def message(_node)
@@ -73,18 +85,6 @@ module RuboCop
           case style
           when :leading then dot_line == selector_line
           when :trailing then dot_line != selector_line
-          end
-        end
-
-        def autocorrect(node)
-          lambda do |corrector|
-            corrector.remove(node.loc.dot)
-            case style
-            when :leading
-              corrector.insert_before(selector_range(node), '.')
-            when :trailing
-              corrector.insert_after(node.receiver.source_range, '.')
-            end
           end
         end
 

--- a/lib/rubocop/cop/layout/empty_line_between_defs.rb
+++ b/lib/rubocop/cop/layout/empty_line_between_defs.rb
@@ -57,6 +57,23 @@ module RuboCop
           add_offense(nodes.last, location: :keyword)
         end
 
+        def autocorrect(node)
+          prev_def = prev_node(node)
+
+          # finds position of first newline
+          end_pos = prev_def.loc.end.end_pos
+          source_buffer = prev_def.loc.end.source_buffer
+          newline_pos = source_buffer.source.index("\n", end_pos)
+
+          count = blank_lines_count_between(prev_def, node)
+
+          if count > maximum_empty_lines
+            autocorrect_remove_lines(newline_pos, count)
+          else
+            autocorrect_insert_lines(newline_pos, count)
+          end
+        end
+
         private
 
         def def_node?(node)
@@ -107,23 +124,6 @@ module RuboCop
 
         def def_end(node)
           node.loc.end.line
-        end
-
-        def autocorrect(node)
-          prev_def = prev_node(node)
-
-          # finds position of first newline
-          end_pos = prev_def.loc.end.end_pos
-          source_buffer = prev_def.loc.end.source_buffer
-          newline_pos = source_buffer.source.index("\n", end_pos)
-
-          count = blank_lines_count_between(prev_def, node)
-
-          if count > maximum_empty_lines
-            autocorrect_remove_lines(newline_pos, count)
-          else
-            autocorrect_insert_lines(newline_pos, count)
-          end
         end
 
         def autocorrect_remove_lines(newline_pos, count)

--- a/lib/rubocop/cop/layout/empty_lines_around_arguments.rb
+++ b/lib/rubocop/cop/layout/empty_lines_around_arguments.rb
@@ -47,13 +47,13 @@ module RuboCop
           extra_lines(node) { |range| add_offense(node, location: range) }
         end
 
-        private
-
         def autocorrect(node)
           lambda do |corrector|
             extra_lines(node) { |range| corrector.remove(range) }
           end
         end
+
+        private
 
         def empty_lines(node)
           @empty_lines ||= begin

--- a/lib/rubocop/cop/layout/leading_comment_space.rb
+++ b/lib/rubocop/cop/layout/leading_comment_space.rb
@@ -28,14 +28,14 @@ module RuboCop
           end
         end
 
-        private
-
         def autocorrect(comment)
           expr = comment.loc.expression
           hash_mark = range_between(expr.begin_pos, expr.begin_pos + 1)
 
           ->(corrector) { corrector.insert_after(hash_mark, ' ') }
         end
+
+        private
 
         def allowed_on_first_line?(comment)
           shebang?(comment) || rackup_config_file? && rackup_options?(comment)

--- a/lib/rubocop/cop/layout/multiline_block_layout.rb
+++ b/lib/rubocop/cop/layout/multiline_block_layout.rb
@@ -53,20 +53,6 @@ module RuboCop
           add_offense_for_expression(node, node.body, MSG)
         end
 
-        private
-
-        def args_on_beginning_line?(node)
-          !node.arguments? ||
-            node.loc.begin.line == node.arguments.loc.last_line
-        end
-
-        def add_offense_for_expression(node, expr, msg)
-          expression = expr.source_range
-          range = range_between(expression.begin_pos, expression.end_pos)
-
-          add_offense(node, location: range, message: msg)
-        end
-
         def autocorrect(node)
           lambda do |corrector|
             unless args_on_beginning_line?(node)
@@ -82,6 +68,20 @@ module RuboCop
               autocorrect_body(corrector, node, node.body)
             end
           end
+        end
+
+        private
+
+        def args_on_beginning_line?(node)
+          !node.arguments? ||
+            node.loc.begin.line == node.arguments.loc.last_line
+        end
+
+        def add_offense_for_expression(node, expr, msg)
+          expression = expr.source_range
+          range = range_between(expression.begin_pos, expression.end_pos)
+
+          add_offense(node, location: range, message: msg)
         end
 
         def autocorrect_arguments(corrector, node)

--- a/lib/rubocop/cop/layout/space_after_colon.rb
+++ b/lib/rubocop/cop/layout/space_after_colon.rb
@@ -32,14 +32,14 @@ module RuboCop
           add_offense(colon, location: colon) unless followed_by_space?(colon)
         end
 
+        def autocorrect(range)
+          ->(corrector) { corrector.insert_after(range, ' ') }
+        end
+
         private
 
         def followed_by_space?(colon)
           colon.source_buffer.source[colon.end_pos] =~ /\s/
-        end
-
-        def autocorrect(range)
-          ->(corrector) { corrector.insert_after(range, ' ') }
         end
       end
     end

--- a/lib/rubocop/cop/layout/space_after_method_name.rb
+++ b/lib/rubocop/cop/layout/space_after_method_name.rb
@@ -30,8 +30,6 @@ module RuboCop
         end
         alias on_defs on_def
 
-        private
-
         def autocorrect(pos_before_left_paren)
           ->(corrector) { corrector.remove(pos_before_left_paren) }
         end

--- a/lib/rubocop/cop/layout/space_around_block_parameters.rb
+++ b/lib/rubocop/cop/layout/space_around_block_parameters.rb
@@ -44,6 +44,15 @@ module RuboCop
           check_each_arg(args)
         end
 
+        def autocorrect(range)
+          lambda do |corrector|
+            case range.source
+            when /^\s+$/ then corrector.remove(range)
+            else              corrector.insert_after(range, ' ')
+            end
+          end
+        end
+
         private
 
         def style_parameter_name
@@ -119,15 +128,6 @@ module RuboCop
           range = range_between(space_begin_pos, space_end_pos)
           add_offense(range, location: range,
                              message: "#{msg} block parameter detected.")
-        end
-
-        def autocorrect(range)
-          lambda do |corrector|
-            case range.source
-            when /^\s+$/ then corrector.remove(range)
-            else              corrector.insert_after(range, ' ')
-            end
-          end
         end
       end
     end

--- a/lib/rubocop/cop/layout/space_around_equals_in_parameter_default.rb
+++ b/lib/rubocop/cop/layout/space_around_equals_in_parameter_default.rb
@@ -27,6 +27,13 @@ module RuboCop
           check_optarg(arg, equals, value)
         end
 
+        def autocorrect(range)
+          m = range.source.match(/=\s*(\S+)/)
+          rest = m ? m.captures[0] : ''
+          replacement = style == :space ? ' = ' : '='
+          ->(corrector) { corrector.replace(range, replacement + rest) }
+        end
+
         private
 
         def check_optarg(arg, equals, value)
@@ -65,13 +72,6 @@ module RuboCop
 
         def message(_)
           format(MSG, type: style == :space ? 'missing' : 'detected')
-        end
-
-        def autocorrect(range)
-          m = range.source.match(/=\s*(\S+)/)
-          rest = m ? m.captures[0] : ''
-          replacement = style == :space ? ' = ' : '='
-          ->(corrector) { corrector.replace(range, replacement + rest) }
         end
       end
     end

--- a/lib/rubocop/cop/layout/space_around_keyword.rb
+++ b/lib/rubocop/cop/layout/space_around_keyword.rb
@@ -127,6 +127,14 @@ module RuboCop
           check(node, [:keyword].freeze)
         end
 
+        def autocorrect(range)
+          if space_before_missing?(range)
+            ->(corrector) { corrector.insert_before(range, ' '.freeze) }
+          else
+            ->(corrector) { corrector.insert_after(range, ' '.freeze) }
+          end
+        end
+
         private
 
         def check(node, locations, begin_keyword = DO)
@@ -215,14 +223,6 @@ module RuboCop
             return true if operator?(ancestor.method_name)
           end
           false
-        end
-
-        def autocorrect(range)
-          if space_before_missing?(range)
-            ->(corrector) { corrector.insert_before(range, ' '.freeze) }
-          else
-            ->(corrector) { corrector.insert_after(range, ' '.freeze) }
-          end
         end
       end
     end

--- a/lib/rubocop/cop/layout/space_around_operators.rb
+++ b/lib/rubocop/cop/layout/space_around_operators.rb
@@ -86,6 +86,18 @@ module RuboCop
         alias on_and_asgn on_binary
         alias on_op_asgn  on_special_asgn
 
+        def autocorrect(range)
+          lambda do |corrector|
+            if range.source =~ /\*\*/
+              corrector.replace(range, '**')
+            elsif range.source.end_with?("\n")
+              corrector.replace(range, " #{range.source.strip}\n")
+            else
+              corrector.replace(range, " #{range.source.strip} ")
+            end
+          end
+        end
+
         private
 
         def regular_operator?(send_node)
@@ -131,18 +143,6 @@ module RuboCop
         def excess_trailing_space?(right_operand, with_space)
           with_space.source =~ /  $/ &&
             (!allow_for_alignment? || !aligned_with_something?(right_operand))
-        end
-
-        def autocorrect(range)
-          lambda do |corrector|
-            if range.source =~ /\*\*/
-              corrector.replace(range, '**')
-            elsif range.source.end_with?("\n")
-              corrector.replace(range, " #{range.source.strip}\n")
-            else
-              corrector.replace(range, " #{range.source.strip} ")
-            end
-          end
         end
 
         def align_hash_cop_config

--- a/lib/rubocop/cop/layout/space_before_block_braces.rb
+++ b/lib/rubocop/cop/layout/space_before_block_braces.rb
@@ -41,6 +41,15 @@ module RuboCop
           end
         end
 
+        def autocorrect(range)
+          lambda do |corrector|
+            case range.source
+            when /\s/ then corrector.remove(range)
+            else           corrector.insert_before(range, ' ')
+            end
+          end
+        end
+
         private
 
         def check_empty(left_brace, space_plus_brace, used_style)
@@ -86,15 +95,6 @@ module RuboCop
           when 'no_space' then :no_space
           when nil then style
           else raise 'Unknown EnforcedStyleForEmptyBraces selected!'
-          end
-        end
-
-        def autocorrect(range)
-          lambda do |corrector|
-            case range.source
-            when /\s/ then corrector.remove(range)
-            else           corrector.insert_before(range, ' ')
-            end
           end
         end
 

--- a/lib/rubocop/cop/layout/space_before_comment.rb
+++ b/lib/rubocop/cop/layout/space_before_comment.rb
@@ -23,8 +23,6 @@ module RuboCop
           end
         end
 
-        private
-
         def autocorrect(range)
           ->(corrector) { corrector.insert_before(range, ' ') }
         end

--- a/lib/rubocop/cop/layout/space_inside_array_literal_brackets.rb
+++ b/lib/rubocop/cop/layout/space_inside_array_literal_brackets.rb
@@ -56,8 +56,6 @@ module RuboCop
           issue_offenses(node, left, right, start_ok, end_ok)
         end
 
-        private
-
         def autocorrect(node)
           left, right = array_brackets(node)
 
@@ -73,6 +71,8 @@ module RuboCop
             end
           end
         end
+
+        private
 
         def array_brackets(node)
           [left_array_bracket(node), right_array_bracket(node)]

--- a/lib/rubocop/cop/layout/space_inside_block_braces.rb
+++ b/lib/rubocop/cop/layout/space_inside_block_braces.rb
@@ -89,6 +89,17 @@ module RuboCop
           check_inside(node, left_brace, right_brace)
         end
 
+        def autocorrect(range)
+          lambda do |corrector|
+            case range.source
+            when /\s/ then corrector.remove(range)
+            when '{}' then corrector.replace(range, '{ }')
+            when '{|' then corrector.replace(range, '{ |')
+            else           corrector.insert_before(range, ' ')
+            end
+          end
+        end
+
         private
 
         def check_inside(node, left_brace, right_brace)
@@ -209,17 +220,6 @@ module RuboCop
           when 'space'    then :space
           when 'no_space' then :no_space
           else raise 'Unknown EnforcedStyleForEmptyBraces selected!'
-          end
-        end
-
-        def autocorrect(range)
-          lambda do |corrector|
-            case range.source
-            when /\s/ then corrector.remove(range)
-            when '{}' then corrector.replace(range, '{ }')
-            when '{|' then corrector.replace(range, '{ |')
-            else           corrector.insert_before(range, ' ')
-            end
           end
         end
       end

--- a/lib/rubocop/cop/layout/space_inside_hash_literal_braces.rb
+++ b/lib/rubocop/cop/layout/space_inside_hash_literal_braces.rb
@@ -53,6 +53,23 @@ module RuboCop
           end
         end
 
+        def autocorrect(range)
+          lambda do |corrector|
+            # It is possible that BracesAroundHashParameters will remove the
+            # braces while this cop inserts spaces. This can lead to unwanted
+            # changes to the inspected code. If we replace the brace with a
+            # brace plus space (rather than just inserting a space), then any
+            # removal of the same brace will give us a clobbering error. This
+            # in turn will make RuboCop fall back on cop-by-cop
+            # auto-correction.  Problem solved.
+            case range.source
+            when /\s/ then corrector.remove(range)
+            when '{' then corrector.replace(range, '{ ')
+            else corrector.replace(range, ' }')
+            end
+          end
+        end
+
         private
 
         def hash_literal_with_braces(node)
@@ -136,23 +153,6 @@ module RuboCop
                         end
           problem = expect_space ? 'missing' : 'detected'
           format(MSG, "#{inside_what} #{problem}")
-        end
-
-        def autocorrect(range)
-          lambda do |corrector|
-            # It is possible that BracesAroundHashParameters will remove the
-            # braces while this cop inserts spaces. This can lead to unwanted
-            # changes to the inspected code. If we replace the brace with a
-            # brace plus space (rather than just inserting a space), then any
-            # removal of the same brace will give us a clobbering error. This
-            # in turn will make RuboCop fall back on cop-by-cop
-            # auto-correction.  Problem solved.
-            case range.source
-            when /\s/ then corrector.remove(range)
-            when '{' then corrector.replace(range, '{ ')
-            else corrector.replace(range, ' }')
-            end
-          end
         end
 
         def space_range(token_range)

--- a/lib/rubocop/cop/layout/space_inside_range_literal.rb
+++ b/lib/rubocop/cop/layout/space_inside_range_literal.rb
@@ -28,21 +28,6 @@ module RuboCop
           check(node)
         end
 
-        private
-
-        def check(node)
-          expression = node.source
-          op = node.loc.operator.source
-          escaped_op = op.gsub(/\./, '\.')
-
-          # account for multiline range literals
-          expression.sub!(/#{escaped_op}\n\s*/, op)
-
-          return unless expression =~ /(\s#{escaped_op})|(#{escaped_op}\s)/
-
-          add_offense(node)
-        end
-
         def autocorrect(node)
           expression = node.source
           operator = node.loc.operator.source
@@ -56,6 +41,21 @@ module RuboCop
                 .sub(/#{operator_escaped}\s+/, operator)
             )
           end
+        end
+
+        private
+
+        def check(node)
+          expression = node.source
+          op = node.loc.operator.source
+          escaped_op = op.gsub(/\./, '\.')
+
+          # account for multiline range literals
+          expression.sub!(/#{escaped_op}\n\s*/, op)
+
+          return unless expression =~ /(\s#{escaped_op})|(#{escaped_op}\s)/
+
+          add_offense(node)
         end
       end
     end

--- a/lib/rubocop/cop/layout/space_inside_reference_brackets.rb
+++ b/lib/rubocop/cop/layout/space_inside_reference_brackets.rb
@@ -48,8 +48,6 @@ module RuboCop
           end
         end
 
-        private
-
         def autocorrect(node)
           lambda do |corrector|
             left, right = reference_brackets(node)
@@ -61,6 +59,8 @@ module RuboCop
             end
           end
         end
+
+        private
 
         def reference_brackets(node)
           left = left_ref_bracket(node)

--- a/lib/rubocop/cop/layout/space_inside_string_interpolation.rb
+++ b/lib/rubocop/cop/layout/space_inside_string_interpolation.rb
@@ -30,6 +30,16 @@ module RuboCop
           end
         end
 
+        def autocorrect(node)
+          new_source = style == :no_space ? node.source : " #{node.source} "
+          lambda do |corrector|
+            corrector.replace(
+              range_with_surrounding_space(range: node.source_range),
+              new_source
+            )
+          end
+        end
+
         private
 
         def each_style_violation(node)
@@ -63,16 +73,6 @@ module RuboCop
             range_with_surrounding_space(range: interp)
 
           interp_with_surrounding_space.source == " #{interp.source} "
-        end
-
-        def autocorrect(node)
-          new_source = style == :no_space ? node.source : " #{node.source} "
-          lambda do |corrector|
-            corrector.replace(
-              range_with_surrounding_space(range: node.source_range),
-              new_source
-            )
-          end
         end
       end
     end

--- a/lib/rubocop/cop/layout/tab.rb
+++ b/lib/rubocop/cop/layout/tab.rb
@@ -28,14 +28,14 @@ module RuboCop
           end
         end
 
-        private
-
         def autocorrect(range)
           lambda do |corrector|
             spaces = ' ' * configured_indentation_width
             corrector.replace(range, range.source.gsub(/\t/, spaces))
           end
         end
+
+        private
 
         def string_literal_lines(ast)
           # which lines start inside a string literal?

--- a/lib/rubocop/cop/layout/trailing_blank_lines.rb
+++ b/lib/rubocop/cop/layout/trailing_blank_lines.rb
@@ -28,6 +28,12 @@ module RuboCop
                            whitespace_at_end)
         end
 
+        def autocorrect(range)
+          lambda do |corrector|
+            corrector.replace(range, style == :final_newline ? "\n" : "\n\n")
+          end
+        end
+
         private
 
         def offense_detected(sb, wanted_blank_lines, blank_lines,
@@ -66,12 +72,6 @@ module RuboCop
                          end
             format('%d trailing blank lines %sdetected.', blank_lines,
                    instead_of)
-          end
-        end
-
-        def autocorrect(range)
-          lambda do |corrector|
-            corrector.replace(range, style == :final_newline ? "\n" : "\n\n")
           end
         end
       end

--- a/lib/rubocop/cop/lint/block_alignment.rb
+++ b/lib/rubocop/cop/lint/block_alignment.rb
@@ -83,6 +83,19 @@ module RuboCop
           'EnforcedStyleAlignWith'
         end
 
+        def autocorrect(node)
+          ancestor_node = start_for_block_node(node)
+          start_col = compute_start_col(ancestor_node, node)
+          loc_end = node.loc.end
+          delta = start_col - loc_end.column
+
+          if delta > 0
+            add_space_before(loc_end, delta)
+          elsif delta < 0
+            remove_space_before(loc_end.begin_pos, -delta)
+          end
+        end
+
         private
 
         def start_for_block_node(block_node)
@@ -212,19 +225,6 @@ module RuboCop
             return do_loc.source_line =~ /\S/
           end
           (ancestor_node || node).source_range.column
-        end
-
-        def autocorrect(node)
-          ancestor_node = start_for_block_node(node)
-          start_col = compute_start_col(ancestor_node, node)
-          loc_end = node.loc.end
-          delta = start_col - loc_end.column
-
-          if delta > 0
-            add_space_before(loc_end, delta)
-          elsif delta < 0
-            remove_space_before(loc_end.begin_pos, -delta)
-          end
         end
 
         def add_space_before(loc, delta)

--- a/lib/rubocop/cop/lint/def_end_alignment.rb
+++ b/lib/rubocop/cop/lint/def_end_alignment.rb
@@ -60,8 +60,6 @@ module RuboCop
           ignore_node(method_def) # Don't check the same `end` again.
         end
 
-        private
-
         def autocorrect(node)
           if style == :start_of_line && node.parent && node.parent.send_type?
             align(node, node.parent)

--- a/lib/rubocop/cop/lint/end_alignment.rb
+++ b/lib/rubocop/cop/lint/end_alignment.rb
@@ -88,6 +88,10 @@ module RuboCop
           end
         end
 
+        def autocorrect(node)
+          align(node, alignment_node(node))
+        end
+
         private
 
         def check_assignment(node, rhs)
@@ -129,10 +133,6 @@ module RuboCop
             start_of_line: start_line_range(node)
           }
           check_end_kw_alignment(node, align_with)
-        end
-
-        def autocorrect(node)
-          align(node, alignment_node(node))
         end
 
         def alignment_node(node)

--- a/lib/rubocop/cop/lint/inherit_exception.rb
+++ b/lib/rubocop/cop/lint/inherit_exception.rb
@@ -55,16 +55,16 @@ module RuboCop
           add_offense(base_class)
         end
 
-        private
-
-        def message(node)
-          format(MSG, preferred_base_class, node.const_name)
-        end
-
         def autocorrect(node)
           lambda do |corrector|
             corrector.replace(node.loc.expression, preferred_base_class)
           end
+        end
+
+        private
+
+        def message(node)
+          format(MSG, preferred_base_class, node.const_name)
         end
 
         def illegal_class_name?(class_node)

--- a/lib/rubocop/cop/lint/percent_string_array.rb
+++ b/lib/rubocop/cop/lint/percent_string_array.rb
@@ -40,19 +40,6 @@ module RuboCop
           add_offense(node)
         end
 
-        private
-
-        def contains_quotes_or_commas?(node)
-          node.values.any? do |value|
-            literal = value.children.first.to_s.scrub
-
-            # To avoid likely false positives (e.g. a single ' or ")
-            next if literal.gsub(/[^\p{Alnum}]/, '').empty?
-
-            QUOTES_AND_COMMAS.any? { |pat| literal =~ pat }
-          end
-        end
-
         # rubocop:disable Performance/HashEachMethods
         def autocorrect(node)
           lambda do |corrector|
@@ -69,6 +56,19 @@ module RuboCop
           end
         end
         # rubocop:enable Performance/HashEachMethods
+
+        private
+
+        def contains_quotes_or_commas?(node)
+          node.values.any? do |value|
+            literal = value.children.first.to_s.scrub
+
+            # To avoid likely false positives (e.g. a single ' or ")
+            next if literal.gsub(/[^\p{Alnum}]/, '').empty?
+
+            QUOTES_AND_COMMAS.any? { |pat| literal =~ pat }
+          end
+        end
       end
     end
   end

--- a/lib/rubocop/cop/lint/percent_symbol_array.rb
+++ b/lib/rubocop/cop/lint/percent_symbol_array.rb
@@ -36,6 +36,17 @@ module RuboCop
           add_offense(node)
         end
 
+        def autocorrect(node)
+          lambda do |corrector|
+            node.children.each do |child|
+              range = child.loc.expression
+
+              corrector.remove_trailing(range, 1) if /,$/ =~ range.source
+              corrector.remove_leading(range, 1) if /^:/ =~ range.source
+            end
+          end
+        end
+
         private
 
         def contains_colons_or_commas?(node)
@@ -47,17 +58,6 @@ module RuboCop
             next if literal.to_s.gsub(/[^\p{Alnum}]/, '').empty?
 
             patterns.any? { |pat| literal =~ pat }
-          end
-        end
-
-        def autocorrect(node)
-          lambda do |corrector|
-            node.children.each do |child|
-              range = child.loc.expression
-
-              corrector.remove_trailing(range, 1) if /,$/ =~ range.source
-              corrector.remove_leading(range, 1) if /^:/ =~ range.source
-            end
           end
         end
       end

--- a/lib/rubocop/cop/lint/rescue_type.rb
+++ b/lib/rubocop/cop/lint/rescue_type.rb
@@ -55,8 +55,6 @@ module RuboCop
           )
         end
 
-        private
-
         def autocorrect(node)
           rescued, _, _body = *node
           range = Parser::Source::Range.new(node.loc.expression.source_buffer,
@@ -67,6 +65,8 @@ module RuboCop
             corrector.replace(range, correction(*rescued))
           end
         end
+
+        private
 
         def correction(*exceptions)
           correction = valid_exceptions(exceptions).map(&:source).join(', ')

--- a/lib/rubocop/cop/lint/string_conversion_in_interpolation.rb
+++ b/lib/rubocop/cop/lint/string_conversion_in_interpolation.rb
@@ -33,12 +33,6 @@ module RuboCop
           end
         end
 
-        private
-
-        def message(node)
-          node.receiver ? MSG_DEFAULT : MSG_SELF
-        end
-
         def autocorrect(node)
           lambda do |corrector|
             receiver, _method_name, *_args = *node
@@ -51,6 +45,12 @@ module RuboCop
               end
             )
           end
+        end
+
+        private
+
+        def message(node)
+          node.receiver ? MSG_DEFAULT : MSG_SELF
         end
       end
     end

--- a/lib/rubocop/cop/lint/unneeded_splat_expansion.rb
+++ b/lib/rubocop/cop/lint/unneeded_splat_expansion.rb
@@ -75,6 +75,14 @@ module RuboCop
           end
         end
 
+        def autocorrect(node)
+          range, content = replacement_range_and_content(node)
+
+          lambda do |corrector|
+            corrector.replace(range, content)
+          end
+        end
+
         private
 
         def unneeded_splat_expansion(node)
@@ -96,14 +104,6 @@ module RuboCop
 
           grandparent = array_new_node.parent.parent
           grandparent.array_type? && grandparent.children.size > 1
-        end
-
-        def autocorrect(node)
-          range, content = replacement_range_and_content(node)
-
-          lambda do |corrector|
-            corrector.replace(range, content)
-          end
         end
 
         def replacement_range_and_content(node)

--- a/lib/rubocop/cop/mixin/ordered_gem_node.rb
+++ b/lib/rubocop/cop/mixin/ordered_gem_node.rb
@@ -5,6 +5,17 @@ module RuboCop
     # Common functionality for Bundler/OrderedGems and
     # Gemspec/OrderedDependencies.
     module OrderedGemNode
+      def autocorrect(node)
+        previous = previous_declaration(node)
+
+        current_range = declaration_with_comment(node)
+        previous_range = declaration_with_comment(previous)
+
+        lambda do |corrector|
+          swap_range(corrector, current_range, previous_range)
+        end
+      end
+
       private
 
       def case_insensitive_out_of_order?(string_a, string_b)
@@ -27,17 +38,6 @@ module RuboCop
 
       def gem_name(declaration_node)
         declaration_node.first_argument.str_content
-      end
-
-      def autocorrect(node)
-        previous = previous_declaration(node)
-
-        current_range = declaration_with_comment(node)
-        previous_range = declaration_with_comment(previous)
-
-        lambda do |corrector|
-          swap_range(corrector, current_range, previous_range)
-        end
       end
 
       def declaration_with_comment(node)

--- a/lib/rubocop/cop/mixin/space_after_punctuation.rb
+++ b/lib/rubocop/cop/mixin/space_after_punctuation.rb
@@ -14,6 +14,10 @@ module RuboCop
         end
       end
 
+      def autocorrect(token)
+        ->(corrector) { corrector.replace(token.pos, token.pos.source + ' ') }
+      end
+
       def each_missing_space(tokens)
         tokens.each_cons(2) do |t1, t2|
           next unless kind(t1)
@@ -46,10 +50,6 @@ module RuboCop
       # token where a space should be, is 1.
       def offset
         1
-      end
-
-      def autocorrect(token)
-        ->(corrector) { corrector.replace(token.pos, token.pos.source + ' ') }
       end
     end
   end

--- a/lib/rubocop/cop/mixin/space_before_punctuation.rb
+++ b/lib/rubocop/cop/mixin/space_before_punctuation.rb
@@ -14,6 +14,10 @@ module RuboCop
         end
       end
 
+      def autocorrect(pos_before_punctuation)
+        ->(corrector) { corrector.remove(pos_before_punctuation) }
+      end
+
       def each_missing_space(tokens)
         tokens.each_cons(2) do |t1, t2|
           next unless kind(t2)
@@ -39,10 +43,6 @@ module RuboCop
         cfg = config.for_cop('Layout/SpaceInsideBlockBraces')
         style = cfg['EnforcedStyle'] || 'space'
         style == 'space'
-      end
-
-      def autocorrect(pos_before_punctuation)
-        ->(corrector) { corrector.remove(pos_before_punctuation) }
       end
     end
   end

--- a/lib/rubocop/cop/mixin/trailing_comma.rb
+++ b/lib/rubocop/cop/mixin/trailing_comma.rb
@@ -9,6 +9,17 @@ module RuboCop
 
       MSG = '%<command>s comma after the last %<unit>s.'.freeze
 
+      def autocorrect(range)
+        return unless range
+
+        lambda do |corrector|
+          case range.source
+          when ',' then corrector.remove(range)
+          else          corrector.insert_after(range, ',')
+          end
+        end
+      end
+
       def style_parameter_name
         'EnforcedStyleForMultiline'
       end
@@ -152,17 +163,6 @@ module RuboCop
       # By default, there's no reason to avoid auto-correct.
       def avoid_autocorrect?(_)
         false
-      end
-
-      def autocorrect(range)
-        return unless range
-
-        lambda do |corrector|
-          case range.source
-          when ',' then corrector.remove(range)
-          else          corrector.insert_after(range, ',')
-          end
-        end
       end
     end
   end

--- a/lib/rubocop/cop/performance/case_when_splat.rb
+++ b/lib/rubocop/cop/performance/case_when_splat.rb
@@ -68,8 +68,6 @@ module RuboCop
           end
         end
 
-        private
-
         def autocorrect(when_node)
           lambda do |corrector|
             if needs_reorder?(when_node)
@@ -79,6 +77,8 @@ module RuboCop
             end
           end
         end
+
+        private
 
         def replacement(conditions)
           reordered = conditions.partition(&:splat_type?).reverse

--- a/lib/rubocop/cop/performance/count.rb
+++ b/lib/rubocop/cop/performance/count.rb
@@ -66,8 +66,6 @@ module RuboCop
           end
         end
 
-        private
-
         def autocorrect(node)
           selector_node, selector, _counter = count_candidate?(node)
           selector_loc = selector_node.loc.selector
@@ -81,6 +79,8 @@ module RuboCop
             corrector.replace(selector_loc, 'count')
           end
         end
+
+        private
 
         def eligible_node?(node)
           !(node.parent && node.parent.block_type?)

--- a/lib/rubocop/cop/performance/hash_each_methods.rb
+++ b/lib/rubocop/cop/performance/hash_each_methods.rb
@@ -37,6 +37,20 @@ module RuboCop
           register_kv_offense(node)
         end
 
+        def autocorrect(node)
+          receiver = node.receiver
+          _caller, first_method = *receiver
+
+          lambda do |corrector|
+            case first_method
+            when :keys, :values
+              correct_key_value_each(node, corrector)
+            else
+              correct_plain_each(node, corrector)
+            end
+          end
+        end
+
         private
 
         def register_each_offense(node)
@@ -70,20 +84,6 @@ module RuboCop
           loc = arg.loc
           variable = @block_args.find { |var| var.declaration_node.loc == loc }
           variable.used?
-        end
-
-        def autocorrect(node)
-          receiver = node.receiver
-          _caller, first_method = *receiver
-
-          lambda do |corrector|
-            case first_method
-            when :keys, :values
-              correct_key_value_each(node, corrector)
-            else
-              correct_plain_each(node, corrector)
-            end
-          end
         end
 
         def correct_implicit(node, corrector, method_name)

--- a/lib/rubocop/cop/performance/redundant_block_call.rb
+++ b/lib/rubocop/cop/performance/redundant_block_call.rb
@@ -52,24 +52,6 @@ module RuboCop
           end
         end
 
-        private
-
-        def calls_to_report(argname, body)
-          return [] if blockarg_assigned?(body, argname)
-
-          calls = to_enum(:blockarg_calls, body, argname)
-
-          return [] if calls.any? { |call| args_include_block_pass?(call) }
-
-          calls
-        end
-
-        def args_include_block_pass?(blockcall)
-          _receiver, _call, *args = *blockcall
-
-          args.any?(&:block_pass_type?)
-        end
-
         # offenses are registered on the `block.call` nodes
         def autocorrect(node)
           _receiver, _method, *args = *node
@@ -86,6 +68,24 @@ module RuboCop
 
           new_source << CLOSE_PAREN if parentheses?(node) && !args.empty?
           ->(corrector) { corrector.replace(node.source_range, new_source) }
+        end
+
+        private
+
+        def calls_to_report(argname, body)
+          return [] if blockarg_assigned?(body, argname)
+
+          calls = to_enum(:blockarg_calls, body, argname)
+
+          return [] if calls.any? { |call| args_include_block_pass?(call) }
+
+          calls
+        end
+
+        def args_include_block_pass?(blockcall)
+          _receiver, _call, *args = *blockcall
+
+          args.any?(&:block_pass_type?)
         end
       end
     end

--- a/lib/rubocop/cop/performance/size.rb
+++ b/lib/rubocop/cop/performance/size.rb
@@ -32,11 +32,11 @@ module RuboCop
           add_offense(node, location: :selector)
         end
 
-        private
-
         def autocorrect(node)
           ->(corrector) { corrector.replace(node.loc.selector, 'size') }
         end
+
+        private
 
         def eligible_node?(node)
           return false unless node.method?(:count) && !node.arguments?

--- a/lib/rubocop/cop/performance/times_map.rb
+++ b/lib/rubocop/cop/performance/times_map.rb
@@ -30,6 +30,18 @@ module RuboCop
           check(node)
         end
 
+        def autocorrect(node)
+          map_or_collect, count = times_map_call(node)
+
+          replacement =
+            "Array.new(#{count.source}" \
+            "#{map_or_collect.arguments.map { |arg| ", #{arg.source}" }.join})"
+
+          lambda do |corrector|
+            corrector.replace(map_or_collect.loc.expression, replacement)
+          end
+        end
+
         private
 
         def check(node)
@@ -53,18 +65,6 @@ module RuboCop
           {(block $(send (send $!nil? :times) {:map :collect}) ...)
            $(send (send $!nil? :times) {:map :collect} (block_pass ...))}
         PATTERN
-
-        def autocorrect(node)
-          map_or_collect, count = times_map_call(node)
-
-          replacement =
-            "Array.new(#{count.source}" \
-            "#{map_or_collect.arguments.map { |arg| ", #{arg.source}" }.join})"
-
-          lambda do |corrector|
-            corrector.replace(map_or_collect.loc.expression, replacement)
-          end
-        end
       end
     end
   end

--- a/lib/rubocop/cop/rails/active_support_aliases.rb
+++ b/lib/rubocop/cop/rails/active_support_aliases.rb
@@ -44,8 +44,6 @@ module RuboCop
           end
         end
 
-        private
-
         def autocorrect(node)
           return false if append(node)
           lambda do |corrector|
@@ -54,6 +52,8 @@ module RuboCop
             corrector.replace(node.loc.selector, replacement.to_s)
           end
         end
+
+        private
 
         def register_offense(node, method_name)
           add_offense(

--- a/lib/rubocop/cop/rails/delegate.rb
+++ b/lib/rubocop/cop/rails/delegate.rb
@@ -62,8 +62,6 @@ module RuboCop
           add_offense(node, location: :keyword)
         end
 
-        private
-
         def autocorrect(node)
           method_name, _args, body = *node
           delegation = ["delegate :#{body.method_name}",
@@ -77,6 +75,8 @@ module RuboCop
             corrector.replace(node.source_range, delegation.join(', '))
           end
         end
+
+        private
 
         def trivial_delegate?(def_node)
           method_name, args, body = *def_node

--- a/lib/rubocop/cop/rails/delegate_allow_blank.rb
+++ b/lib/rubocop/cop/rails/delegate_allow_blank.rb
@@ -32,13 +32,13 @@ module RuboCop
           add_offense(offending_node)
         end
 
-        private
-
         def autocorrect(pair_node)
           lambda do |corrector|
             corrector.replace(pair_node.key.source_range, 'allow_nil')
           end
         end
+
+        private
 
         def allow_blank_option(node)
           delegate_options(node) do |hash|

--- a/lib/rubocop/cop/rails/pluralization_grammar.rb
+++ b/lib/rubocop/cop/rails/pluralization_grammar.rb
@@ -37,20 +37,20 @@ module RuboCop
           add_offense(node)
         end
 
-        private
-
-        def message(node)
-          number, = *node.receiver
-
-          format(MSG, number, correct_method(node.method_name.to_s))
-        end
-
         def autocorrect(node)
           lambda do |corrector|
             method_name = node.loc.selector.source
 
             corrector.replace(node.loc.selector, correct_method(method_name))
           end
+        end
+
+        private
+
+        def message(node)
+          number, = *node.receiver
+
+          format(MSG, number, correct_method(node.method_name.to_s))
         end
 
         def correct_method(method_name)

--- a/lib/rubocop/cop/rails/read_write_attribute.rb
+++ b/lib/rubocop/cop/rails/read_write_attribute.rb
@@ -31,16 +31,6 @@ module RuboCop
           add_offense(node, location: :selector)
         end
 
-        private
-
-        def message(node)
-          if node.method?(:read_attribute)
-            format(MSG, 'self[:attr]', 'read_attribute(:attr)')
-          else
-            format(MSG, 'self[:attr] = val', 'write_attribute(:attr, val)')
-          end
-        end
-
         def autocorrect(node)
           case node.method_name
           when :read_attribute
@@ -50,6 +40,16 @@ module RuboCop
           end
 
           ->(corrector) { corrector.replace(node.source_range, replacement) }
+        end
+
+        private
+
+        def message(node)
+          if node.method?(:read_attribute)
+            format(MSG, 'self[:attr]', 'read_attribute(:attr)')
+          else
+            format(MSG, 'self[:attr] = val', 'write_attribute(:attr, val)')
+          end
         end
 
         def read_attribute_replacement(node)

--- a/lib/rubocop/cop/rails/relative_date_constant.rb
+++ b/lib/rubocop/cop/rails/relative_date_constant.rb
@@ -51,6 +51,15 @@ module RuboCop
           check_node(rhs)
         end
 
+        def autocorrect(node)
+          _scope, const_name, value = *node
+          indent = ' ' * node.loc.column
+          new_code = ["def self.#{const_name.downcase}",
+                      "#{indent}#{value.source}",
+                      'end'].join("\n#{indent}")
+          ->(corrector) { corrector.replace(node.source_range, new_code) }
+        end
+
         private
 
         def check_node(node)
@@ -72,15 +81,6 @@ module RuboCop
           node.send_type? &&
             RELATIVE_DATE_METHODS.include?(node.method_name) &&
             !node.arguments?
-        end
-
-        def autocorrect(node)
-          _scope, const_name, value = *node
-          indent = ' ' * node.loc.column
-          new_code = ["def self.#{const_name.downcase}",
-                      "#{indent}#{value.source}",
-                      'end'].join("\n#{indent}")
-          ->(corrector) { corrector.replace(node.source_range, new_code) }
         end
       end
     end

--- a/lib/rubocop/cop/rails/safe_navigation.rb
+++ b/lib/rubocop/cop/rails/safe_navigation.rb
@@ -59,8 +59,6 @@ module RuboCop
           end
         end
 
-        private
-
         def autocorrect(node)
           method_node, *params = *node.arguments
           method = method_node.source[1..-1]
@@ -72,6 +70,8 @@ module RuboCop
             corrector.replace(range, replacement(method, params))
           end
         end
+
+        private
 
         def replacement(method, params)
           new_params = params.map(&:source).join(', ')

--- a/lib/rubocop/cop/rails/validation.rb
+++ b/lib/rubocop/cop/rails/validation.rb
@@ -29,6 +29,13 @@ module RuboCop
           add_offense(node, location: :selector)
         end
 
+        def autocorrect(node)
+          lambda do |corrector|
+            corrector.replace(node.loc.selector, 'validates')
+            correct_validate_type(corrector, node)
+          end
+        end
+
         private
 
         def message(node)
@@ -37,13 +44,6 @@ module RuboCop
 
         def preferred_method(method)
           WHITELIST[BLACKLIST.index(method.to_sym)]
-        end
-
-        def autocorrect(node)
-          lambda do |corrector|
-            corrector.replace(node.loc.selector, 'validates')
-            correct_validate_type(corrector, node)
-          end
         end
 
         def correct_validate_type(corrector, node)

--- a/lib/rubocop/cop/style/alias.rb
+++ b/lib/rubocop/cop/style/alias.rb
@@ -49,6 +49,16 @@ module RuboCop
           end
         end
 
+        def autocorrect(node)
+          if node.send_type?
+            correct_alias_method_to_alias(node)
+          elsif scope_type(node) == :dynamic || style == :prefer_alias_method
+            correct_alias_to_alias_method(node)
+          else
+            correct_alias_with_symbol_args(node)
+          end
+        end
+
         private
 
         def alias_keyword_possible?(node)
@@ -58,16 +68,6 @@ module RuboCop
         def alias_method_possible?(node)
           scope_type(node) != :instance_eval &&
             node.children.none?(&:gvar_type?)
-        end
-
-        def autocorrect(node)
-          if node.send_type?
-            correct_alias_method_to_alias(node)
-          elsif scope_type(node) == :dynamic || style == :prefer_alias_method
-            correct_alias_to_alias_method(node)
-          else
-            correct_alias_with_symbol_args(node)
-          end
         end
 
         def add_offense_for_args(node)

--- a/lib/rubocop/cop/style/and_or.rb
+++ b/lib/rubocop/cop/style/and_or.rb
@@ -54,6 +54,22 @@ module RuboCop
         alias on_until      on_if
         alias on_until_post on_if
 
+        def autocorrect(node)
+          lambda do |corrector|
+            node.each_child_node do |expr|
+              if expr.send_type?
+                correct_send(expr, corrector)
+              elsif expr.return_type?
+                correct_other(expr, corrector)
+              elsif expr.assignment?
+                correct_other(expr, corrector)
+              end
+            end
+
+            corrector.replace(node.loc.operator, node.alternate_operator)
+          end
+        end
+
         private
 
         def on_conditionals(node)
@@ -70,22 +86,6 @@ module RuboCop
 
         def message(node)
           format(MSG, prefer: node.alternate_operator, current: node.operator)
-        end
-
-        def autocorrect(node)
-          lambda do |corrector|
-            node.each_child_node do |expr|
-              if expr.send_type?
-                correct_send(expr, corrector)
-              elsif expr.return_type?
-                correct_other(expr, corrector)
-              elsif expr.assignment?
-                correct_other(expr, corrector)
-              end
-            end
-
-            corrector.replace(node.loc.operator, node.alternate_operator)
-          end
         end
 
         def correct_send(node, corrector)

--- a/lib/rubocop/cop/style/attr.rb
+++ b/lib/rubocop/cop/style/attr.rb
@@ -23,8 +23,6 @@ module RuboCop
           add_offense(node, location: :selector)
         end
 
-        private
-
         def autocorrect(node)
           attr_name, setter = *node.arguments
 
@@ -40,6 +38,8 @@ module RuboCop
             corrector.remove(remove) if remove
           end
         end
+
+        private
 
         def message(node)
           format(MSG, replacement: replacement_method(node))

--- a/lib/rubocop/cop/style/bare_percent_literals.rb
+++ b/lib/rubocop/cop/style/bare_percent_literals.rb
@@ -36,6 +36,14 @@ module RuboCop
           check(node)
         end
 
+        def autocorrect(node)
+          src = node.loc.begin.source
+          replacement = src.start_with?('%Q') ? '%' : '%Q'
+          lambda do |corrector|
+            corrector.replace(node.loc.begin, src.sub(/%Q?/, replacement))
+          end
+        end
+
         private
 
         def check(node)
@@ -63,14 +71,6 @@ module RuboCop
           add_offense(node, location: :begin, message: format(MSG,
                                                               good: good,
                                                               bad: bad))
-        end
-
-        def autocorrect(node)
-          src = node.loc.begin.source
-          replacement = src.start_with?('%Q') ? '%' : '%Q'
-          lambda do |corrector|
-            corrector.replace(node.loc.begin, src.sub(/%Q?/, replacement))
-          end
         end
       end
     end

--- a/lib/rubocop/cop/style/block_comments.rb
+++ b/lib/rubocop/cop/style/block_comments.rb
@@ -29,8 +29,6 @@ module RuboCop
           end
         end
 
-        private
-
         def autocorrect(comment)
           eq_begin, eq_end, contents = parts(comment)
 
@@ -46,6 +44,8 @@ module RuboCop
             corrector.remove(eq_end)
           end
         end
+
+        private
 
         def parts(comment)
           expr = comment.loc.expression

--- a/lib/rubocop/cop/style/block_delimiters.rb
+++ b/lib/rubocop/cop/style/block_delimiters.rb
@@ -94,6 +94,16 @@ module RuboCop
           add_offense(node, location: :begin) unless proper_block_style?(node)
         end
 
+        def autocorrect(node)
+          return if correction_would_break_code?(node)
+
+          if node.braces?
+            replace_braces_with_do_end(node.loc)
+          else
+            replace_do_end_with_braces(node.loc)
+          end
+        end
+
         private
 
         def line_count_based_message(node)
@@ -131,16 +141,6 @@ module RuboCop
           when :line_count_based    then line_count_based_message(node)
           when :semantic            then semantic_message(node)
           when :braces_for_chaining then braces_for_chaining_message(node)
-          end
-        end
-
-        def autocorrect(node)
-          return if correction_would_break_code?(node)
-
-          if node.braces?
-            replace_braces_with_do_end(node.loc)
-          else
-            replace_do_end_with_braces(node.loc)
           end
         end
 

--- a/lib/rubocop/cop/style/braces_around_hash_parameters.rb
+++ b/lib/rubocop/cop/style/braces_around_hash_parameters.rb
@@ -53,6 +53,24 @@ module RuboCop
           check(node.last_argument, node.arguments)
         end
 
+        # We let AutocorrectUnlessChangingAST#autocorrect work with the send
+        # node, because that context is needed. When parsing the code to see if
+        # the AST has changed, a braceless hash would not be parsed as a hash
+        # otherwise.
+        def autocorrect(send_node)
+          hash_node = send_node.last_argument
+
+          lambda do |corrector|
+            if hash_node.braces?
+              remove_braces_with_whitespace(corrector,
+                                            hash_node,
+                                            extra_space(hash_node))
+            else
+              add_braces(corrector, hash_node)
+            end
+          end
+        end
+
         private
 
         def check(arg, args)
@@ -81,24 +99,6 @@ module RuboCop
           add_offense(arg.parent, location: arg.source_range,
                                   message: format(MSG,
                                                   type: type.to_s.capitalize))
-        end
-
-        # We let AutocorrectUnlessChangingAST#autocorrect work with the send
-        # node, because that context is needed. When parsing the code to see if
-        # the AST has changed, a braceless hash would not be parsed as a hash
-        # otherwise.
-        def autocorrect(send_node)
-          hash_node = send_node.last_argument
-
-          lambda do |corrector|
-            if hash_node.braces?
-              remove_braces_with_whitespace(corrector,
-                                            hash_node,
-                                            extra_space(hash_node))
-            else
-              add_braces(corrector, hash_node)
-            end
-          end
         end
 
         def extra_space(hash_node)

--- a/lib/rubocop/cop/style/class_check.rb
+++ b/lib/rubocop/cop/style/class_check.rb
@@ -38,19 +38,19 @@ module RuboCop
           end
         end
 
-        def message(node)
-          if node.method?(:is_a?)
-            format(MSG, prefer: 'kind_of?', current: 'is_a?')
-          else
-            format(MSG, prefer: 'is_a?', current: 'kind_of?')
-          end
-        end
-
         def autocorrect(node)
           lambda do |corrector|
             replacement = node.method?(:is_a?) ? 'kind_of?' : 'is_a?'
 
             corrector.replace(node.loc.selector, replacement)
+          end
+        end
+
+        def message(node)
+          if node.method?(:is_a?)
+            format(MSG, prefer: 'kind_of?', current: 'is_a?')
+          else
+            format(MSG, prefer: 'is_a?', current: 'kind_of?')
           end
         end
       end

--- a/lib/rubocop/cop/style/class_methods.rb
+++ b/lib/rubocop/cop/style/class_methods.rb
@@ -33,6 +33,10 @@ module RuboCop
           check(name, body)
         end
 
+        def autocorrect(node)
+          ->(corrector) { corrector.replace(node.loc.name, 'self') }
+        end
+
         private
 
         def check(name, node)
@@ -57,10 +61,6 @@ module RuboCop
 
         def message(class_name, method_name)
           format(MSG, method: method_name, class: class_name)
-        end
-
-        def autocorrect(node)
-          ->(corrector) { corrector.replace(node.loc.name, 'self') }
         end
       end
     end

--- a/lib/rubocop/cop/style/command_literal.rb
+++ b/lib/rubocop/cop/style/command_literal.rb
@@ -91,6 +91,21 @@ module RuboCop
           end
         end
 
+        def autocorrect(node)
+          return if contains_backtick?(node)
+
+          replacement = if backtick_literal?(node)
+                          ['%x', ''].zip(preferred_delimiters).map(&:join)
+                        else
+                          %w[` `]
+                        end
+
+          lambda do |corrector|
+            corrector.replace(node.loc.begin, replacement.first)
+            corrector.replace(node.loc.end, replacement.last)
+          end
+        end
+
         private
 
         def check_backtick_literal(node)
@@ -157,21 +172,6 @@ module RuboCop
         def preferred_delimiters
           config.for_cop('Style/PercentLiteralDelimiters') \
             ['PreferredDelimiters']['%x'].split(//)
-        end
-
-        def autocorrect(node)
-          return if contains_backtick?(node)
-
-          replacement = if backtick_literal?(node)
-                          ['%x', ''].zip(preferred_delimiters).map(&:join)
-                        else
-                          %w[` `]
-                        end
-
-          lambda do |corrector|
-            corrector.replace(node.loc.begin, replacement.first)
-            corrector.replace(node.loc.end, replacement.last)
-          end
         end
       end
     end

--- a/lib/rubocop/cop/style/comment_annotation.rb
+++ b/lib/rubocop/cop/style/comment_annotation.rb
@@ -56,12 +56,6 @@ module RuboCop
           end
         end
 
-        private
-
-        def first_comment_line?(comments, ix)
-          ix.zero? || comments[ix - 1].loc.line < comments[ix].loc.line - 1
-        end
-
         def autocorrect(comment)
           margin, first_word, colon, space, note = split_comment(comment)
           return if note.nil?
@@ -70,6 +64,12 @@ module RuboCop
           range = annotation_range(comment, margin, length)
 
           ->(corrector) { corrector.replace(range, "#{first_word.upcase}: ") }
+        end
+
+        private
+
+        def first_comment_line?(comments, ix)
+          ix.zero? || comments[ix - 1].loc.line < comments[ix].loc.line - 1
         end
 
         def annotation_range(comment, margin, length)

--- a/lib/rubocop/cop/style/conditional_assignment.rb
+++ b/lib/rubocop/cop/style/conditional_assignment.rb
@@ -266,6 +266,14 @@ module RuboCop
           check_node(node, branches)
         end
 
+        def autocorrect(node)
+          if assignment_type?(node)
+            move_assignment_inside_condition(node)
+          else
+            move_assignment_outside_condition(node)
+          end
+        end
+
         private
 
         def check_assignment_to_condition(node)
@@ -296,14 +304,6 @@ module RuboCop
 
         def allowed_single_line?(branches)
           single_line_conditions_only? && branches.any?(&:begin_type?)
-        end
-
-        def autocorrect(node)
-          if assignment_type?(node)
-            move_assignment_inside_condition(node)
-          else
-            move_assignment_outside_condition(node)
-          end
         end
 
         def assignment_node(node)

--- a/lib/rubocop/cop/style/copyright.rb
+++ b/lib/rubocop/cop/style/copyright.rb
@@ -29,6 +29,20 @@ module RuboCop
                       location: range, message: format(MSG, notice: notice))
         end
 
+        def autocorrect(token)
+          raise Warning, AUTOCORRECT_EMPTY_WARNING if autocorrect_notice.empty?
+          regex = Regexp.new(notice)
+          unless autocorrect_notice =~ regex
+            raise Warning, "AutocorrectNotice '#{autocorrect_notice}' must " \
+                           "match Notice /#{notice}/"
+          end
+
+          lambda do |corrector|
+            range = token.nil? ? range_between(0, 0) : token.pos
+            corrector.insert_before(range, "#{autocorrect_notice}\n")
+          end
+        end
+
         private
 
         def notice
@@ -68,20 +82,6 @@ module RuboCop
             break if notice_found
           end
           notice_found
-        end
-
-        def autocorrect(token)
-          raise Warning, AUTOCORRECT_EMPTY_WARNING if autocorrect_notice.empty?
-          regex = Regexp.new(notice)
-          unless autocorrect_notice =~ regex
-            raise Warning, "AutocorrectNotice '#{autocorrect_notice}' must " \
-                           "match Notice /#{notice}/"
-          end
-
-          lambda do |corrector|
-            range = token.nil? ? range_between(0, 0) : token.pos
-            corrector.insert_before(range, "#{autocorrect_notice}\n")
-          end
         end
       end
     end

--- a/lib/rubocop/cop/style/def_with_parentheses.rb
+++ b/lib/rubocop/cop/style/def_with_parentheses.rb
@@ -45,8 +45,6 @@ module RuboCop
         end
         alias on_defs on_def
 
-        private
-
         def autocorrect(node)
           lambda do |corrector|
             corrector.remove(node.loc.begin)

--- a/lib/rubocop/cop/style/dir.rb
+++ b/lib/rubocop/cop/style/dir.rb
@@ -31,13 +31,13 @@ module RuboCop
           end
         end
 
-        private
-
         def autocorrect(node)
           lambda do |corrector|
             corrector.replace(node.source_range, '__dir__')
           end
         end
+
+        private
 
         def file_keyword?(node)
           node.str_type? && node.source_range.is?('__FILE__')

--- a/lib/rubocop/cop/style/each_for_simple_loop.rb
+++ b/lib/rubocop/cop/style/each_for_simple_loop.rb
@@ -36,8 +36,6 @@ module RuboCop
           add_offense(node, location: range)
         end
 
-        private
-
         def autocorrect(node)
           lambda do |corrector|
             range_type, min, max = offending_each_range(node)
@@ -48,6 +46,8 @@ module RuboCop
                               "#{max - min}.times")
           end
         end
+
+        private
 
         def_node_matcher :offending_each_range, <<-PATTERN
           (block (send (begin (${irange erange} (int $_) (int $_))) :each) (args) ...)

--- a/lib/rubocop/cop/style/each_with_object.rb
+++ b/lib/rubocop/cop/style/each_with_object.rb
@@ -39,8 +39,6 @@ module RuboCop
           end
         end
 
-        private
-
         # rubocop:disable Metrics/AbcSize
         def autocorrect(node)
           lambda do |corrector|
@@ -57,6 +55,8 @@ module RuboCop
           end
         end
         # rubocop:enable Metrics/AbcSize
+
+        private
 
         def simple_method_arg?(method_arg)
           method_arg && method_arg.basic_literal?

--- a/lib/rubocop/cop/style/empty_block_parameter.rb
+++ b/lib/rubocop/cop/style/empty_block_parameter.rb
@@ -31,8 +31,6 @@ module RuboCop
           check(node) unless send_node.send_type? && send_node.stabby_lambda?
         end
 
-        private
-
         def autocorrect(node)
           lambda do |corrector|
             block = node.parent

--- a/lib/rubocop/cop/style/empty_case_condition.rb
+++ b/lib/rubocop/cop/style/empty_case_condition.rb
@@ -45,8 +45,6 @@ module RuboCop
           add_offense(case_node, location: :keyword)
         end
 
-        private
-
         def autocorrect(case_node)
           when_branches = case_node.when_branches
 
@@ -55,6 +53,8 @@ module RuboCop
             correct_when_conditions(corrector, when_branches)
           end
         end
+
+        private
 
         def correct_case_when(corrector, case_node, when_nodes)
           case_range = case_node.loc.keyword.join(when_nodes.first.loc.keyword)

--- a/lib/rubocop/cop/style/empty_else.rb
+++ b/lib/rubocop/cop/style/empty_else.rb
@@ -103,6 +103,16 @@ module RuboCop
           check(node)
         end
 
+        def autocorrect(node)
+          return false if autocorrect_forbidden?(node.type.to_s)
+          return false if comment_in_else?(node)
+
+          lambda do |corrector|
+            end_pos = base_if_node(node).loc.end.begin_pos
+            corrector.remove(range_between(node.loc.else.begin_pos, end_pos))
+          end
+        end
+
         private
 
         def check(node)
@@ -128,16 +138,6 @@ module RuboCop
           return unless node.else_branch && node.else_branch.nil_type?
 
           add_offense(node, location: :else)
-        end
-
-        def autocorrect(node)
-          return false if autocorrect_forbidden?(node.type.to_s)
-          return false if comment_in_else?(node)
-
-          lambda do |corrector|
-            end_pos = base_if_node(node).loc.end.begin_pos
-            corrector.remove(range_between(node.loc.else.begin_pos, end_pos))
-          end
         end
 
         def comment_in_else?(node)

--- a/lib/rubocop/cop/style/empty_lambda_parameter.rb
+++ b/lib/rubocop/cop/style/empty_lambda_parameter.rb
@@ -27,8 +27,6 @@ module RuboCop
           check(node) if node.send_node.stabby_lambda?
         end
 
-        private
-
         def autocorrect(node)
           lambda do |corrector|
             send_node = node.parent.send_node

--- a/lib/rubocop/cop/style/empty_method.rb
+++ b/lib/rubocop/cop/style/empty_method.rb
@@ -55,13 +55,13 @@ module RuboCop
         end
         alias on_defs on_def
 
-        private
-
         def autocorrect(node)
           lambda do |corrector|
             corrector.replace(node.source_range, corrected(node))
           end
         end
+
+        private
 
         def message(_node)
           compact_style? ? MSG_COMPACT : MSG_EXPANDED

--- a/lib/rubocop/cop/style/if_unless_modifier.rb
+++ b/lib/rubocop/cop/style/if_unless_modifier.rb
@@ -23,13 +23,13 @@ module RuboCop
                             message: format(MSG, keyword: node.keyword))
         end
 
-        private
-
         def autocorrect(node)
           lambda do |corrector|
             corrector.replace(node.source_range, to_modifier_form(node))
           end
         end
+
+        private
 
         def eligible_node?(node)
           !non_eligible_if?(node) && !node.chained? &&

--- a/lib/rubocop/cop/style/infinite_loop.rb
+++ b/lib/rubocop/cop/style/infinite_loop.rb
@@ -35,8 +35,6 @@ module RuboCop
         alias on_while_post on_while
         alias on_until_post on_until
 
-        private
-
         def autocorrect(node)
           if node.while_post_type? || node.until_post_type?
             replace_begin_end_with_modifier(node)
@@ -46,6 +44,8 @@ module RuboCop
             replace_source(non_modifier_range(node), 'loop do')
           end
         end
+
+        private
 
         def replace_begin_end_with_modifier(node)
           lambda do |corrector|

--- a/lib/rubocop/cop/style/lambda.rb
+++ b/lib/rubocop/cop/style/lambda.rb
@@ -76,6 +76,22 @@ module RuboCop
                       message: message(node, selector))
         end
 
+        def autocorrect(node)
+          block_method, _args = *node
+          selector = block_method.source
+
+          # Don't autocorrect if this would change the meaning of the code
+          return if selector == '->' && arg_to_unparenthesized_call?(node)
+
+          lambda do |corrector|
+            if selector == 'lambda'
+              autocorrect_method_to_literal(corrector, node)
+            else
+              autocorrect_literal_to_method(corrector, node)
+            end
+          end
+        end
+
         private
 
         def offending_selector?(node, selector)
@@ -96,22 +112,6 @@ module RuboCop
             node.multiline? ? 'multiline' : 'single line'
           else
             'all'
-          end
-        end
-
-        def autocorrect(node)
-          block_method, _args = *node
-          selector = block_method.source
-
-          # Don't autocorrect if this would change the meaning of the code
-          return if selector == '->' && arg_to_unparenthesized_call?(node)
-
-          lambda do |corrector|
-            if selector == 'lambda'
-              autocorrect_method_to_literal(corrector, node)
-            else
-              autocorrect_literal_to_method(corrector, node)
-            end
           end
         end
 

--- a/lib/rubocop/cop/style/lambda_call.rb
+++ b/lib/rubocop/cop/style/lambda_call.rb
@@ -31,13 +31,6 @@ module RuboCop
           end
         end
 
-        private
-
-        def offense?(node)
-          explicit_style? && node.implicit_call? ||
-            implicit_style? && !node.implicit_call?
-        end
-
         def autocorrect(node)
           lambda do |corrector|
             if explicit_style?
@@ -50,6 +43,13 @@ module RuboCop
               corrector.remove(node.loc.selector)
             end
           end
+        end
+
+        private
+
+        def offense?(node)
+          explicit_style? && node.implicit_call? ||
+            implicit_style? && !node.implicit_call?
         end
 
         def add_parentheses(node, corrector)

--- a/lib/rubocop/cop/style/method_call_with_args_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_with_args_parentheses.rb
@@ -51,14 +51,14 @@ module RuboCop
         alias on_super on_send
         alias on_yield on_send
 
-        private
-
         def autocorrect(node)
           lambda do |corrector|
             corrector.replace(args_begin(node), '(')
             corrector.insert_after(args_end(node), ')')
           end
         end
+
+        private
 
         def ignored_method?(node)
           node.operator_method? || node.setter_method? ||

--- a/lib/rubocop/cop/style/method_call_without_args_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_without_args_parentheses.rb
@@ -25,14 +25,14 @@ module RuboCop
           add_offense(node, location: :begin)
         end
 
-        private
-
         def autocorrect(node)
           lambda do |corrector|
             corrector.remove(node.loc.begin)
             corrector.remove(node.loc.end)
           end
         end
+
+        private
 
         def ineligible_node?(node)
           node.camel_case_method? || node.implicit_call? || node.keyword_not?

--- a/lib/rubocop/cop/style/method_def_parentheses.rb
+++ b/lib/rubocop/cop/style/method_def_parentheses.rb
@@ -29,8 +29,6 @@ module RuboCop
         end
         alias on_defs on_def
 
-        private
-
         def autocorrect(node)
           lambda do |corrector|
             if node.args_type?
@@ -48,6 +46,8 @@ module RuboCop
             end
           end
         end
+
+        private
 
         def require_parentheses?(args)
           style == :require_parentheses ||

--- a/lib/rubocop/cop/style/min_max.rb
+++ b/lib/rubocop/cop/style/min_max.rb
@@ -27,6 +27,15 @@ module RuboCop
         end
         alias on_return on_array
 
+        def autocorrect(node)
+          receiver = node.children.first.receiver
+
+          lambda do |corrector|
+            corrector.replace(offending_range(node),
+                              "#{receiver.source}.minmax")
+          end
+        end
+
         private
 
         def_node_matcher :min_max_candidate, <<-PATTERN
@@ -36,15 +45,6 @@ module RuboCop
         def message(offender, receiver)
           format(MSG, offender: offender.source,
                       receiver: receiver.source)
-        end
-
-        def autocorrect(node)
-          receiver = node.children.first.receiver
-
-          lambda do |corrector|
-            corrector.replace(offending_range(node),
-                              "#{receiver.source}.minmax")
-          end
         end
 
         def offending_range(node)

--- a/lib/rubocop/cop/style/multiline_if_modifier.rb
+++ b/lib/rubocop/cop/style/multiline_if_modifier.rb
@@ -27,13 +27,13 @@ module RuboCop
           add_offense(node)
         end
 
-        private
-
         def autocorrect(node)
           lambda do |corrector|
             corrector.replace(node.source_range, to_normal_if(node))
           end
         end
+
+        private
 
         def message(node)
           format(MSG, keyword: node.keyword)

--- a/lib/rubocop/cop/style/multiline_if_then.rb
+++ b/lib/rubocop/cop/style/multiline_if_then.rb
@@ -30,18 +30,18 @@ module RuboCop
                             message: format(MSG, keyword: node.keyword))
         end
 
-        private
-
-        def non_modifier_then?(node)
-          node.loc.begin && node.loc.begin.source_line =~ NON_MODIFIER_THEN
-        end
-
         def autocorrect(node)
           lambda do |corrector|
             corrector.remove(
               range_with_surrounding_space(range: node.loc.begin, side: :left)
             )
           end
+        end
+
+        private
+
+        def non_modifier_then?(node)
+          node.loc.begin && node.loc.begin.source_line =~ NON_MODIFIER_THEN
         end
       end
     end

--- a/lib/rubocop/cop/style/multiline_memoization.rb
+++ b/lib/rubocop/cop/style/multiline_memoization.rb
@@ -43,8 +43,6 @@ module RuboCop
           add_offense(rhs, location: node.source_range)
         end
 
-        private
-
         def autocorrect(node)
           lambda do |corrector|
             if style == :keyword
@@ -55,6 +53,8 @@ module RuboCop
             end
           end
         end
+
+        private
 
         def bad_rhs?(rhs)
           return false unless rhs.multiline?

--- a/lib/rubocop/cop/style/mutable_constant.rb
+++ b/lib/rubocop/cop/style/mutable_constant.rb
@@ -30,18 +30,6 @@ module RuboCop
           on_assignment(value)
         end
 
-        private
-
-        def on_assignment(value)
-          value = splat_value(value) if splat_value(value)
-
-          return unless value && value.mutable_literal?
-          return if FROZEN_STRING_LITERAL_TYPES.include?(value.type) &&
-                    frozen_string_literals_enabled?
-
-          add_offense(value)
-        end
-
         def autocorrect(node)
           expr = node.source_range
 
@@ -53,6 +41,18 @@ module RuboCop
               corrector.insert_after(expr, '.freeze')
             end
           end
+        end
+
+        private
+
+        def on_assignment(value)
+          value = splat_value(value) if splat_value(value)
+
+          return unless value && value.mutable_literal?
+          return if FROZEN_STRING_LITERAL_TYPES.include?(value.type) &&
+                    frozen_string_literals_enabled?
+
+          add_offense(value)
         end
 
         def_node_matcher :splat_value, <<-PATTERN

--- a/lib/rubocop/cop/style/negated_if.rb
+++ b/lib/rubocop/cop/style/negated_if.rb
@@ -79,14 +79,14 @@ module RuboCop
           check_negative_conditional(node)
         end
 
+        def autocorrect(node)
+          negative_conditional_corrector(node)
+        end
+
         private
 
         def message(node)
           format(MSG, inverse: node.inverse_keyword, current: node.keyword)
-        end
-
-        def autocorrect(node)
-          negative_conditional_corrector(node)
         end
 
         def correct_style?(node)

--- a/lib/rubocop/cop/style/negated_while.rb
+++ b/lib/rubocop/cop/style/negated_while.rb
@@ -19,8 +19,6 @@ module RuboCop
           format(MSG, inverse: node.inverse_keyword, current: node.keyword)
         end
 
-        private
-
         def autocorrect(node)
           negative_conditional_corrector(node)
         end

--- a/lib/rubocop/cop/style/nested_parenthesized_calls.rb
+++ b/lib/rubocop/cop/style/nested_parenthesized_calls.rb
@@ -27,20 +27,6 @@ module RuboCop
           end
         end
 
-        private
-
-        def allowed_omission?(send_node)
-          !send_node.arguments? || send_node.parenthesized? ||
-            send_node.setter_method? || send_node.operator_method? ||
-            whitelisted?(send_node)
-        end
-
-        def whitelisted?(send_node)
-          send_node.parent.arguments.one? &&
-            whitelisted_methods.include?(send_node.method_name.to_s) &&
-            send_node.arguments.one?
-        end
-
         def autocorrect(nested)
           first_arg = nested.first_argument.source_range
           last_arg = nested.last_argument.source_range
@@ -53,6 +39,20 @@ module RuboCop
             corrector.replace(leading_space, '(')
             corrector.insert_after(last_arg, ')')
           end
+        end
+
+        private
+
+        def allowed_omission?(send_node)
+          !send_node.arguments? || send_node.parenthesized? ||
+            send_node.setter_method? || send_node.operator_method? ||
+            whitelisted?(send_node)
+        end
+
+        def whitelisted?(send_node)
+          send_node.parent.arguments.one? &&
+            whitelisted_methods.include?(send_node.method_name.to_s) &&
+            send_node.arguments.one?
         end
 
         def whitelisted_methods

--- a/lib/rubocop/cop/style/next.rb
+++ b/lib/rubocop/cop/style/next.rb
@@ -72,6 +72,16 @@ module RuboCop
         alias on_until on_while
         alias on_for on_while
 
+        def autocorrect(node)
+          lambda do |corrector|
+            if node.modifier_form?
+              autocorrect_modifier(corrector, node)
+            else
+              autocorrect_block(corrector, node)
+            end
+          end
+        end
+
         private
 
         def check(node)
@@ -128,16 +138,6 @@ module RuboCop
           condition_expression, = *offense_node
           offense_begin_pos = offense_node.source_range.begin
           offense_begin_pos.join(condition_expression.source_range)
-        end
-
-        def autocorrect(node)
-          lambda do |corrector|
-            if node.modifier_form?
-              autocorrect_modifier(corrector, node)
-            else
-              autocorrect_block(corrector, node)
-            end
-          end
         end
 
         def autocorrect_modifier(corrector, node)

--- a/lib/rubocop/cop/style/nil_comparison.rb
+++ b/lib/rubocop/cop/style/nil_comparison.rb
@@ -25,8 +25,6 @@ module RuboCop
           end
         end
 
-        private
-
         def autocorrect(node)
           new_code = node.source.sub(/\s*={2,3}\s*nil/, '.nil?')
           ->(corrector) { corrector.replace(node.source_range, new_code) }

--- a/lib/rubocop/cop/style/non_nil_check.rb
+++ b/lib/rubocop/cop/style/non_nil_check.rb
@@ -56,6 +56,17 @@ module RuboCop
         end
         alias on_defs on_def
 
+        def autocorrect(node)
+          case node.method_name
+          when :!=
+            autocorrect_comparison(node)
+          when :!
+            autocorrect_non_nil(node, node.receiver)
+          when :nil?
+            autocorrect_unless_nil(node, node.receiver)
+          end
+        end
+
         private
 
         def unless_and_nil_check?(send_node)
@@ -75,17 +86,6 @@ module RuboCop
 
         def include_semantic_changes?
           cop_config['IncludeSemanticChanges']
-        end
-
-        def autocorrect(node)
-          case node.method_name
-          when :!=
-            autocorrect_comparison(node)
-          when :!
-            autocorrect_non_nil(node, node.receiver)
-          when :nil?
-            autocorrect_unless_nil(node, node.receiver)
-          end
         end
 
         def autocorrect_comparison(node)

--- a/lib/rubocop/cop/style/not.rb
+++ b/lib/rubocop/cop/style/not.rb
@@ -31,8 +31,6 @@ module RuboCop
           add_offense(node, location: :selector)
         end
 
-        private
-
         def autocorrect(node)
           range = range_with_surrounding_space(range: node.loc.selector,
                                                side: :right)
@@ -45,6 +43,8 @@ module RuboCop
             correct_without_parens(range)
           end
         end
+
+        private
 
         def opposite_method?(child)
           child.send_type? && OPPOSITE_METHODS.key?(child.method_name)

--- a/lib/rubocop/cop/style/numeric_literal_prefix.rb
+++ b/lib/rubocop/cop/style/numeric_literal_prefix.rb
@@ -33,18 +33,18 @@ module RuboCop
           add_offense(node)
         end
 
-        private
-
-        def message(node)
-          self.class.const_get("#{literal_type(node).upcase}_MSG")
-        end
-
         def autocorrect(node)
           lambda do |corrector|
             type = literal_type(node)
             corrector.replace(node.source_range,
                               send(:"format_#{type}", node.source))
           end
+        end
+
+        private
+
+        def message(node)
+          self.class.const_get("#{literal_type(node).upcase}_MSG")
         end
 
         def literal_type(node)

--- a/lib/rubocop/cop/style/numeric_literals.rb
+++ b/lib/rubocop/cop/style/numeric_literals.rb
@@ -41,6 +41,12 @@ module RuboCop
           check(node)
         end
 
+        def autocorrect(node)
+          lambda do |corrector|
+            corrector.replace(node.source_range, format_number(node))
+          end
+        end
+
         private
 
         def max_parameter_name
@@ -66,12 +72,6 @@ module RuboCop
 
         def short_group_regex
           cop_config['Strict'] ? /_\d{1,2}(_|$)/ : /_\d{1,2}_/
-        end
-
-        def autocorrect(node)
-          lambda do |corrector|
-            corrector.replace(node.source_range, format_number(node))
-          end
         end
 
         def format_number(node)

--- a/lib/rubocop/cop/style/numeric_predicate.rb
+++ b/lib/rubocop/cop/style/numeric_predicate.rb
@@ -63,6 +63,14 @@ module RuboCop
                                       current: node.source))
         end
 
+        def autocorrect(node)
+          _, replacement = check(node)
+
+          lambda do |corrector|
+            corrector.replace(node.loc.expression, replacement)
+          end
+        end
+
         private
 
         def check(node)
@@ -76,14 +84,6 @@ module RuboCop
           return unless numeric && operator && replacement_supported?(operator)
 
           [numeric, replacement(numeric, operator)]
-        end
-
-        def autocorrect(node)
-          _, replacement = check(node)
-
-          lambda do |corrector|
-            corrector.replace(node.loc.expression, replacement)
-          end
         end
 
         def replacement(numeric, operation)

--- a/lib/rubocop/cop/style/one_line_conditional.rb
+++ b/lib/rubocop/cop/style/one_line_conditional.rb
@@ -17,13 +17,13 @@ module RuboCop
           add_offense(node)
         end
 
-        private
-
         def autocorrect(node)
           lambda do |corrector|
             corrector.replace(node.source_range, replacement(node))
           end
         end
+
+        private
 
         def message(node)
           format(MSG, keyword: node.keyword)

--- a/lib/rubocop/cop/style/or_assignment.rb
+++ b/lib/rubocop/cop/style/or_assignment.rb
@@ -58,8 +58,6 @@ module RuboCop
         alias on_cvasgn on_lvasgn
         alias on_gvasgn on_lvasgn
 
-        private
-
         def autocorrect(node)
           if ternary_assignment?(node)
             variable, default = take_variable_and_default_from_ternary(node)
@@ -72,6 +70,8 @@ module RuboCop
                               "#{variable} ||= #{default.source}")
           end
         end
+
+        private
 
         def take_variable_and_default_from_ternary(node)
           variable, if_statement = *node

--- a/lib/rubocop/cop/style/parallel_assignment.rb
+++ b/lib/rubocop/cop/style/parallel_assignment.rb
@@ -38,6 +38,19 @@ module RuboCop
           add_offense(node)
         end
 
+        def autocorrect(node)
+          lambda do |corrector|
+            left, right = *node
+            left_elements = *left
+            right_elements = [*right].compact
+            order = find_valid_order(left_elements, right_elements)
+            correction = assignment_corrector(node, order)
+
+            corrector.replace(correction.correction_range,
+                              correction.correction)
+          end
+        end
+
         private
 
         def allowed_masign?(lhs_elements, rhs_elements)
@@ -66,19 +79,6 @@ module RuboCop
 
         def return_of_method_call?(node)
           node.block_type? || node.send_type?
-        end
-
-        def autocorrect(node)
-          lambda do |corrector|
-            left, right = *node
-            left_elements = *left
-            right_elements = [*right].compact
-            order = find_valid_order(left_elements, right_elements)
-            correction = assignment_corrector(node, order)
-
-            corrector.replace(correction.correction_range,
-                              correction.correction)
-          end
         end
 
         def assignment_corrector(node, order)

--- a/lib/rubocop/cop/style/percent_literal_delimiters.rb
+++ b/lib/rubocop/cop/style/percent_literal_delimiters.rb
@@ -55,8 +55,6 @@ module RuboCop
           "`#{delimiters[0]}` and `#{delimiters[1]}`."
         end
 
-        private
-
         def autocorrect(node)
           type = type(node)
 
@@ -67,6 +65,8 @@ module RuboCop
             corrector.replace(node.loc.end, closing_delimiter)
           end
         end
+
+        private
 
         def on_percent_literal(node)
           type = type(node)

--- a/lib/rubocop/cop/style/percent_q_literals.rb
+++ b/lib/rubocop/cop/style/percent_q_literals.rb
@@ -37,6 +37,12 @@ module RuboCop
           process(node, '%Q', '%q')
         end
 
+        def autocorrect(node)
+          lambda do |corrector|
+            corrector.replace(node.source_range, corrected(node.source))
+          end
+        end
+
         private
 
         def on_percent_literal(node)
@@ -56,12 +62,6 @@ module RuboCop
 
         def message(_node)
           style == :lower_case_q ? LOWER_CASE_Q_MSG : UPPER_CASE_Q_MSG
-        end
-
-        def autocorrect(node)
-          lambda do |corrector|
-            corrector.replace(node.source_range, corrected(node.source))
-          end
         end
 
         def corrected(src)

--- a/lib/rubocop/cop/style/raise_args.rb
+++ b/lib/rubocop/cop/style/raise_args.rb
@@ -51,8 +51,6 @@ module RuboCop
           end
         end
 
-        private
-
         def autocorrect(node)
           replacement = if style == :compact
                           correction_exploded_to_compact(node)
@@ -62,6 +60,8 @@ module RuboCop
 
           ->(corrector) { corrector.replace(node.source_range, replacement) }
         end
+
+        private
 
         def correction_compact_to_exploded(node)
           exception_node, _new, message_node = *node.first_argument

--- a/lib/rubocop/cop/style/random_with_offset.rb
+++ b/lib/rubocop/cop/style/random_with_offset.rb
@@ -62,8 +62,6 @@ module RuboCop
           add_offense(node)
         end
 
-        private
-
         def autocorrect(node)
           lambda do |corrector|
             if integer_op_rand?(node)
@@ -78,6 +76,8 @@ module RuboCop
             end
           end
         end
+
+        private
 
         def corrected_integer_op_rand(node)
           left, operator, right = *node

--- a/lib/rubocop/cop/style/redundant_begin.rb
+++ b/lib/rubocop/cop/style/redundant_begin.rb
@@ -38,19 +38,19 @@ module RuboCop
           check(node)
         end
 
+        def autocorrect(node)
+          lambda do |corrector|
+            corrector.remove(node.loc.begin)
+            corrector.remove(node.loc.end)
+          end
+        end
+
         private
 
         def check(node)
           return unless node.body && node.body.kwbegin_type?
 
           add_offense(node.body, location: :begin)
-        end
-
-        def autocorrect(node)
-          lambda do |corrector|
-            corrector.remove(node.loc.begin)
-            corrector.remove(node.loc.end)
-          end
         end
       end
     end

--- a/lib/rubocop/cop/style/redundant_conditional.rb
+++ b/lib/rubocop/cop/style/redundant_conditional.rb
@@ -38,6 +38,12 @@ module RuboCop
           add_offense(node)
         end
 
+        def autocorrect(node)
+          lambda do |corrector|
+            corrector.replace(node.loc.expression, replacement_condition(node))
+          end
+        end
+
         private
 
         def message(node)
@@ -58,12 +64,6 @@ module RuboCop
         def offense?(node)
           return if node.modifier_form?
           redundant_condition?(node) || redundant_condition_inverted?(node)
-        end
-
-        def autocorrect(node)
-          lambda do |corrector|
-            corrector.replace(node.loc.expression, replacement_condition(node))
-          end
         end
 
         def replacement_condition(node)

--- a/lib/rubocop/cop/style/redundant_return.rb
+++ b/lib/rubocop/cop/style/redundant_return.rb
@@ -31,8 +31,6 @@ module RuboCop
         end
         alias on_defs on_def
 
-        private
-
         def autocorrect(node) # rubocop:disable Metrics/MethodLength
           lambda do |corrector|
             unless arguments?(node.children)
@@ -51,6 +49,8 @@ module RuboCop
             corrector.remove(return_kw)
           end
         end
+
+        private
 
         def add_brackets(corrector, node)
           kids = node.children.map(&:source_range)

--- a/lib/rubocop/cop/style/redundant_self.rb
+++ b/lib/rubocop/cop/style/redundant_self.rb
@@ -100,14 +100,14 @@ module RuboCop
           add_scope(node, @local_variables_scopes[node])
         end
 
-        private
-
         def autocorrect(node)
           lambda do |corrector|
             corrector.remove(node.receiver.source_range)
             corrector.remove(node.loc.dot)
           end
         end
+
+        private
 
         def add_scope(node, local_variables = [])
           node.descendants.each do |child_node|

--- a/lib/rubocop/cop/style/regexp_literal.rb
+++ b/lib/rubocop/cop/style/regexp_literal.rb
@@ -95,6 +95,21 @@ module RuboCop
           end
         end
 
+        def autocorrect(node)
+          return if contains_slash?(node)
+
+          replacement = if slash_literal?(node)
+                          ['%r', ''].zip(preferred_delimiters).map(&:join)
+                        else
+                          %w[/ /]
+                        end
+
+          lambda do |corrector|
+            corrector.replace(node.loc.begin, replacement.first)
+            corrector.replace(node.loc.end, replacement.last)
+          end
+        end
+
         private
 
         def check_slash_literal(node)
@@ -153,21 +168,6 @@ module RuboCop
         def preferred_delimiters
           config.for_cop('Style/PercentLiteralDelimiters') \
             ['PreferredDelimiters']['%r'].split(//)
-        end
-
-        def autocorrect(node)
-          return if contains_slash?(node)
-
-          replacement = if slash_literal?(node)
-                          ['%r', ''].zip(preferred_delimiters).map(&:join)
-                        else
-                          %w[/ /]
-                        end
-
-          lambda do |corrector|
-            corrector.replace(node.loc.begin, replacement.first)
-            corrector.replace(node.loc.end, replacement.last)
-          end
         end
       end
     end

--- a/lib/rubocop/cop/style/return_nil.rb
+++ b/lib/rubocop/cop/style/return_nil.rb
@@ -57,14 +57,14 @@ module RuboCop
           add_offense(node) unless correct_style?(node)
         end
 
-        private
-
         def autocorrect(node)
           lambda do |corrector|
             corrected = style == :return ? 'return' : 'return nil'
             corrector.replace(node.source_range, corrected)
           end
         end
+
+        private
 
         def message(_node)
           style == :return ? RETURN_MSG : RETURN_NIL_MSG

--- a/lib/rubocop/cop/style/self_assignment.rb
+++ b/lib/rubocop/cop/style/self_assignment.rb
@@ -32,6 +32,16 @@ module RuboCop
           check(node, :cvar)
         end
 
+        def autocorrect(node)
+          _var_name, rhs = *node
+
+          if rhs.send_type?
+            autocorrect_send_node(node, rhs)
+          elsif %i[and or].include?(rhs.type)
+            autocorrect_boolean_node(node, rhs)
+          end
+        end
+
         private
 
         def check(node, var_type)
@@ -63,16 +73,6 @@ module RuboCop
 
           operator = rhs.loc.operator.source
           add_offense(node, message: format(MSG, method: operator))
-        end
-
-        def autocorrect(node)
-          _var_name, rhs = *node
-
-          if rhs.send_type?
-            autocorrect_send_node(node, rhs)
-          elsif %i[and or].include?(rhs.type)
-            autocorrect_boolean_node(node, rhs)
-          end
         end
 
         def autocorrect_send_node(node, rhs)

--- a/lib/rubocop/cop/style/semicolon.rb
+++ b/lib/rubocop/cop/style/semicolon.rb
@@ -46,6 +46,11 @@ module RuboCop
           end
         end
 
+        def autocorrect(range)
+          return unless range
+          ->(corrector) { corrector.remove(range) }
+        end
+
         private
 
         def check_for_line_terminator_or_opener
@@ -68,11 +73,6 @@ module RuboCop
           # Don't attempt to autocorrect if semicolon is separating statements
           # on the same line
           add_offense(autocorrect ? range : nil, location: range)
-        end
-
-        def autocorrect(range)
-          return unless range
-          ->(corrector) { corrector.remove(range) }
         end
       end
     end

--- a/lib/rubocop/cop/style/single_line_methods.rb
+++ b/lib/rubocop/cop/style/single_line_methods.rb
@@ -30,12 +30,6 @@ module RuboCop
         end
         alias on_defs on_def
 
-        private
-
-        def allow_empty?
-          cop_config['AllowIfMethodIsEmpty']
-        end
-
         def autocorrect(node)
           body = node.body
 
@@ -49,6 +43,12 @@ module RuboCop
             eol_comment = end_of_line_comment(node.source_range.line)
             move_comment(eol_comment, node, corrector) if eol_comment
           end
+        end
+
+        private
+
+        def allow_empty?
+          cop_config['AllowIfMethodIsEmpty']
         end
 
         def end_of_line_comment(line)

--- a/lib/rubocop/cop/style/string_hash_keys.rb
+++ b/lib/rubocop/cop/style/string_hash_keys.rb
@@ -24,8 +24,6 @@ module RuboCop
           add_offense(node.key)
         end
 
-        private
-
         def autocorrect(node)
           lambda do |corrector|
             symbol_content = node.str_content.to_sym.inspect

--- a/lib/rubocop/cop/style/string_methods.rb
+++ b/lib/rubocop/cop/style/string_methods.rb
@@ -25,19 +25,19 @@ module RuboCop
           add_offense(node, location: :selector)
         end
 
+        def autocorrect(node)
+          lambda do |corrector|
+            corrector.replace(node.loc.selector,
+                              preferred_method(node.method_name))
+          end
+        end
+
         private
 
         def message(node)
           format(MSG,
                  prefer: preferred_method(node.method_name),
                  current: node.method_name)
-        end
-
-        def autocorrect(node)
-          lambda do |corrector|
-            corrector.replace(node.loc.selector,
-                              preferred_method(node.method_name))
-          end
         end
       end
     end

--- a/lib/rubocop/cop/style/symbol_array.rb
+++ b/lib/rubocop/cop/style/symbol_array.rb
@@ -51,8 +51,6 @@ module RuboCop
           end
         end
 
-        private
-
         def autocorrect(node)
           if style == :percent
             correct_percent(node, 'i')
@@ -60,6 +58,8 @@ module RuboCop
             correct_bracketed(node)
           end
         end
+
+        private
 
         def symbols_contain_spaces?(node)
           node.children.any? do |sym|

--- a/lib/rubocop/cop/style/ternary_parentheses.rb
+++ b/lib/rubocop/cop/style/ternary_parentheses.rb
@@ -58,6 +58,20 @@ module RuboCop
           add_offense(node, location: node.source_range)
         end
 
+        def autocorrect(node)
+          condition = node.condition
+
+          return nil if parenthesized?(condition) &&
+                        (safe_assignment?(condition) ||
+                        unsafe_autocorrect?(condition))
+
+          if parenthesized?(condition)
+            correct_parenthesized(condition)
+          else
+            correct_unparenthesized(condition)
+          end
+        end
+
         private
 
         def offense?(node)
@@ -73,20 +87,6 @@ module RuboCop
             else
               require_parentheses? ? !parens : parens
             end
-          end
-        end
-
-        def autocorrect(node)
-          condition = node.condition
-
-          return nil if parenthesized?(condition) &&
-                        (safe_assignment?(condition) ||
-                        unsafe_autocorrect?(condition))
-
-          if parenthesized?(condition)
-            correct_parenthesized(condition)
-          else
-            correct_unparenthesized(condition)
           end
         end
 

--- a/lib/rubocop/cop/style/trailing_body_on_method_definition.rb
+++ b/lib/rubocop/cop/style/trailing_body_on_method_definition.rb
@@ -37,6 +37,14 @@ module RuboCop
         end
         alias on_defs on_def
 
+        def autocorrect(node)
+          lambda do |corrector|
+            break_line_before_body(node, corrector)
+            move_comment(node, corrector)
+            remove_semicolon(corrector)
+          end
+        end
+
         private
 
         def trailing_body?(node)
@@ -45,14 +53,6 @@ module RuboCop
 
         def on_def_line?(node)
           node.source_range.first_line == node.body.source_range.first_line
-        end
-
-        def autocorrect(node)
-          lambda do |corrector|
-            break_line_before_body(node, corrector)
-            move_comment(node, corrector)
-            remove_semicolon(corrector)
-          end
         end
 
         def break_line_before_body(node, corrector)

--- a/lib/rubocop/cop/style/trailing_method_end_statement.rb
+++ b/lib/rubocop/cop/style/trailing_method_end_statement.rb
@@ -45,6 +45,13 @@ module RuboCop
           add_offense(node.to_a.last, location: end_token.pos)
         end
 
+        def autocorrect(_node)
+          lambda do |corrector|
+            break_line_before_end(corrector)
+            remove_semicolon(corrector)
+          end
+        end
+
         private
 
         def trailing_end?(node)
@@ -68,13 +75,6 @@ module RuboCop
           @token_before_end ||= begin
             i = processed_source.tokens.index(end_token)
             processed_source.tokens[i - 1]
-          end
-        end
-
-        def autocorrect(_node)
-          lambda do |corrector|
-            break_line_before_end(corrector)
-            remove_semicolon(corrector)
           end
         end
 

--- a/lib/rubocop/cop/style/trivial_accessors.rb
+++ b/lib/rubocop/cop/style/trivial_accessors.rb
@@ -38,6 +38,14 @@ module RuboCop
         end
         alias on_defs on_def
 
+        def autocorrect(node)
+          if node.def_type?
+            autocorrect_instance(node)
+          elsif node.defs_type? && node.children.first.self_type?
+            autocorrect_class(node)
+          end
+        end
+
         private
 
         def in_module_or_instance_eval?(node)
@@ -141,14 +149,6 @@ module RuboCop
 
         def accessor(kind, method_name)
           "attr_#{kind} :#{method_name.to_s.chomp('=')}"
-        end
-
-        def autocorrect(node)
-          if node.def_type?
-            autocorrect_instance(node)
-          elsif node.defs_type? && node.children.first.self_type?
-            autocorrect_class(node)
-          end
         end
 
         def autocorrect_instance(node)

--- a/lib/rubocop/cop/style/unneeded_capital_w.rb
+++ b/lib/rubocop/cop/style/unneeded_capital_w.rb
@@ -24,6 +24,13 @@ module RuboCop
           process(node, '%W')
         end
 
+        def autocorrect(node)
+          lambda do |corrector|
+            src = node.loc.begin.source
+            corrector.replace(node.loc.begin, src.tr('W', 'w'))
+          end
+        end
+
         private
 
         def on_percent_literal(node)
@@ -36,13 +43,6 @@ module RuboCop
           node.child_nodes.any? do |string|
             string.dstr_type? ||
               double_quotes_required?(string.source)
-          end
-        end
-
-        def autocorrect(node)
-          lambda do |corrector|
-            src = node.loc.begin.source
-            corrector.replace(node.loc.begin, src.tr('W', 'w'))
           end
         end
       end

--- a/lib/rubocop/cop/style/unneeded_interpolation.rb
+++ b/lib/rubocop/cop/style/unneeded_interpolation.rb
@@ -28,6 +28,18 @@ module RuboCop
           add_offense(node) if single_interpolation?(node)
         end
 
+        def autocorrect(node)
+          embedded_node = node.children.first
+
+          if variable_interpolation?(embedded_node)
+            autocorrect_variable_interpolation(embedded_node, node)
+          elsif single_variable_interpolation?(embedded_node)
+            autocorrect_single_variable_interpolation(embedded_node, node)
+          else
+            autocorrect_other(embedded_node, node)
+          end
+        end
+
         private
 
         def single_interpolation?(node)
@@ -56,18 +68,6 @@ module RuboCop
         def embedded_in_percent_array?(node)
           node.parent && node.parent.array_type? &&
             percent_literal?(node.parent)
-        end
-
-        def autocorrect(node)
-          embedded_node = node.children.first
-
-          if variable_interpolation?(embedded_node)
-            autocorrect_variable_interpolation(embedded_node, node)
-          elsif single_variable_interpolation?(embedded_node)
-            autocorrect_single_variable_interpolation(embedded_node, node)
-          else
-            autocorrect_other(embedded_node, node)
-          end
         end
 
         def autocorrect_variable_interpolation(embedded_node, node)

--- a/lib/rubocop/cop/style/unneeded_percent_q.rb
+++ b/lib/rubocop/cop/style/unneeded_percent_q.rb
@@ -30,6 +30,15 @@ module RuboCop
           check(node)
         end
 
+        def autocorrect(node)
+          delimiter =
+            node.source =~ /^%Q[^"]+$|'/ ? QUOTE : SINGLE_QUOTE
+          lambda do |corrector|
+            corrector.replace(node.loc.begin, delimiter)
+            corrector.replace(node.loc.end, delimiter)
+          end
+        end
+
         private
 
         def check(node)
@@ -57,15 +66,6 @@ module RuboCop
                     EMPTY
                   end
           format(MSG, q_type: src[0, 2], extra: extra)
-        end
-
-        def autocorrect(node)
-          delimiter =
-            node.source =~ /^%Q[^"]+$|'/ ? QUOTE : SINGLE_QUOTE
-          lambda do |corrector|
-            corrector.replace(node.loc.begin, delimiter)
-            corrector.replace(node.loc.end, delimiter)
-          end
         end
 
         def string_literal?(node)

--- a/lib/rubocop/cop/style/variable_interpolation.rb
+++ b/lib/rubocop/cop/style/variable_interpolation.rb
@@ -31,6 +31,12 @@ module RuboCop
           check_for_interpolation(node)
         end
 
+        def autocorrect(node)
+          lambda do |corrector|
+            corrector.replace(node.source_range, "{#{node.source}}")
+          end
+        end
+
         private
 
         def check_for_interpolation(node)
@@ -41,12 +47,6 @@ module RuboCop
 
         def message(node)
           format(MSG, variable: node.source)
-        end
-
-        def autocorrect(node)
-          lambda do |corrector|
-            corrector.replace(node.source_range, "{#{node.source}}")
-          end
         end
 
         def var_nodes(nodes)

--- a/lib/rubocop/cop/style/while_until_do.rb
+++ b/lib/rubocop/cop/style/while_until_do.rb
@@ -46,8 +46,6 @@ module RuboCop
                             message: format(MSG, keyword: node.keyword))
         end
 
-        private
-
         def autocorrect(node)
           do_range = node.condition.source_range.end.join(node.loc.begin)
 

--- a/lib/rubocop/cop/style/while_until_modifier.rb
+++ b/lib/rubocop/cop/style/while_until_modifier.rb
@@ -38,8 +38,6 @@ module RuboCop
           check(node)
         end
 
-        private
-
         def autocorrect(node)
           oneline = "#{node.body.source} #{node.keyword} " \
                     "#{node.condition.source}"
@@ -48,6 +46,8 @@ module RuboCop
             corrector.replace(node.source_range, oneline)
           end
         end
+
+        private
 
         def check(node)
           return unless node.multiline? && single_line_as_modifier?(node)

--- a/lib/rubocop/cop/style/word_array.rb
+++ b/lib/rubocop/cop/style/word_array.rb
@@ -52,8 +52,6 @@ module RuboCop
           end
         end
 
-        private
-
         def autocorrect(node)
           if style == :percent
             correct_percent(node, 'w')
@@ -61,6 +59,8 @@ module RuboCop
             correct_bracketed(node)
           end
         end
+
+        private
 
         def check_bracketed_array(node)
           return if allowed_bracket_array?(node)

--- a/lib/rubocop/cop/style/yoda_condition.rb
+++ b/lib/rubocop/cop/style/yoda_condition.rb
@@ -50,6 +50,12 @@ module RuboCop
           add_offense(node)
         end
 
+        def autocorrect(node)
+          lambda do |corrector|
+            corrector.replace(actual_code_range(node), corrected_code(node))
+          end
+        end
+
         private
 
         def yoda_condition?(node)
@@ -67,12 +73,6 @@ module RuboCop
 
         def message(node)
           format(MSG, source: node.source)
-        end
-
-        def autocorrect(node)
-          lambda do |corrector|
-            corrector.replace(actual_code_range(node), corrected_code(node))
-          end
         end
 
         def corrected_code(node)

--- a/lib/rubocop/cop/style/zero_length_predicate.rb
+++ b/lib/rubocop/cop/style/zero_length_predicate.rb
@@ -35,6 +35,12 @@ module RuboCop
           check_nonzero_length_predicate(node)
         end
 
+        def autocorrect(node)
+          lambda do |corrector|
+            corrector.replace(node.loc.expression, replacement(node))
+          end
+        end
+
         private
 
         def check_zero_length_predicate(node)
@@ -74,12 +80,6 @@ module RuboCop
           {(send (send (...) ${:length :size}) ${:> :!=} (int $0))
            (send (int $0) ${:< :!=} (send (...) ${:length :size}))}
         PATTERN
-
-        def autocorrect(node)
-          lambda do |corrector|
-            corrector.replace(node.loc.expression, replacement(node))
-          end
-        end
 
         def replacement(node)
           receiver = zero_length_receiver(node)


### PR DESCRIPTION
Resolves issue #5206 .

This change makes all Cop `autocorrect` methods public and removes `AutocorrectLogic`'s
2nd argument to `respond_to?` that allows private autocorrect methods to be read.

There were mixins where all methods were either public or private. In these situations,
`autocorrect` is moved to the top of the file, under any `on_type(node)` methods should
they exist.

-----------------

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests -- Already coverage for every change
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
