### PR TITLE
Fix Rails/Presence cop when #present? or #blank? is used in if or unless modifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [#5234](https://github.com/bbatsov/rubocop/issues/5234): Fix a false positive for `Rails/HasManyOrHasOneDependent` when using `class_name` option. ([@koic][])
 * [#5273](https://github.com/bbatsov/rubocop/issues/5273): Fix `Style/EvalWithLocation` reporting bad line offset. ([@pocke][])
 * [#5228](https://github.com/bbatsov/rubocop/issues/5228): Handle overridden `Metrics/LineLength:Max` for `--auto-gen-config`. ([@jonas054][])
+* [#5238](https://github.com/bbatsov/rubocop/pull/5238): Fix error when #present? or #blank? is used in if or unless modifier. ([@eitoball][])
 
 ### Changes
 

--- a/lib/rubocop/cop/rails/presence.rb
+++ b/lib/rubocop/cop/rails/presence.rb
@@ -96,7 +96,7 @@ module RuboCop
         private
 
         def replacement(receiver, other)
-          or_source = other.nil_type? ? '' : " || #{other.source}"
+          or_source = other.nil? || other.nil_type? ? '' : " || #{other.source}"
           "#{receiver.source}.presence" + or_source
         end
       end

--- a/spec/rubocop/cop/rails/presence_spec.rb
+++ b/spec/rubocop/cop/rails/presence_spec.rb
@@ -50,6 +50,9 @@ describe RuboCop::Cop::Rails::Presence do
     end
   RUBY
 
+  it_behaves_like :offense, 'a if a.present?', 'a.presence', 1, 1
+  it_behaves_like :offense, 'a unless a.blank?', 'a.presence', 1, 1
+
   it 'does not register an offense when using `#presence`' do
     expect_no_offenses(<<-RUBY.strip_indent)
       a.presence
@@ -66,5 +69,12 @@ describe RuboCop::Cop::Rails::Presence do
     expect_no_offenses(<<-RUBY.strip_indent)
       a.blank? ? nil : b
     RUBY
+  end
+
+  it 'does not register an offense when if or unless modifier is used ' do
+    [
+      'a if a.blank?',
+      'a unless a.present?'
+    ].each { |source| expect_no_offenses(source) }
   end
 end


### PR DESCRIPTION
This PR should fix `Rails/Presence` cop when `#present?` on `#blank?` is used in `if` or `unless` modifier.

Below is a sample output that represents bug.

<details>

```
$ cat sample.rb
# frozen_string_literal: true

v if v.present?
$ rubocop -c .rubocop_empty.yml -d --rails sample.rb
bundle exec rubocop -c .rubocop_empty.yml -d --rails sample.rb
configuration from /.../.rubocop_empty.yml
Default configuration from /.../gems/rubocop-0.52.0/config/default.yml                                             Inheriting configuration from /.../gems/rubocop-0.52.0/config/enabled.yml
Inheriting configuration from /.../gems/rubocop-0.52.0/config/disabled.yml
Inspecting 1 file
Scanning /.../sample.rb
An error occurred while Rails/Presence cop was inspecting /.../sample.rb:3:0.
undefined method `nil_type?' for nil:NilClass
/.../gems/rubocop-0.52.0/lib/rubocop/cop/rails/presence.rb:99:in `replacement'
/.../gems/rubocop-0.52.0/lib/rubocop/cop/rails/presence.rb:80:in `on_if'
<snip>
.

1 file inspected, no offenses detected

1 error occurred:
An error occurred while Rails/Presence cop was inspecting /.../sample.rb:3:0.
Errors are usually caused by RuboCop bugs.
Please, report your problems to RuboCop's issue tracker.
Mention the following information in the issue report:
0.52.0 (using Parser 2.4.0.2, running on ruby 2.4.2 x86_64-darwin16)
Finished in 0.22184800007380545 seconds
```

</details>

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] ~~Commit message starts with `[Fix #issue-number]` (if the related issue exists).~~
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
