### PR TITLE
CLEANUP - Add first_ & last_line delegators to node

### DIFF
--- a/lib/rubocop/ast/node.rb
+++ b/lib/rubocop/ast/node.rb
@@ -259,6 +259,27 @@ module RuboCop
         loc.expression
       end
 
+      def first_line
+        loc.line
+      end
+
+      def last_line
+        loc.last_line
+      end
+
+      def line_count
+        return 0 unless source_range
+        source_range.last_line - source_range.first_line + 1
+      end
+
+      def nonempty_line_count
+        source.lines.grep(/\S/).size
+      end
+
+      def source_length
+        source_range ? source_range.size : 0
+      end
+
       ## Destructuring
 
       def_node_matcher :receiver, <<-PATTERN
@@ -322,21 +343,8 @@ module RuboCop
         line_count == 1
       end
 
-      def line_count
-        return 0 unless source_range
-        source_range.last_line - source_range.first_line + 1
-      end
-
-      def nonempty_line_count
-        source.lines.grep(/\S/).size
-      end
-
       def empty_source?
         source_length.zero?
-      end
-
-      def source_length
-        source_range ? source_range.size : 0
       end
 
       def asgn_method_call?

--- a/lib/rubocop/cop/bundler/duplicated_gem.rb
+++ b/lib/rubocop/cop/bundler/duplicated_gem.rb
@@ -37,7 +37,7 @@ module RuboCop
               register_offense(
                 node,
                 node.first_argument.to_a.first,
-                nodes.first.loc.line
+                nodes.first.first_line
               )
             end
           end
@@ -57,7 +57,7 @@ module RuboCop
         def register_offense(node, gem_name, line_of_first_occurrence)
           line_range = node.loc.column...node.loc.last_column
           offense_location =
