### PR TITLE
CLEANUP - Add `Token` methods to reduce method chains

### DIFF
--- a/lib/rubocop/comment_config.rb
+++ b/lib/rubocop/comment_config.rb
@@ -148,7 +148,7 @@ module RuboCop
           token.type == :tCOMMENT
         end
 
-        non_comment_tokens.map { |token| token.pos.line }.uniq
+        non_comment_tokens.map(&:line).uniq
       end
     end
   end

--- a/lib/rubocop/comment_config.rb
+++ b/lib/rubocop/comment_config.rb
@@ -144,10 +144,7 @@ module RuboCop
 
     def non_comment_token_line_numbers
       @non_comment_token_line_numbers ||= begin
-        non_comment_tokens = processed_source.tokens.reject do |token|
-          token.type == :tCOMMENT
-        end
-
+        non_comment_tokens = processed_source.tokens.reject(&:comment?)
         non_comment_tokens.map(&:line).uniq
       end
     end

--- a/lib/rubocop/cop/layout/empty_lines.rb
+++ b/lib/rubocop/cop/layout/empty_lines.rb
@@ -29,7 +29,7 @@ module RuboCop
 
           lines = Set.new
           processed_source.tokens.each do |token|
-            lines << token.pos.line
+            lines << token.line
           end
 
           each_extra_empty_line(lines.sort) do |range|

--- a/lib/rubocop/cop/layout/end_of_line.rb
+++ b/lib/rubocop/cop/layout/end_of_line.rb
@@ -13,7 +13,7 @@ module RuboCop
         def investigate(processed_source)
           last_token = processed_source.tokens.last
           last_line =
-            last_token ? last_token.pos.line : processed_source.lines.length
+            last_token ? last_token.line : processed_source.lines.length
 
           processed_source.raw_source.each_line.with_index do |line, index|
             break if index >= last_line

--- a/lib/rubocop/cop/layout/extra_spacing.rb
+++ b/lib/rubocop/cop/layout/extra_spacing.rb
@@ -126,7 +126,7 @@ module RuboCop
         end
 
         def aligned_tok?(token)
-          if token.type == :tCOMMENT
+          if token.comment?
             aligned_comments?(token)
           else
             aligned_with_something?(token.pos)

--- a/lib/rubocop/cop/layout/initial_indentation.rb
+++ b/lib/rubocop/cop/layout/initial_indentation.rb
@@ -26,18 +26,18 @@ module RuboCop
 
         def space_before(token)
           return unless token
-          return if token.pos.column.zero?
+          return if token.column.zero?
 
-          token_with_space =
+          space_range =
             range_with_surrounding_space(range: token.pos,
                                          side: :left,
                                          newlines: false)
           # If the file starts with a byte order mark (BOM), the column can be
           # non-zero, but then we find out here if there's no space to the left
           # of the first token.
-          return if token_with_space == token.pos
+          return if space_range == token.pos
 
-          yield range_between(token_with_space.begin_pos, token.pos.begin_pos)
+          yield range_between(space_range.begin_pos, token.begin_pos)
         end
       end
     end

--- a/lib/rubocop/cop/layout/space_after_comma.rb
+++ b/lib/rubocop/cop/layout/space_after_comma.rb
@@ -23,7 +23,7 @@ module RuboCop
         end
 
         def kind(token)
-          'comma' if token.type == :tCOMMA
+          'comma' if token.comma?
         end
       end
     end

--- a/lib/rubocop/cop/layout/space_after_semicolon.rb
+++ b/lib/rubocop/cop/layout/space_after_semicolon.rb
@@ -20,7 +20,7 @@ module RuboCop
         end
 
         def kind(token)
-          'semicolon' if token.type == :tSEMI
+          'semicolon' if token.semicolon?
         end
       end
     end

--- a/lib/rubocop/cop/layout/space_around_equals_in_parameter_default.rb
+++ b/lib/rubocop/cop/layout/space_around_equals_in_parameter_default.rb
@@ -44,7 +44,7 @@ module RuboCop
 
         def incorrect_style_detected(arg, value, space_on_both_sides,
                                      no_surrounding_space)
-          range = range_between(arg.pos.end_pos, value.pos.begin_pos)
+          range = range_between(arg.end_pos, value.begin_pos)
           add_offense(range, location: range) do
             if style == :space && no_surrounding_space ||
                style == :no_space && space_on_both_sides

