### PR TITLE
Restyle example formatting for `Style/RescueStandardError` cop

### DIFF
--- a/lib/rubocop/cop/style/rescue_standard_error.rb
+++ b/lib/rubocop/cop/style/rescue_standard_error.rb
@@ -7,7 +7,23 @@ module RuboCop
       # styles `implicit` and `explicit`. This cop will not register an offense
       # if any error other than `StandardError` is specified.
       #
-      # @example
+      # @example EnforcedStyle: implicit
+      #   # `implicit` will enforce using `rescue` instead of
+      #   # `rescue StandardError`.
+      #
+      #   # bad
+      #   begin
+      #     foo
+      #   rescue StandardError
+      #     bar
+      #   end
+      #
+      #   # good
+      #   begin
+      #     foo
+      #   rescue
+      #     bar
+      #   end
       #
       #   # good
       #   begin
@@ -23,29 +39,9 @@ module RuboCop
       #     bar
       #   end
       #
-      # `implicit` will enforce using `rescue` instead of
-      # `rescue StandardError`.
-      #
-      # @example
-      #
-      #   # bad
-      #   begin
-      #     foo
-      #   rescue StandardError
-      #     bar
-      #   end
-      #
-      #   # good
-      #   begin
-      #     foo
-      #   rescue
-      #     bar
-      #   end
-      #
-      # `explicit` will enforce using `rescue StandardError`
-      # instead of `rescue`.
-      #
-      # @example
+      # @example EnforcedStyle: explicit (default)
+      #   # `explicit` will enforce using `rescue StandardError`
+      #   # instead of `rescue`.
       #
       #   # bad
       #   begin
@@ -58,6 +54,20 @@ module RuboCop
       #   begin
       #     foo
       #   rescue StandardError
+      #     bar
+      #   end
+      #
+      #   # good
+      #   begin
+      #     foo
+      #   rescue OtherError
+      #     bar
+      #   end
+      #
+      #   # good
+      #   begin
+      #     foo
+      #   rescue StandardError, SecurityError
       #     bar
       #   end
       class RescueStandardError < Cop

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -4256,15 +4256,28 @@ This cop checks for rescuing `StandardError`. There are two supported
 styles `implicit` and `explicit`. This cop will not register an offense
 if any error other than `StandardError` is specified.
 
-`implicit` will enforce using `rescue` instead of
-`rescue StandardError`.
-
-`explicit` will enforce using `rescue StandardError`
-instead of `rescue`.
-
 ### Examples
 
+#### EnforcedStyle: implicit
+
 ```ruby
+# `implicit` will enforce using `rescue` instead of
+# `rescue StandardError`.
+
+# bad
+begin
+  foo
+rescue StandardError
+  bar
+end
+
+# good
+begin
+  foo
+rescue
+  bar
+end
+
 # good
 begin
   foo
@@ -4279,22 +4292,12 @@ rescue StandardError, SecurityError
   bar
 end
 ```
-```ruby
-# bad
-begin
-  foo
-rescue StandardError
-  bar
-end
+#### EnforcedStyle: explicit (default)
 
-# good
-begin
-  foo
-rescue
-  bar
-end
-```
 ```ruby
+# `explicit` will enforce using `rescue StandardError`
+# instead of `rescue`.
+
 # bad
 begin
   foo
@@ -4306,6 +4309,20 @@ end
 begin
   foo
 rescue StandardError
+  bar
+end
+
+# good
+begin
+  foo
+rescue OtherError
+  bar
+end
+
+# good
+begin
+  foo
+rescue StandardError, SecurityError
   bar
 end
 ```


### PR DESCRIPTION
Follow up of https://github.com/bbatsov/rubocop/pull/4880#issuecomment-338499947.

This commit is a change of document format for `Style/RescueStandardError` cop.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
