### PR TITLE
[Fix #5219] Layout/EmptyLinesAroundArguments excludes lines in block args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 ### Bug fixes
 
 * [#5096](https://github.com/bbatsov/rubocop/issues/5096): Fix incorrect detection and autocorrection of multiple extend/include/prepend. ([@marcandre][])
+* [#5219](https://github.com/bbatsov/rubocop/issues/5219): Fix incorrect empty line detection for block arguments in `Layout/EmptyLinesAroundArguments`. ([@garettarrowood][])
 * [#4662](https://github.com/bbatsov/rubocop/issues/4662): Fix incorrect indent level detection when first line of heredoc is blank. ([@sambostock][])
 * [#5016](https://github.com/bbatsov/rubocop/issues/5016): Fix a false positive for `Style/ConstantName` with constant names using non-ASCII capital letters with accents. ([@timrogers][])
 * [#4866](https://github.com/bbatsov/rubocop/issues/4866): Prevent `Layout/BlockEndNewline` cop from introducing trailing whitespaces. ([@bgeuken][])

--- a/lib/rubocop/cop/layout/empty_lines_around_arguments.rb
+++ b/lib/rubocop/cop/layout/empty_lines_around_arguments.rb
@@ -57,14 +57,20 @@ module RuboCop
 
         def empty_lines(node)
           @empty_lines ||= begin
-            lines = send_lines(node).map.with_index(1).to_a
+            lines = source_lines(node).map.with_index(1).to_a
             lines.select! { |code, _| code == '' }
             lines.map { |_, line| line }
           end
         end
 
-        def send_lines(node)
-          node.source.lines.map { |line| line.delete("\n") }
+        def source_lines(node)
+          source =
+            if node.arguments.last && node.arguments.last.block_type?
+              source_without_block(node, node.arguments.last)
+            else
+              node.source
+            end
+          source.lines.map { |line| line.delete("\n") }
         end
 
         def extra_lines(node)
@@ -72,6 +78,10 @@ module RuboCop
             range = source_range(processed_source.buffer, line, 0)
             yield(range)
           end
+        end
+
+        def source_without_block(node, block_node)
+          node.source.split(block_node.source).first
         end
       end
     end

--- a/spec/rubocop/cop/layout/empty_lines_around_arguments_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_arguments_spec.rb
@@ -63,6 +63,23 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundArguments, :config do
       expect(cop.messages)
         .to eq(['Empty line detected around arguments.'])
     end
+
+    it 'when empty line before a block argument' do
+      inspect_source(<<-RUBY.strip_indent)
+        Foo.prepend(
+          a,
+
+          Module.new do
+            def something; end
+
+            def anything; end
+          end
+        )
+      RUBY
+      expect(cop.offenses.size).to eq 1
+      expect(cop.messages)
+        .to eq(['Empty line detected around arguments.'])
+    end
   end
 
   context 'does not register offense' do
@@ -90,6 +107,17 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundArguments, :config do
         foo(bar,
             [],
             qux: 2)
+      RUBY
+      expect(cop.offenses.empty?).to be(true)
+    end
+
+    it 'when passed block argument with empty line' do
+      inspect_source(<<-RUBY.strip_indent)
+        Foo.prepend(Module.new do
+          def something; end
+
+          def anything; end
+        end)
       RUBY
       expect(cop.offenses.empty?).to be(true)
     end


### PR DESCRIPTION
Resolves issue #5219 . `Layout/EmptyLinesAroundArguments` will now exclude evaluating lines of code contained inside a block argument.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