--- a/lib/rubocop/cop/layout/space_before_comma.rb
+++ b/lib/rubocop/cop/layout/space_before_comma.rb
@@ -19,7 +19,7 @@ module RuboCop
         include SpaceBeforePunctuation
 
         def kind(token)
-          'comma' if token.type == :tCOMMA
+          'comma' if token.comma?
         end
       end
     end

--- a/lib/rubocop/cop/layout/space_before_comment.rb
+++ b/lib/rubocop/cop/layout/space_before_comment.rb
@@ -17,7 +17,7 @@ module RuboCop
 
         def investigate(processed_source)
           processed_source.tokens.each_cons(2) do |t1, t2|
-            next unless t2.type == :tCOMMENT
+            next unless t2.comment?
             next unless t1.line == t2.line
             add_offense(t2.pos, location: t2.pos) if t1.pos.end == t2.pos.begin
           end

--- a/lib/rubocop/cop/layout/space_before_comment.rb
+++ b/lib/rubocop/cop/layout/space_before_comment.rb
@@ -18,7 +18,7 @@ module RuboCop
         def investigate(processed_source)
           processed_source.tokens.each_cons(2) do |t1, t2|
             next unless t2.type == :tCOMMENT
-            next unless t1.pos.line == t2.pos.line
+            next unless t1.line == t2.line
             add_offense(t2.pos, location: t2.pos) if t1.pos.end == t2.pos.begin
           end
         end

--- a/lib/rubocop/cop/layout/space_before_semicolon.rb
+++ b/lib/rubocop/cop/layout/space_before_semicolon.rb
@@ -15,7 +15,7 @@ module RuboCop
         include SpaceBeforePunctuation
 
         def kind(token)
-          'semicolon' if token.type == :tSEMI
+          'semicolon' if token.semicolon?
         end
       end
     end

--- a/lib/rubocop/cop/layout/space_inside_array_literal_brackets.rb
+++ b/lib/rubocop/cop/layout/space_inside_array_literal_brackets.rb
@@ -110,11 +110,11 @@ module RuboCop
         end
 
         def space_between?(left, right)
-          left.pos.end_pos + 1 == right.pos.begin_pos
+          left.end_pos + 1 == right.begin_pos
         end
 
         def no_space_between?(left, right)
-          left.pos.end_pos == right.pos.begin_pos
+          left.end_pos == right.begin_pos
         end
 
         def empty_config
@@ -133,7 +133,7 @@ module RuboCop
         end
 
         def next_to_newline?(node, token)
-          tokens(node)[index_for(node, token) + 1].pos.line != token.pos.line
+          tokens(node)[index_for(node, token) + 1].line != token.line
         end
 
         def end_has_own_line?(token)
@@ -147,7 +147,7 @@ module RuboCop
         end
 
         def line_and_column_for(token)
-          [token.pos.line - 1, token.pos.column - 1]
+          [token.line - 1, token.column - 1]
         end
 
         def issue_offenses(node, left, right, start_ok, end_ok)

--- a/lib/rubocop/cop/layout/space_inside_array_literal_brackets.rb
+++ b/lib/rubocop/cop/layout/space_inside_array_literal_brackets.rb
@@ -79,11 +79,11 @@ module RuboCop
         end
 
         def left_array_bracket(node)
-          tokens(node).find { |token| left_bracket?(token) }
+          tokens(node).find(&:left_array_bracket?)
         end
 
         def right_array_bracket(node)
-          tokens(node).reverse.find { |token| right_bracket?(token) }
+          tokens(node).reverse.find(&:right_bracket?)
         end
 
         def empty_brackets?(left, right)
@@ -195,18 +195,10 @@ module RuboCop
         def multi_dimensional_array?(node, token, side: :right)
           i = index_for(node, token)
           if side == :right
-            right_bracket?(tokens(node)[i - 1])
+            tokens(node)[i - 1].right_bracket?
           else
-            left_bracket?(tokens(node)[i + 1])
+            tokens(node)[i + 1].left_array_bracket?
           end
-        end
-
-        def right_bracket?(token)
-          token.type == :tRBRACK
-        end
-
-        def left_bracket?(token)
-          token.type == :tLBRACK
         end
 
         def next_to_bracket?(token, side: :right)

--- a/lib/rubocop/cop/layout/space_inside_array_literal_brackets.rb
+++ b/lib/rubocop/cop/layout/space_inside_array_literal_brackets.rb
@@ -164,7 +164,7 @@ module RuboCop
         end
 
         def next_to_comment?(node, token)
