### PR TITLE
CLEANUP - More descriptive names for Node# empty? & length

### DIFF
--- a/lib/rubocop/ast/node.rb
+++ b/lib/rubocop/ast/node.rb
@@ -331,11 +331,11 @@ module RuboCop
         source.lines.grep(/\S/).size
       end
 
-      def empty?
-        length.zero?
+      def empty_source?
+        source_length.zero?
       end
 
-      def length
+      def source_length
         source_range ? source_range.size : 0
       end
 

--- a/lib/rubocop/cop/mixin/statement_modifier.rb
+++ b/lib/rubocop/cop/mixin/statement_modifier.rb
@@ -19,7 +19,7 @@ module RuboCop
 
       def non_eligible_body?(body)
         body.nil? ||
-          body.empty? ||
+          body.empty_source? ||
           body.begin_type? ||
           commented?(body.source_range)
       end
@@ -30,7 +30,7 @@ module RuboCop
 
       def modifier_fits_on_single_line?(node)
         modifier_length = length_in_modifier_form(node, node.condition,
-                                                  node.body.length)
+                                                  node.body.source_length)
 
         modifier_length <= max_line_length
       end


### PR DESCRIPTION
Per @Drenmi 's comment [here](https://github.com/bbatsov/rubocop/pull/5204#issuecomment-351470316), these two recently moved methods require more specific naming.

Full comment:

> Using #length and #empty? directly on Node is going to conflate two different ideas. The node data structure often contains nested nodes (i.e. the node is a container, for which #length and #empty already has a definition.) The #length and #empty? here actually apply to the node's source code string. It will also conflict with the CollectionNode extension. 🙂

> Perhaps #source_length and something else would be better?

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests. _coverage in `style/if_unless_modifier_spec.rb`_
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
