### PR TITLE
Add style guide for `Rails/LexicallyScopedActionFilter` cop

### DIFF
--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -1139,6 +1139,7 @@ Rails/InverseOf:
 
 Rails/LexicallyScopedActionFilter:
   Description: "Checks that methods specified in the filter's `only` or `except` options are explicitly defined in the controller."
+  StyleGuide: 'https://github.com/bbatsov/rails-style-guide#lexically-scoped-action-filter'
   Enabled: true
 
 Rails/NotNullColumn:

--- a/manual/cops_rails.md
+++ b/manual/cops_rails.md
@@ -728,6 +728,10 @@ Name | Default value | Configurable values
 --- | --- | ---
 Include | `app/controllers/**/*.rb` | Array
 
+### References
+
+* [https://github.com/bbatsov/rails-style-guide#lexically-scoped-action-filter](https://github.com/bbatsov/rails-style-guide#lexically-scoped-action-filter)
+
 ## Rails/NotNullColumn
 
 Enabled by default | Supports autocorrection


### PR DESCRIPTION
See also: https://github.com/bbatsov/rubocop/pull/5177, https://github.com/bbatsov/rails-style-guide/pull/222

I forgot to add a style guide when adding `Rails/LexicallyScopedActionFilter` cop.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
