### PR TITLE
[Fix #5250] Fix incorrect autocorrection for `Rails/Presence`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * [#5261](https://github.com/bbatsov/rubocop/issues/5261): Fix a false positive for `Style/MixinUsage` when using inside class or module. ([@koic][])
 * [#4444](https://github.com/bbatsov/rubocop/issues/4444): Fix `Style/AutoResourceCleanup` shouldn't flag `File.open(...).close. ([@dpostorivo][])
 * [#5278](https://github.com/bbatsov/rubocop/pull/5278): Fix deprecation check to use `loaded_path` in warning. ([@chrishulton][])
+* [#5258](https://github.com/bbatsov/rubocop/issues/5258): Fix incorrect autocorrection for `Rails/Presence` when the else block is multiline. ([@wata727][])
 
 ### Changes
 


### PR DESCRIPTION
Fixes #5250 

When an else block is multiline, the syntax is broken by autocorrection, so it must be ignored.

**Original**

```ruby
if a.present?
  a
else
  something
  something
  something
end
```

**Auto Fixed**

```ruby
a.presence || something # This is obviously broken... :(
  something
  something
```

Also, note postfix if and postfix rescue. If it applies autocorrection to these, the return value may change.

**Original**

```ruby
if 1.present?
  1
else
  2 if false
end
# => 1
```

**Auto Fixed**

```ruby
1.presence || 2 if false
# => nil
```

Unfortunately, this cop still includes another bug... But this will be fixed in https://github.com/bbatsov/rubocop/pull/5238.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
