### PR TITLE
[Fix #5221] Switch Layout/SpaceBeforeBlockBraces's empty braces default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Changes
 
 * [#5233](https://github.com/bbatsov/rubocop/pull/5233): Remove `Style/ExtendSelf` cop. ([@pocke][])
+* [#5221](https://github.com/bbatsov/rubocop/issues/5221): Change `Layout/SpaceBeforeBlockBraces`'s `EnforcedStyleForEmptyBraces` from `no_space` to `space`. ([@garettarrowood][])
 
 ## 0.52.0 (2017-12-12)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -490,7 +490,7 @@ Layout/SpaceBeforeBlockBraces:
   SupportedStyles:
     - space
     - no_space
-  EnforcedStyleForEmptyBraces: no_space
+  EnforcedStyleForEmptyBraces: space
   SupportedStylesForEmptyBraces:
     - space
     - no_space

--- a/lib/rubocop/cli.rb
+++ b/lib/rubocop/cli.rb
@@ -89,7 +89,7 @@ module RuboCop
 
     def reset_config_and_auto_gen_file
       @config_store = ConfigStore.new
-      File.open(ConfigLoader::AUTO_GENERATED_FILE, 'w'){}
+      File.open(ConfigLoader::AUTO_GENERATED_FILE, 'w') {}
       ConfigLoader.add_inheritance_from_auto_generated_file
     end
 

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -2556,7 +2556,7 @@ foo.map { |a|
 Name | Default value | Configurable values
 --- | --- | ---
 EnforcedStyle | `space` | `space`, `no_space`
-EnforcedStyleForEmptyBraces | `no_space` | `space`, `no_space`
+EnforcedStyleForEmptyBraces | `space` | `space`, `no_space`
 
 ## Layout/SpaceBeforeComma
 

--- a/spec/rubocop/cop/cop_spec.rb
+++ b/spec/rubocop/cop/cop_spec.rb
@@ -112,7 +112,7 @@ describe RuboCop::Cop::Cop do
       context 'when offense was corrected' do
         before do
           allow(cop).to receive(:autocorrect?).and_return(true)
-          allow(cop).to receive(:autocorrect).and_return(->(_corrector){})
+          allow(cop).to receive(:autocorrect).and_return(->(_corrector) {})
         end
 
         it 'is set to true' do

--- a/spec/rubocop/cop/layout/space_before_block_braces_spec.rb
+++ b/spec/rubocop/cop/layout/space_before_block_braces_spec.rb
@@ -63,11 +63,6 @@ describe RuboCop::Cop::Layout::SpaceBeforeBlockBraces, :config do
       expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end
 
-    it 'auto-corrects unwanted space' do
-      new_source = autocorrect_source('each {}')
-      expect(new_source).to eq('each{}')
-    end
-
     it 'accepts left brace without outer space' do
       expect_no_offenses('each{ puts }')
     end


### PR DESCRIPTION
As discussed on #5221 , the `EnforcedStyleForEmptyBraces` config for `Layout/SpaceBeforeBlockBraces` should be `space` and not `no_space`. This PR makes that switch.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