-          tokens(node)[index_for(node, token) + 1].type == :tCOMMENT
+          tokens(node)[index_for(node, token) + 1].comment?
         end
 
         def compact_offenses(node, left, right, start_ok, end_ok)

--- a/lib/rubocop/cop/layout/space_inside_hash_literal_braces.rb
+++ b/lib/rubocop/cop/layout/space_inside_hash_literal_braces.rb
@@ -58,20 +58,12 @@ module RuboCop
         def hash_literal_with_braces(node)
           tokens = processed_source.tokens
           begin_index = index_of_first_token(node)
-          return unless left_brace?(tokens[begin_index])
+          return unless tokens[begin_index].left_brace?
 
           end_index = index_of_last_token(node)
-          return unless right_brace?(tokens[end_index])
+          return unless tokens[end_index].right_curly_brace?
 
           yield begin_index, end_index
-        end
-
-        def left_brace?(token)
-          token.type == :tLBRACE
-        end
-
-        def right_brace?(token)
-          token.type == :tRCURLY
         end
 
         def check(t1, t2)
@@ -79,7 +71,7 @@ module RuboCop
           return if t1.line < t2.line
           return if t2.comment? # Also indicates there's a line break.
 
-          is_empty_braces = left_brace?(t1) && right_brace?(t2)
+          is_empty_braces = t1.left_brace? && t2.right_curly_brace?
           expect_space    = expect_space?(t1, t2)
 
           if offense?(t1, expect_space)
@@ -91,7 +83,7 @@ module RuboCop
 
         def expect_space?(t1, t2)
           is_same_braces  = t1.type == t2.type
-          is_empty_braces = left_brace?(t1) && right_brace?(t2)
+          is_empty_braces = t1.left_brace? && t2.right_curly_brace?
 
           if is_same_braces && style == :compact
             false

--- a/lib/rubocop/cop/layout/space_inside_hash_literal_braces.rb
+++ b/lib/rubocop/cop/layout/space_inside_hash_literal_braces.rb
@@ -77,7 +77,7 @@ module RuboCop
         def check(t1, t2)
           # No offense if line break inside.
           return if t1.line < t2.line
-          return if t2.type == :tCOMMENT # Also indicates there's a line break.
+          return if t2.comment? # Also indicates there's a line break.
 
           is_empty_braces = left_brace?(t1) && right_brace?(t2)
           expect_space    = expect_space?(t1, t2)

--- a/lib/rubocop/cop/layout/space_inside_hash_literal_braces.rb
+++ b/lib/rubocop/cop/layout/space_inside_hash_literal_braces.rb
@@ -76,7 +76,7 @@ module RuboCop
 
         def check(t1, t2)
           # No offense if line break inside.
-          return if t1.pos.line < t2.pos.line
+          return if t1.line < t2.line
           return if t2.type == :tCOMMENT # Also indicates there's a line break.
 
           is_empty_braces = left_brace?(t1) && right_brace?(t2)

--- a/lib/rubocop/cop/layout/space_inside_parens.rb
+++ b/lib/rubocop/cop/layout/space_inside_parens.rb
@@ -45,15 +45,7 @@ module RuboCop
         end
 
         def parens?(t1, t2)
-          left_parens?(t1) || right_parens?(t2)
-        end
-
-        def left_parens?(token)
-          %i[tLPAREN tLPAREN2].include?(token.type)
-        end
-
-        def right_parens?(token)
-          token.type == :tRPAREN
+          t1.left_parens? || t2.right_parens?
         end
       end
     end

--- a/lib/rubocop/cop/layout/space_inside_parens.rb
+++ b/lib/rubocop/cop/layout/space_inside_parens.rb
@@ -37,7 +37,7 @@ module RuboCop
 
             # If the second token is a comment, that means that a line break
             # follows, and that the rules for space inside don't apply.
-            next if t2.type == :tCOMMENT
+            next if t2.comment?
             next unless t2.line == t1.line && space_after?(t1)
 
             yield range_between(t1.end_pos, t2.begin_pos)

--- a/lib/rubocop/cop/layout/space_inside_parens.rb
+++ b/lib/rubocop/cop/layout/space_inside_parens.rb
@@ -38,9 +38,9 @@ module RuboCop
             # If the second token is a comment, that means that a line break
             # follows, and that the rules for space inside don't apply.
             next if t2.type == :tCOMMENT
-            next unless t2.pos.line == t1.pos.line && space_after?(t1)
+            next unless t2.line == t1.line && space_after?(t1)
 
