### PR TITLE
Fix incorrect description of InverseOf spec

### DIFF
--- a/spec/rubocop/cop/rails/inverse_of_spec.rb
+++ b/spec/rubocop/cop/rails/inverse_of_spec.rb
@@ -86,7 +86,7 @@ describe RuboCop::Cop::Rails::InverseOf do
     context 'Rails >= 5.2', :config do
       let(:rails_version) { 5.2 }
 
-      it 'does not register an offense when not specifying `:inverse_of`' do
+      it 'does not register an offense when specifying `:inverse_of`' do
         expect_no_offenses(
           'belongs_to :foo, polymorphic: true'
         )


### PR DESCRIPTION
The description doesn't match what the test is actually doing. Seems like a simple typo.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
