### PR TITLE
Make `Style/StringHashKeys` to accepts environment variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * Rename `Lint/UnneededDisable` to `Lint/UnneededCopDisableDirective`. ([@garettarrowood][])
 * [#5365](https://github.com/bbatsov/rubocop/pull/5365): Add `*.gemfile` to Bundler cop target. ([@sue445][])
 * [#4477](https://github.com/bbatsov/rubocop/issues/4477): Warn when user configuration overrides other user configuration. ([@jonas054][])
+* [#5240](https://github.com/bbatsov/rubocop/pull/5240): Make `Style/StringHashKeys` to accepts environment variables. ([@pocke][])
 
 ## 0.52.1 (2017-12-27)
 

--- a/lib/rubocop/cop/style/string_hash_keys.rb
+++ b/lib/rubocop/cop/style/string_hash_keys.rb
@@ -19,8 +19,20 @@ module RuboCop
           (pair (str _) _)
         PATTERN
 
+        def_node_matcher :receive_environments_method?, <<-PATTERN
+          {
+            ^^(send (const {nil? cbase} :IO) :popen ...)
+            ^^(send (const {nil? cbase} :Open3)
+                {:capture2 :capture2e :capture3 :popen2 :popen2e :popen3} ...)
+            ^^^(send (const {nil? cbase} :Open3)
+                {:pipeline :pipeline_r :pipeline_rw :pipeline_start :pipeline_w} ...)
+            ^^(send {nil? (const {nil? cbase} :Kernel)} {:spawn :system} ...)
+          }
+        PATTERN
+
         def on_pair(node)
           return unless string_hash_key?(node)
+          return if receive_environments_method?(node)
           add_offense(node.key)
         end
 

--- a/spec/rubocop/cop/style/string_hash_keys_spec.rb
+++ b/spec/rubocop/cop/style/string_hash_keys_spec.rb
@@ -39,4 +39,22 @@ RSpec.describe RuboCop::Cop::Style::StringHashKeys do
       { one: 1 }
     RUBY
   end
+
+  it 'does not register an offense when string key is used in IO.popen' do
+    expect_no_offenses(<<-RUBY.strip_indent)
+      IO.popen({"RUBYOPT" => '-w'}, 'ruby', 'foo.rb')
+    RUBY
+  end
+
+  it 'does not register an offense when string key is used in Open3.capture3' do
+    expect_no_offenses(<<-RUBY.strip_indent)
+      Open3.capture3({"RUBYOPT" => '-w'}, 'ruby', 'foo.rb')
+    RUBY
+  end
+
+  it 'does not register an offense when string key is used in Open3.pipeline' do
+    expect_no_offenses(<<-RUBY.strip_indent)
+      Open3.pipeline([{"RUBYOPT" => '-w'}, 'ruby', 'foo.rb'], ['wc', '-l'])
+    RUBY
+  end
 end


### PR DESCRIPTION
Command execution methods, such as `system`, `capture3`, receive environments variables as a Hash.
And the hash keys should be strings.

```ruby
Open3.capture3({'FOO' => 'a'}, 'ls') # ok
Open3.capture3({:FOO => 'a'}, 'ls') # TypeError: no implicit conversion of Symbol into String
```

So `Style/StringHashKeys` should allow the environment variables.


-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
