### PR TITLE
CLEANUP - Move space before/after token logic into Token class

### DIFF
--- a/lib/rubocop/cop/layout/space_around_equals_in_parameter_default.rb
+++ b/lib/rubocop/cop/layout/space_around_equals_in_parameter_default.rb
@@ -63,11 +63,11 @@ module RuboCop
         end
 
         def space_on_both_sides?(arg, equals)
-          space_after?(arg) && space_after?(equals)
+          arg.space_after? && equals.space_after?
         end
 
         def no_surrounding_space?(arg, equals)
-          !space_after?(arg) && !space_after?(equals)
+          !arg.space_after? && !equals.space_after?
         end
 
         def message(_)

--- a/lib/rubocop/cop/layout/space_inside_array_literal_brackets.rb
+++ b/lib/rubocop/cop/layout/space_inside_array_literal_brackets.rb
@@ -219,13 +219,13 @@ module RuboCop
           if qualifies_for_compact?(node, left, side: :left)
             range = side_space_range(range: left.pos, side: :right)
             corrector.remove(range)
-          elsif !space_after?(left)
+          elsif !left.space_after?
             corrector.insert_after(left.pos, ' ')
           end
           if qualifies_for_compact?(node, right)
             range = side_space_range(range: right.pos, side: :left)
             corrector.remove(range)
-          elsif !space_before?(right)
+          elsif !right.space_before?
             corrector.insert_before(right.pos, ' ')
           end
         end

--- a/lib/rubocop/cop/layout/space_inside_hash_literal_braces.rb
+++ b/lib/rubocop/cop/layout/space_inside_hash_literal_braces.rb
@@ -133,7 +133,7 @@ module RuboCop
         end
 
         def offense?(t1, expect_space)
-          has_space = space_after?(t1)
+          has_space = t1.space_after?
           expect_space ? !has_space : has_space
         end
 

--- a/lib/rubocop/cop/layout/space_inside_parens.rb
+++ b/lib/rubocop/cop/layout/space_inside_parens.rb
@@ -38,7 +38,7 @@ module RuboCop
             # If the second token is a comment, that means that a line break
             # follows, and that the rules for space inside don't apply.
             next if t2.comment?
-            next unless t2.line == t1.line && space_after?(t1)
+            next unless t2.line == t1.line && t1.space_after?
 
             yield range_between(t1.end_pos, t2.begin_pos)
           end

--- a/lib/rubocop/cop/style/ternary_parentheses.rb
+++ b/lib/rubocop/cop/style/ternary_parentheses.rb
@@ -187,7 +187,7 @@ module RuboCop
         def whitespace_after?(node)
           index = index_of_last_token(node)
           last_token = processed_source.tokens[index]
-          space_after?(last_token)
+          last_token.space_after?
         end
       end
     end

--- a/lib/rubocop/token.rb
+++ b/lib/rubocop/token.rb
@@ -81,5 +81,15 @@ module RuboCop
     def to_s
       "[[#{@pos.line}, #{@pos.column}], #{@type}, #{@text.inspect}]"
     end
+
+    # Checks if there is whitespace after token
+    def space_after?
+      pos.source_buffer.source.match(/\G\s/, end_pos)
+    end
+
+    # Checks if there is whitespace before token
+    def space_before?
+      pos.source_buffer.source.match(/\G\s/, begin_pos - 1)
+    end
   end
 end


### PR DESCRIPTION
This PR moves `SurroundingSpace`'s `space_after?(token)` & `space_before?(token)` methods directly into `Token`.  

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