-            source_range(processed_source.buffer, node.loc.line, line_range)
+            source_range(processed_source.buffer, node.first_line, line_range)
           message = format(
             MSG,
             gem_name: gem_name,

--- a/lib/rubocop/cop/commissioner.rb
+++ b/lib/rubocop/cop/commissioner.rb
@@ -110,7 +110,7 @@ module RuboCop
       rescue StandardError => e
         raise e if @options[:raise_error]
         if node
-          line = node.loc.line
+          line = node.first_line
           column = node.loc.column
         end
         error = CopError.new(e, line, column)

--- a/lib/rubocop/cop/gemspec/duplicated_assignment.rb
+++ b/lib/rubocop/cop/gemspec/duplicated_assignment.rb
@@ -60,7 +60,7 @@ module RuboCop
               register_offense(
                 node,
                 node.method_name,
-                nodes.first.loc.line
+                nodes.first.first_line
               )
             end
           end
@@ -88,7 +88,7 @@ module RuboCop
         def register_offense(node, assignment, line_of_first_occurrence)
           line_range = node.loc.column...node.loc.last_column
           offense_location =
-            source_range(processed_source.buffer, node.loc.line, line_range)
+            source_range(processed_source.buffer, node.first_line, line_range)
           message = format(
             MSG,
             assignment: assignment,

--- a/lib/rubocop/cop/layout/class_structure.rb
+++ b/lib/rubocop/cop/layout/class_structure.rb
@@ -264,7 +264,7 @@ module RuboCop
         end
 
         def begin_pos_with_comment(node)
-          annotation_line = node.loc.line - 1
+          annotation_line = node.first_line - 1
           first_comment = nil
 
           comments_before_line(annotation_line).reverse_each do |comment|
@@ -278,7 +278,7 @@ module RuboCop
         end
 
         def start_line_position(node)
-          buffer.line_range(node.loc.line).begin_pos - 1
+          buffer.line_range(node.first_line).begin_pos - 1
         end
 
         def comments_before_line(line)

--- a/lib/rubocop/cop/layout/empty_lines_around_access_modifier.rb
+++ b/lib/rubocop/cop/layout/empty_lines_around_access_modifier.rb
@@ -37,7 +37,7 @@ module RuboCop
 
         def autocorrect(node)
           lambda do |corrector|
-            send_line = node.loc.line
+            send_line = node.first_line
             previous_line = processed_source[send_line - 2]
             next_line = processed_source[send_line]
             line = range_by_whole_lines(node.source_range)
@@ -71,7 +71,7 @@ module RuboCop
         end
 
         def empty_lines_around?(node)
-          send_line = node.loc.line
+          send_line = node.first_line
           previous_line = previous_line_ignoring_comments(processed_source,
                                                           send_line)
           next_line = processed_source[send_line]
@@ -92,7 +92,7 @@ module RuboCop
         end
 
         def message(node)
-          previous_line = processed_source[node.loc.line - 2]
+          previous_line = processed_source[node.first_line - 2]
 
           if block_start?(previous_line) ||
              class_def?(previous_line)

--- a/lib/rubocop/cop/layout/first_parameter_indentation.rb
+++ b/lib/rubocop/cop/layout/first_parameter_indentation.rb
@@ -54,7 +54,7 @@ module RuboCop
           if special_inner_call_indentation?(node)
             column_of(base_range(node, node.first_argument))
           else
-            previous_code_line(node.first_argument.loc.line) =~ /\S/
+            previous_code_line(node.first_argument.first_line) =~ /\S/
           end
         end
 

--- a/lib/rubocop/cop/layout/indent_assignment.rb
+++ b/lib/rubocop/cop/layout/indent_assignment.rb
@@ -31,7 +31,7 @@ module RuboCop
         def check_assignment(node, rhs)
           return unless rhs
           return unless node.loc.operator
-          return if node.loc.operator.line == rhs.loc.line
+          return if node.loc.operator.line == rhs.first_line
 
           base = display_column(node.source_range)
           check_alignment([rhs], base + configured_indentation_width)

--- a/lib/rubocop/cop/layout/multiline_assignment_layout.rb
+++ b/lib/rubocop/cop/layout/multiline_assignment_layout.rb
@@ -44,7 +44,7 @@ module RuboCop
         def check_assignment(node, rhs)
           return unless rhs
           return unless supported_types.include?(rhs.type)
-          return if rhs.loc.first_line == rhs.loc.last_line
+          return if rhs.first_line == rhs.last_line
 
           case style
           when :new_line
@@ -55,13 +55,13 @@ module RuboCop
         end
 
         def check_new_line_offense(node, rhs)
-          return unless node.loc.operator.line == rhs.loc.line
+          return unless node.loc.operator.line == rhs.first_line
 
           add_offense(node, message: NEW_LINE_OFFENSE)
         end
 
         def check_same_line_offense(node, rhs)
-          return unless node.loc.operator.line != rhs.loc.line
+          return unless node.loc.operator.line != rhs.first_line
 
           add_offense(node, message: SAME_LINE_OFFENSE)
         end

--- a/lib/rubocop/cop/layout/multiline_block_layout.rb
+++ b/lib/rubocop/cop/layout/multiline_block_layout.rb
@@ -48,7 +48,7 @@ module RuboCop
             add_offense_for_expression(node, node.arguments, ARG_MSG)
           end
 
-          return unless node.body && node.loc.begin.line == node.body.loc.line
+          return unless node.body && node.loc.begin.line == node.body.first_line
 
           add_offense_for_expression(node, node.body, MSG)
         end
@@ -64,7 +64,7 @@ module RuboCop
 
             expr_before_body ||= node.loc.begin
 
-            if expr_before_body.line == node.body.loc.line
+            if expr_before_body.line == node.body.first_line
               autocorrect_body(corrector, node, node.body)
             end
           end

--- a/lib/rubocop/cop/layout/multiline_method_call_indentation.rb
+++ b/lib/rubocop/cop/layout/multiline_method_call_indentation.rb
@@ -191,7 +191,7 @@ module RuboCop
           node = node.parent
           node = node.parent until node.loc.dot
 
-          return if node.loc.dot.line != node.loc.line
+          return if node.loc.dot.line != node.first_line
           node
         end
 

--- a/lib/rubocop/cop/layout/multiline_operation_indentation.rb
+++ b/lib/rubocop/cop/layout/multiline_operation_indentation.rb
@@ -54,7 +54,7 @@ module RuboCop
 
         def offending_range(node, lhs, rhs, given_style)
           return false unless begins_its_line?(rhs)
-          return false if lhs.loc.line == rhs.line # Needed for unary op.
+          return false if lhs.first_line == rhs.line # Needed for unary op.
           return false if not_for_this_cop?(node)
 
           correct_column = if should_align?(node, rhs, given_style)

--- a/lib/rubocop/cop/lint/block_alignment.rb
+++ b/lib/rubocop/cop/lint/block_alignment.rb
@@ -124,7 +124,7 @@ module RuboCop
         end
 
         def disqualified_parent?(parent, node)
-          parent && parent.loc && parent.loc.line != node.loc.line &&
+          parent && parent.loc && parent.first_line != node.first_line &&
             !parent.masgn_type?
         end
 

--- a/lib/rubocop/cop/lint/implicit_string_concatenation.rb
+++ b/lib/rubocop/cop/lint/implicit_string_concatenation.rb
@@ -49,7 +49,7 @@ module RuboCop
           node.children.each_cons(2) do |child1, child2|
             # `'abc' 'def'` -> (dstr (str "abc") (str "def"))
             next unless string_literal?(child1) && string_literal?(child2)
-            next unless child1.loc.last_line == child2.loc.line
+            next unless child1.last_line == child2.first_line
 
             # Make sure we don't flag a string literal which simply has
             # embedded newlines

--- a/lib/rubocop/cop/mixin/def_node.rb
+++ b/lib/rubocop/cop/mixin/def_node.rb
@@ -14,7 +14,7 @@ module RuboCop
       end
 
       def preceding_non_public_modifier?(node)
-        stripped_source_upto(node.loc.line).any? do |line|
+        stripped_source_upto(node.first_line).any? do |line|
           NON_PUBLIC_MODIFIERS.include?(line)
         end
       end

--- a/lib/rubocop/cop/mixin/empty_lines_around_body.rb
+++ b/lib/rubocop/cop/mixin/empty_lines_around_body.rb
@@ -111,7 +111,7 @@ module RuboCop
           node = first_empty_line_required_child(body)
           return unless node
 
-          line = previous_line_ignoring_comments(node.loc.first_line)
+          line = previous_line_ignoring_comments(node.first_line)
           return if processed_source[line].empty?
 
           range = source_range(processed_source.buffer, line + 2, 0)

--- a/lib/rubocop/cop/mixin/end_keyword_alignment.rb
+++ b/lib/rubocop/cop/mixin/end_keyword_alignment.rb
@@ -58,7 +58,7 @@ module RuboCop
       end
 
       def line_break_before_keyword?(whole_expression, rhs)
-        rhs.loc.line > whole_expression.line
+        rhs.first_line > whole_expression.line
       end
 
       def align(node, align_to)

--- a/lib/rubocop/cop/mixin/first_element_line_break.rb
+++ b/lib/rubocop/cop/mixin/first_element_line_break.rb
@@ -27,23 +27,23 @@ module RuboCop
       def check_children_line_break(node, children, start = node)
         return if children.size < 2
 
-        line = start.loc.line
+        line = start.first_line
 
         min = first_by_line(children)
-        return if line != min.loc.first_line
+        return if line != min.first_line
 
         max = last_by_line(children)
-        return if line == max.loc.last_line
+        return if line == max.last_line
 
         add_offense(min)
       end
 
       def first_by_line(nodes)
-        nodes.min_by { |n| n.loc.first_line }
+        nodes.min_by(&:first_line)
       end
 
       def last_by_line(nodes)
-        nodes.max_by { |n| n.loc.last_line }
+        nodes.max_by(&:last_line)
       end
     end
   end

--- a/lib/rubocop/cop/mixin/multiline_literal_brace_layout.rb
+++ b/lib/rubocop/cop/mixin/multiline_literal_brace_layout.rb
@@ -127,13 +127,13 @@ module RuboCop
       # This method depends on the fact that we have guarded
       # against implicit and empty literals.
       def opening_brace_on_same_line?(node)
-        node.loc.begin.line == children(node).first.loc.first_line
+        node.loc.begin.line == children(node).first.first_line
       end
 
       # This method depends on the fact that we have guarded
       # against implicit and empty literals.
       def closing_brace_on_same_line?(node)
-        node.loc.end.line == children(node).last.loc.last_line
+        node.loc.end.line == children(node).last.last_line
       end
 
       # Starting with the parent node and recursively for the parent node's
@@ -165,7 +165,7 @@ module RuboCop
 
         if node.respond_to?(:loc) &&
            node.loc.respond_to?(:heredoc_end) &&
-           node.loc.heredoc_end.last_line >= parent.loc.last_line
+           node.loc.heredoc_end.last_line >= parent.last_line
           return true
         end
 

--- a/lib/rubocop/cop/mixin/percent_literal.rb
+++ b/lib/rubocop/cop/mixin/percent_literal.rb
@@ -38,7 +38,7 @@ module RuboCop
         escape = words.any? { |w| needs_escaping?(w.children[0]) }
         char = char.upcase if escape
         delimiters = preferred_delimiters_for("%#{char}")
-        contents = autocorrect_words(words, escape, node.loc.line, delimiters)
+        contents = autocorrect_words(words, escape, node.first_line, delimiters)
 
         lambda do |corrector|
           corrector.replace(
@@ -51,9 +51,9 @@ module RuboCop
       def autocorrect_words(word_nodes, escape, base_line_number, delimiters)
         previous_node_line_number = base_line_number
         word_nodes.map do |node|
-          number_of_line_breaks = node.loc.line - previous_node_line_number
+          number_of_line_breaks = node.first_line - previous_node_line_number
           line_breaks = "\n" * number_of_line_breaks
-          previous_node_line_number = node.loc.line
+          previous_node_line_number = node.first_line
           content = node.children.first.to_s
           content = escape ? escape_string(content) : content
           delimiters.each do |delimiter|

--- a/lib/rubocop/cop/rails/delegate.rb
+++ b/lib/rubocop/cop/rails/delegate.rb
@@ -112,7 +112,7 @@ module RuboCop
         end
 
         def private_or_protected_delegation(node)
-          line = node.loc.line
+          line = node.first_line
           private_or_protected_before(line) ||
             private_or_protected_inline(line)
         end

--- a/lib/rubocop/cop/rails/file_path.rb
+++ b/lib/rubocop/cop/rails/file_path.rb
@@ -62,7 +62,7 @@ module RuboCop
 
         def register_offense(node)
           line_range = node.loc.column...node.loc.last_column
-          source_range = source_range(processed_source.buffer, node.loc.line,
+          source_range = source_range(processed_source.buffer, node.first_line,
                                       line_range)
           add_offense(node, location: source_range)
         end


### PR DESCRIPTION
This adds `first_line` and `last_line` delegators in `AST:Node`, then trims some method chains in the codebase.  `first_line` replaces `node.loc.first_line` as well as `node.loc.line` since they are [alias methods](https://github.com/whitequark/parser/blob/master/lib/parser/source/range.rb#L83).

Additionally, It moves 3 other methods up in the file. I did not notice before, but these were placed in a [section marked `## Predicates`](https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/ast/node.rb#L315) in the file. These were an exception to that documentation.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