-            yield range_between(t1.pos.end_pos, t2.pos.begin_pos)
+            yield range_between(t1.end_pos, t2.begin_pos)
           end
         end
 

--- a/lib/rubocop/cop/layout/space_inside_reference_brackets.rb
+++ b/lib/rubocop/cop/layout/space_inside_reference_brackets.rb
@@ -68,12 +68,12 @@ module RuboCop
         end
 
         def left_ref_bracket(node)
-          tokens(node).reverse.find { |t| t.type == :tLBRACK2 }
+          tokens(node).reverse.find(&:left_ref_bracket?)
         end
 
         def right_ref_bracket(node, token)
           i = tokens(node).index(token)
-          tokens(node).slice(i..-1).find { |t| t.type == :tRBRACK }
+          tokens(node).slice(i..-1).find(&:right_bracket?)
         end
       end
     end

--- a/lib/rubocop/cop/layout/trailing_blank_lines.rb
+++ b/lib/rubocop/cop/layout/trailing_blank_lines.rb
@@ -48,7 +48,7 @@ module RuboCop
           return true if sb.source.strip.start_with?('__END__')
           return false if processed_source.tokens.empty?
 
-          extra = sb.source[processed_source.tokens.last.pos.end_pos..-1]
+          extra = sb.source[processed_source.tokens.last.end_pos..-1]
           extra && extra.strip.start_with?('__END__')
         end
 

--- a/lib/rubocop/cop/mixin/space_after_punctuation.rb
+++ b/lib/rubocop/cop/mixin/space_after_punctuation.rb
@@ -25,7 +25,7 @@ module RuboCop
       end
 
       def space_missing?(t1, t2)
-        t1.pos.line == t2.pos.line && t2.pos.column == t1.pos.column + offset
+        t1.line == t2.line && t2.column == t1.column + offset
       end
 
       def space_required_before?(token)

--- a/lib/rubocop/cop/mixin/space_after_punctuation.rb
+++ b/lib/rubocop/cop/mixin/space_after_punctuation.rb
@@ -30,7 +30,7 @@ module RuboCop
 
       def space_required_before?(token)
         !(allowed_type?(token) ||
-          (token.type == :tRCURLY && space_forbidden_before_rcurly?))
+          (token.right_curly_brace? && space_forbidden_before_rcurly?))
       end
 
       def allowed_type?(token)

--- a/lib/rubocop/cop/mixin/space_before_punctuation.rb
+++ b/lib/rubocop/cop/mixin/space_before_punctuation.rb
@@ -32,7 +32,7 @@ module RuboCop
       end
 
       def space_required_after?(token)
-        token.type == :tLCURLY && space_required_after_lcurly?
+        token.left_curly_brace? && space_required_after_lcurly?
       end
 
       def space_required_after_lcurly?

--- a/lib/rubocop/cop/mixin/space_before_punctuation.rb
+++ b/lib/rubocop/cop/mixin/space_before_punctuation.rb
@@ -20,15 +20,15 @@ module RuboCop
           next unless space_missing?(t1, t2)
           next if space_required_after?(t1)
 
-          pos_before_punctuation = range_between(t1.pos.end_pos,
-                                                 t2.pos.begin_pos)
+          pos_before_punctuation = range_between(t1.end_pos,
+                                                 t2.begin_pos)
 
           yield t2, pos_before_punctuation
         end
       end
 
       def space_missing?(t1, t2)
-        t1.pos.line == t2.pos.line && t2.pos.begin_pos > t1.pos.end_pos
+        t1.line == t2.line && t2.begin_pos > t1.end_pos
       end
 
       def space_required_after?(token)

--- a/lib/rubocop/cop/mixin/surrounding_space.rb
+++ b/lib/rubocop/cop/mixin/surrounding_space.rb
@@ -9,12 +9,12 @@ module RuboCop
 
       def space_after?(token)
         # Checks if there is whitespace after token
-        token.pos.source_buffer.source.match(/\G\s/, token.pos.end_pos)
+        token.pos.source_buffer.source.match(/\G\s/, token.end_pos)
       end
 
       def space_before?(token)
         # Checks if there is whitespace before token
-        token.pos.source_buffer.source.match(/\G\s/, token.pos.begin_pos - 1)
+        token.pos.source_buffer.source.match(/\G\s/, token.begin_pos - 1)
       end
 
       def side_space_range(range:, side:)
