### PR TITLE
[Fix #5245] Make `Style/FormatStringToken` to allow regexp token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bug fixes
 
 * [#5241](https://github.com/bbatsov/rubocop/issues/5241): Fix an error for `Layout/AlignHash` when using a hash including only a keyword splat. ([@wata727][])
+* [#5245](https://github.com/bbatsov/rubocop/issues/5245): Make `Style/FormatStringToken` to allow regexp token. ([@pocke][])
 
 ## 0.52.0 (2017-12-12)
 

--- a/lib/rubocop/cop/style/format_string_token.rb
+++ b/lib/rubocop/cop/style/format_string_token.rb
@@ -45,7 +45,7 @@ module RuboCop
         TOKEN_PATTERN = Regexp.union(STYLE_PATTERNS.values)
 
         def on_str(node)
-          return if node.each_ancestor(:xstr).any?
+          return if node.each_ancestor(:xstr, :regexp).any?
 
           tokens(node) do |detected_style, token_range|
             if detected_style == style

--- a/spec/rubocop/cop/style/format_string_token_spec.rb
+++ b/spec/rubocop/cop/style/format_string_token_spec.rb
@@ -85,6 +85,14 @@ describe RuboCop::Cop::Style::FormatStringToken, :config do
     expect_no_offenses('`echo "%s %<annotated>s %{template}"`')
   end
 
+  it 'ignores regexp' do
+    expect_no_offenses('/foo bar %u/')
+  end
+
+  it 'ignores `%r` regexp' do
+    expect_no_offenses('%r{foo bar %u}')
+  end
+
   it 'handles dstrs' do
     inspect_source('"c#{b}%{template}"')
     expect(cop.highlights).to eql(['%{template}'])


### PR DESCRIPTION
See #5245 

`regexp` node has `str` node. So the cop should ignore `regexp` node also.


```ruby
$ ruby-parse -e /%u/
(regexp
  (str "%u")
  (regopt))
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
