### PR TITLE
[#4910] Update examples for `Lint/UriEscapeUnescape` cop

### DIFF
--- a/lib/rubocop/cop/lint/uri_escape_unescape.rb
+++ b/lib/rubocop/cop/lint/uri_escape_unescape.rb
@@ -17,7 +17,8 @@ module RuboCop
       #
       #   # good
       #   CGI.escape('http://example.com')
-      #   URI.encode_www_form('http://example.com')
+      #   URI.encode_www_form([['example', 'param'], ['lang', 'en']])
+      #   URI.encode_www_form(page: 10, locale: 'en')
       #   URI.encode_www_form_component('http://example.com')
       #
       #   # bad

--- a/manual/cops_lint.md
+++ b/manual/cops_lint.md
@@ -2256,7 +2256,8 @@ URI.encode('http://example.com')
 
 # good
 CGI.escape('http://example.com')
-URI.encode_www_form('http://example.com')
+URI.encode_www_form([['example', 'param'], ['lang', 'en']])
+URI.encode_www_form(page: 10, locale: 'en')
 URI.encode_www_form_component('http://example.com')
 
 # bad


### PR DESCRIPTION
  Remove confusing example in the cop.
`URI.encode_www_form` does not accept string as a param.

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
