### PR TITLE
[Fix #5224] Solve false EmptyLinesAroundArgument offenses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#5241](https://github.com/bbatsov/rubocop/issues/5241): Fix an error for `Layout/AlignHash` when using a hash including only a keyword splat. ([@wata727][])
 * [#5245](https://github.com/bbatsov/rubocop/issues/5245): Make `Style/FormatStringToken` to allow regexp token. ([@pocke][])
+* [#5224](https://github.com/bbatsov/rubocop/pull/5224): Fix false positives for `Layout/EmptyLinesAroundArguments` operating on blocks. ([@garettarrowood][])
 * [#5234](https://github.com/bbatsov/rubocop/issues/5234): Fix a false positive for `Rails/HasManyOrHasOneDependent` when using `class_name` option. ([@koic][])
 
 ### Changes

--- a/spec/rubocop/cop/layout/empty_lines_around_arguments_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_arguments_spec.rb
@@ -3,8 +3,8 @@
 describe RuboCop::Cop::Layout::EmptyLinesAroundArguments, :config do
   subject(:cop) { described_class.new(config) }
 
-  context 'registers offense' do
-    it 'when empty line detected at top' do
+  context 'when extra lines' do
+    it 'registers offense for empty line before arg' do
       inspect_source(<<-RUBY.strip_indent)
         foo(
 
@@ -15,7 +15,7 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundArguments, :config do
         .to eq(['Empty line detected around arguments.'])
     end
 
-    it 'when empty line detected at bottom' do
+    it 'registers offense for empty line after arg' do
       inspect_source(<<-RUBY.strip_indent)
         bar(
           [baz, qux]
@@ -26,9 +26,9 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundArguments, :config do
         .to eq(['Empty line detected around arguments.'])
     end
 
-    it 'when empty line detected in the middle' do
+    it 'registers offense for empty line between args' do
       inspect_source(<<-RUBY.strip_indent)
-        do_something(
+        foo.do_something(
           baz,
 
           qux: 0
@@ -38,7 +38,19 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundArguments, :config do
         .to eq(['Empty line detected around arguments.'])
     end
 
-    it 'when multiple empty lines are detected' do
+    it 'registers offense for empty line in-between one arg' do
+      inspect_source(<<-RUBY.strip_indent)
+        do_stuff([
+          "some text",
+
+          "some more text"
+        ])
+      RUBY
+      expect(cop.messages)
+        .to eq(['Empty line detected around arguments.'])
+    end
+
+    it 'registers offenses when multiple empty lines are detected' do
       inspect_source(<<-RUBY.strip_indent)
         foo(
           baz,
@@ -54,7 +66,7 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundArguments, :config do
         .to eq(['Empty line detected around arguments.'])
     end
 
-    it 'when args start on defintion line' do
+    it 'registers offense when args start on definition line' do
       inspect_source(<<-RUBY.strip_indent)
         foo(biz,
 
@@ -64,7 +76,7 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundArguments, :config do
         .to eq(['Empty line detected around arguments.'])
     end
 
-    it 'when empty line before a block argument' do
+    it 'registers offense when empty line between normal arg & block arg' do
       inspect_source(<<-RUBY.strip_indent)
         Foo.prepend(
           a,
@@ -80,51 +92,52 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundArguments, :config do
       expect(cop.messages)
         .to eq(['Empty line detected around arguments.'])
     end
-  end
 
-  context 'does not register offense' do
-    it 'for one line methods' do
+    it 'registers offense on correct line for single offense example' do
       inspect_source(<<-RUBY.strip_indent)
-        foo(bar)
+        class Foo
+
+          include Bar
+
+          def baz(qux)
+            fizz(
+              qux,
+
+              10
+            )
+          end
+        end
       RUBY
-      expect(cop.offenses.empty?).to be(true)
+      expect(cop.offenses.size).to eq 1
+      expect(cop.offenses.first.location.line).to eq 8
+      expect(cop.messages.uniq)
+        .to eq(['Empty line detected around arguments.'])
     end
 
-    it 'for multiple correctly listed mixed args' do
+    it 'registers offense on correct lines for multi-offense example' do
       inspect_source(<<-RUBY.strip_indent)
-        foo(
-          bar,
-          [],
-          baz = nil,
-          qux: 2
+        something(1, 5)
+        something_else
+
+        foo(biz,
+
+            qux)
+
+        quux.map do
+
+        end.another.thing(
+
+          [baz]
         )
       RUBY
-      expect(cop.offenses.empty?).to be(true)
+      expect(cop.offenses.size).to eq 2
+      expect(cop.offenses[0].location.line).to eq 5
+      expect(cop.offenses[1].location.line).to eq 11
+      expect(cop.messages.uniq)
+        .to eq(['Empty line detected around arguments.'])
     end
 
-    it 'for correctly listed args starting on defintion line' do
-      inspect_source(<<-RUBY.strip_indent)
-        foo(bar,
-            [],
-            qux: 2)
-      RUBY
-      expect(cop.offenses.empty?).to be(true)
-    end
-
-    it 'when passed block argument with empty line' do
-      inspect_source(<<-RUBY.strip_indent)
-        Foo.prepend(Module.new do
-          def something; end
-
-          def anything; end
-        end)
-      RUBY
-      expect(cop.offenses.empty?).to be(true)
-    end
-  end
-
-  context 'autocorrects' do
-    it 'when empty line detected at top' do
+    it 'autocorrects empty line detected at top' do
       corrected = autocorrect_source(['foo(',
                                       '',
                                       '  bar',
@@ -134,7 +147,7 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundArguments, :config do
                                ')'].join("\n")
     end
 
-    it 'when empty line detected at bottom' do
+    it 'autocorrects empty line detected at bottom' do
       corrected = autocorrect_source(['foo(',
                                       '  baz: 1',
                                       '',
@@ -144,7 +157,7 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundArguments, :config do
                                ')'].join("\n")
     end
 
-    it 'when empty line detected in the middle' do
+    it 'autocorrects empty line detected in the middle' do
       corrected = autocorrect_source(['do_something(',
                                       '  [baz],',
                                       '',
@@ -156,7 +169,19 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundArguments, :config do
                                ')'].join("\n")
     end
 
-    it 'when multiple empty lines are detected' do
+    it 'autocorrects empty line in-between one arg' do
+      corrected = autocorrect_source(['do_stuff([',
+                                      "  'some text',",
+                                      '',
+                                      "  'some more text'",
+                                      '])'].join("\n"))
+      expect(corrected).to eq ['do_stuff([',
+                               "  'some text',",
+                               "  'some more text'",
+                               '])'].join("\n")
+    end
+
+    it 'autocorrects multiple empty lines' do
       corrected = autocorrect_source(['do_stuff(',
                                       '  baz,',
                                       '',
@@ -172,12 +197,76 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundArguments, :config do
                                ')'].join("\n")
     end
 
-    it 'when args start on defintion line' do
+    it 'autocorrects args that start on definition line' do
       corrected = autocorrect_source(['bar(qux,',
                                       '',
                                       '    78)'].join("\n"))
       expect(corrected).to eq ['bar(qux,',
                                '    78)'].join("\n")
+    end
+  end
+
+  context 'when no extra lines' do
+    it 'accpets one line methods' do
+      inspect_source(<<-RUBY.strip_indent)
+        foo(bar)
+      RUBY
+      expect(cop.offenses.empty?).to be(true)
+    end
+
+    it 'accepts multiple listed mixed args' do
+      inspect_source(<<-RUBY.strip_indent)
+        foo(
+          bar,
+          [],
+          baz = nil,
+          qux: 2
+        )
+      RUBY
+      expect(cop.offenses.empty?).to be(true)
+    end
+
+    it 'accepts listed args starting on defintion line' do
+      inspect_source(<<-RUBY.strip_indent)
+        foo(bar,
+            [],
+            qux: 2)
+      RUBY
+      expect(cop.offenses.empty?).to be(true)
+    end
+
+    it 'accepts block argument with empty line' do
+      inspect_source(<<-RUBY.strip_indent)
+        Foo.prepend(Module.new do
+          def something; end
+
+          def anything; end
+        end)
+      RUBY
+      expect(cop.offenses.empty?).to be(true)
+    end
+
+    it 'accepts method with argument that trails off block' do
+      inspect_source(<<-RUBY.strip_indent)
+        fred.map do
+          <<-EOT
+            bar
+
+            foo
+          EOT
+        end.join("\n")
+      RUBY
+      expect(cop.offenses.empty?).to be(true)
+    end
+
+    it 'accepts method with no arguments that trails off block' do
+      inspect_source(<<-RUBY.strip_indent)
+        foo.baz do
+
+          bar
+        end.compact
+      RUBY
+      expect(cop.offenses.empty?).to be(true)
     end
   end
 end

--- a/spec/rubocop/cop/layout/indent_array_spec.rb
+++ b/spec/rubocop/cop/layout/indent_array_spec.rb
@@ -298,7 +298,6 @@ describe RuboCop::Cop::Layout::IndentArray do
           expect(cop.messages)
             .to eq(['Use 2 spaces for indentation in an array, relative to ' \
                     'the start of the line where the left square bracket is.',
-
                     'Indent the right bracket the same as the start of the ' \
                     'line where the left bracket is.'])
           expect(cop.config_to_allow_offenses)

--- a/spec/rubocop/cop/layout/indent_hash_spec.rb
+++ b/spec/rubocop/cop/layout/indent_hash_spec.rb
@@ -373,7 +373,6 @@ describe RuboCop::Cop::Layout::IndentHash do
           expect(cop.messages)
             .to eq(['Use 2 spaces for indentation in a hash, relative to the' \
                     ' start of the line where the left curly brace is.',
-
                     'Indent the right brace the same as the start of the ' \
                     'line where the left brace is.'])
           expect(cop.config_to_allow_offenses)


### PR DESCRIPTION
This resolves all the odd bugs reported in #5229 & #5224 .

The problems can be boiled down to 2 things.

1. This line of code, `lines = source_lines(node).map.with_index(1).to_a`, was attaching lines to each string of source code in the `send` starting with `1`.  Then this arbitrary line number was getting passed to `range = source_range(processed_source.buffer, line, 0)` and thus grabbing an entirely wrong line to report an offense/autocorrect.

The reason we didn't see this in the tests is that every example, every `processed_source`, started on line 1. I was blind to the issue.

[This test](https://github.com/bbatsov/rubocop/pull/5231/files#diff-569b9b5f892ab8676c337e5048b56ebbR67) has been added to verify the issue is now resolved.

2. Even with reporting wrong line numbers, this cop was also grabbing too many lines of code.

Grabbing the source based on the start and stop of the `send` node itself meant the range included all the previous methods it was chained to. [This `first_line(node)` method](https://github.com/bbatsov/rubocop/pull/5231/files#diff-569b9b5f892ab8676c337e5048b56ebbR67) checks if the `send` has a receiver. If so, it starts the check at that last of the receiver. [`last_line(node`)](https://github.com/bbatsov/rubocop/pull/5231/files#diff-569b9b5f892ab8676c337e5048b56ebbR67) reports an earlier end line if the last/only arg is a block.

This bugfix picked up 2 offenses in rubocop that were missed before. Happy to see that the lines were reported accurately :).

```
Offenses:

spec/rubocop/cop/layout/indent_array_spec.rb:301:1: C: Layout/EmptyLinesAroundArguments: Empty line detected around arguments.
spec/rubocop/cop/layout/indent_hash_spec.rb:376:1: C: Layout/EmptyLinesAroundArguments: Empty line detected around arguments.

1071 files inspected, 2 offenses detected
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