@@ -52,8 +52,8 @@ module RuboCop
         @token_table ||= begin
           table = {}
           @processed_source.tokens.each_with_index do |t, ix|
-            table[t.pos.line] ||= {}
-            table[t.pos.line][t.pos.column] = ix
+            table[t.line] ||= {}
+            table[t.line][t.column] = ix
           end
           table
         end
@@ -61,8 +61,8 @@ module RuboCop
 
       def tokens(node)
         processed_source.tokens.select do |token|
-          token.pos.end_pos <= node.source_range.end_pos &&
-            token.pos.begin_pos >= node.source_range.begin_pos
+          token.end_pos <= node.source_range.end_pos &&
+            token.begin_pos >= node.source_range.begin_pos
         end
       end
 

--- a/lib/rubocop/cop/style/copyright.rb
+++ b/lib/rubocop/cop/style/copyright.rb
@@ -49,21 +49,20 @@ module RuboCop
         def shebang_token?(processed_source, token_index)
           return false if token_index >= processed_source.tokens.size
           token = processed_source.tokens[token_index]
-          token.type == :tCOMMENT && token.text =~ /^#!.*$/
+          token.comment? && token.text =~ /^#!.*$/
         end
 
         def encoding_token?(processed_source, token_index)
           return false if token_index >= processed_source.tokens.size
           token = processed_source.tokens[token_index]
-          token.type == :tCOMMENT &&
-            token.text =~ /^#.*coding\s?[:=]\s?(?:UTF|utf)-8/
+          token.comment? && token.text =~ /^#.*coding\s?[:=]\s?(?:UTF|utf)-8/
         end
 
         def notice_found?(processed_source)
           notice_found = false
           notice_regexp = Regexp.new(notice)
           processed_source.tokens.each do |token|
-            break unless token.type == :tCOMMENT
+            break unless token.comment?
             notice_found = !(token.text =~ notice_regexp).nil?
             break if notice_found
           end

--- a/lib/rubocop/cop/style/line_end_concatenation.rb
+++ b/lib/rubocop/cop/style/line_end_concatenation.rb
@@ -61,7 +61,7 @@ module RuboCop
                         eligible_operator?(operator) &&
                         eligible_predecessor?(predecessor)
 
-          return if operator.pos.line == successor.pos.line
+          return if operator.line == successor.line
 
           next_successor = token_after_last_string(successor, index)
 

--- a/lib/rubocop/cop/style/semicolon.rb
+++ b/lib/rubocop/cop/style/semicolon.rb
@@ -54,8 +54,8 @@ module RuboCop
 
         def each_semicolon
           tokens_for_lines.each do |line, tokens|
-            yield line, tokens.last.column if tokens.last.type == :tSEMI
-            yield line, tokens.first.column if tokens.first.type == :tSEMI
+            yield line, tokens.last.column if tokens.last.semicolon?
+            yield line, tokens.first.column if tokens.first.semicolon?
           end
         end
 

--- a/lib/rubocop/cop/style/semicolon.rb
+++ b/lib/rubocop/cop/style/semicolon.rb
@@ -54,13 +54,13 @@ module RuboCop
 
         def each_semicolon
           tokens_for_lines.each do |line, tokens|
-            yield line, tokens.last.pos.column if tokens.last.type == :tSEMI
-            yield line, tokens.first.pos.column if tokens.first.type == :tSEMI
+            yield line, tokens.last.column if tokens.last.type == :tSEMI
+            yield line, tokens.first.column if tokens.first.type == :tSEMI
           end
         end
 
         def tokens_for_lines
-          @processed_source.tokens.group_by { |token| token.pos.line }
+          @processed_source.tokens.group_by(&:line)
         end
 
         def convention_on(line, column, autocorrect)

--- a/lib/rubocop/cop/style/trailing_body_on_method_definition.rb
+++ b/lib/rubocop/cop/style/trailing_body_on_method_definition.rb
@@ -92,7 +92,7 @@ module RuboCop
 
         def semicolon
           @semicolon ||= processed_source.tokens.find do |token|
-            token.pos.line == 1 && token.type == :tSEMI
+            token.line == 1 && token.type == :tSEMI
           end
         end
       end

--- a/lib/rubocop/cop/style/trailing_body_on_method_definition.rb
+++ b/lib/rubocop/cop/style/trailing_body_on_method_definition.rb
@@ -92,7 +92,7 @@ module RuboCop
 
         def semicolon
           @semicolon ||= processed_source.tokens.find do |token|
