### PR TITLE
Remove redundant example for `Lint/EndAlignment` cop

### DIFF
--- a/lib/rubocop/cop/lint/end_alignment.rb
+++ b/lib/rubocop/cop/lint/end_alignment.rb
@@ -17,13 +17,6 @@ module RuboCop
       # If it's set to `start_of_line`, the `end` shall be aligned with the
       # start of the line where the matching keyword appears.
       #
-      # @example
-      #
-      #   # bad
-      #
-      #   variable = if true
-      #       end
-      #
       # @example EnforcedStyleAlignWith: keyword (default)
       #   # bad
       #

--- a/manual/cops_lint.md
+++ b/manual/cops_lint.md
@@ -722,12 +722,6 @@ start of the line where the matching keyword appears.
 
 ### Examples
 
-```ruby
-# bad
-
-variable = if true
-    end
-```
 #### EnforcedStyleAlignWith: keyword (default)
 
 ```ruby


### PR DESCRIPTION
Follow up for https://github.com/bbatsov/rubocop/commit/818104f73e1a987eb3acf8306da90de4ca8f1b57#diff-2fd929361da19daeec655fc29166b32b.

This commit is a change of document for Lint/EndAlignment cop.
I forgot to remove redundant bad example with the commit mentioned above 💦 

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
