### PR TITLE
[Fix #5239] Fix an error for `Layout/AlignHash`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#5241](https://github.com/bbatsov/rubocop/issues/5241): Fix an error for `Layout/AlignHash` when using a hash including only a keyword splat. ([@wata727][])
+
 ## 0.52.0 (2017-12-12)
 
 ### New features

--- a/lib/rubocop/cop/layout/align_hash.rb
+++ b/lib/rubocop/cop/layout/align_hash.rb
@@ -116,7 +116,7 @@ module RuboCop
 
         def on_hash(node)
           return if ignored_node?(node)
-          return if node.empty? || node.single_line?
+          return if node.pairs.empty? || node.single_line?
 
           return unless alignment_for_hash_rockets.checkable_layout?(node) &&
                         alignment_for_colons.checkable_layout?(node)

--- a/spec/rubocop/cop/layout/align_hash_spec.rb
+++ b/spec/rubocop/cop/layout/align_hash_spec.rb
@@ -339,6 +339,14 @@ describe RuboCop::Cop::Layout::AlignHash, :config do
       RUBY
     end
 
+    it 'accepts a keyword splat only hash' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        hash = {
+          **kw
+        }
+      RUBY
+    end
+
     it 'registers an offense for misaligned hash values' do
       expect_offense(<<-RUBY.strip_indent)
         hash1 = {


### PR DESCRIPTION
Fixes #5239
See also #5021

A hash including only a keyword splat, `node.empty?` returns false, but `node.pairs.empty?` returns true. Therefore, check whether the pairs exist, not whether the hash is empty.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