-            token.line == 1 && token.type == :tSEMI
+            token.line == 1 && token.semicolon?
           end
         end
       end

--- a/lib/rubocop/cop/style/trailing_method_end_statement.rb
+++ b/lib/rubocop/cop/style/trailing_method_end_statement.rb
@@ -61,7 +61,7 @@ module RuboCop
         end
 
         def body_and_end_on_same_line?
-          end_token.pos.line == token_before_end.pos.line
+          end_token.line == token_before_end.line
         end
 
         def token_before_end

--- a/lib/rubocop/cop/style/trailing_method_end_statement.rb
+++ b/lib/rubocop/cop/style/trailing_method_end_statement.rb
@@ -86,7 +86,7 @@ module RuboCop
         end
 
         def remove_semicolon(corrector)
-          return unless token_before_end.type == :tSEMI
+          return unless token_before_end.semicolon?
           corrector.remove(token_before_end.pos)
         end
       end

--- a/lib/rubocop/processed_source.rb
+++ b/lib/rubocop/processed_source.rb
@@ -54,7 +54,7 @@ module RuboCop
     def lines
       @lines ||= begin
         all_lines = @buffer.source_lines
-        last_token_line = tokens.any? ? tokens.last.pos.line : all_lines.size
+        last_token_line = tokens.any? ? tokens.last.line : all_lines.size
         result = []
         all_lines.each_with_index do |line, ix|
           break if ix >= last_token_line && line == '__END__'

--- a/lib/rubocop/token.rb
+++ b/lib/rubocop/token.rb
@@ -42,6 +42,18 @@ module RuboCop
       type == :tSEMI
     end
 
+    def left_array_bracket?
+      type == :tLBRACK
+    end
+
+    def left_ref_bracket?
+      type == :tLBRACK2
+    end
+
+    def right_bracket?
+      type == :tRBRACK
+    end
+
     def to_s
       "[[#{@pos.line}, #{@pos.column}], #{@type}, #{@text.inspect}]"
     end

--- a/lib/rubocop/token.rb
+++ b/lib/rubocop/token.rb
@@ -66,6 +66,18 @@ module RuboCop
       type == :tRCURLY
     end
 
+    def left_parens?
+      %i[tLPAREN tLPAREN2].include?(type)
+    end
+
+    def right_parens?
+      type == :tRPAREN
+    end
+
+    def comma?
+      type == :tCOMMA
+    end
+
     def to_s
       "[[#{@pos.line}, #{@pos.column}], #{@type}, #{@text.inspect}]"
     end

--- a/lib/rubocop/token.rb
+++ b/lib/rubocop/token.rb
@@ -54,6 +54,18 @@ module RuboCop
       type == :tRBRACK
     end
 
+    def left_brace?
+      type == :tLBRACE
+    end
+
+    def left_curly_brace?
+      type == :tLCURLY
+    end
+
+    def right_curly_brace?
+      type == :tRCURLY
+    end
+
     def to_s
       "[[#{@pos.line}, #{@pos.column}], #{@type}, #{@text.inspect}]"
     end

--- a/lib/rubocop/token.rb
+++ b/lib/rubocop/token.rb
@@ -18,6 +18,22 @@ module RuboCop
       @text = text.to_s
     end
 
+    def line
+      pos.line
+    end
+
+    def column
+      pos.column
+    end
+
+    def begin_pos
+      pos.begin_pos
+    end
+
+    def end_pos
+      pos.end_pos
+    end
+
     def to_s
       "[[#{@pos.line}, #{@pos.column}], #{@type}, #{@text.inspect}]"
     end

--- a/lib/rubocop/token.rb
+++ b/lib/rubocop/token.rb
@@ -34,6 +34,14 @@ module RuboCop
       pos.end_pos
     end
 
+    def comment?
+      type == :tCOMMENT
+    end
+
+    def semicolon?
+      type == :tSEMI
+    end
+
     def to_s
       "[[#{@pos.line}, #{@pos.column}], #{@type}, #{@text.inspect}]"
     end


### PR DESCRIPTION
When juggling logic with tokens, it very often becomes necessary to reference the `line`, `column`, `start_pos` and `end_pos` of its affiliated `Parser::Source::Range`, or `pos`.  I think there is more room for growth in Token's public API, but this is a good start.  Defining these simple methods helps reduce method chaining and overall method complexity throughout the application.

-----------------

Before submitting the PR make sure the following are checked:

* [ ] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [x] Added tests.  -- Covered by existing tests.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
