### PR TITLE
[Fix #5226] Limit RedundantReceiverInWithOptions to Rails associations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 * [#5241](https://github.com/bbatsov/rubocop/issues/5241): Fix an error for `Layout/AlignHash` when using a hash including only a keyword splat. ([@wata727][])
+* [#5226](https://github.com/bbatsov/rubocop/issues/5226): Fix `Rails/RedundantReceiverInWithOptions` to only register for Rails associations. ([@garettarrowood][])
 * [#5245](https://github.com/bbatsov/rubocop/issues/5245): Make `Style/FormatStringToken` to allow regexp token. ([@pocke][])
 * [#5234](https://github.com/bbatsov/rubocop/issues/5234): Fix a false positive for `Rails/HasManyOrHasOneDependent` when using `class_name` option. ([@koic][])
 

--- a/lib/rubocop/cop/rails/redundant_receiver_in_with_options.rb
+++ b/lib/rubocop/cop/rails/redundant_receiver_in_with_options.rb
@@ -42,14 +42,14 @@ module RuboCop
             ...)
         PATTERN
 
-        def_node_search :assoc_has_redundant_receiver, <<-PATTERN
+        def_node_search :rails_assoc_with_redundant_receiver, <<-PATTERN
           (send
-            (lvar _) ...)
+            (lvar _) {:has_many :has_one :belongs_to :has_and_belongs_to_many} ...)
         PATTERN
 
         def on_block(node)
           with_options?(node) do
-            assoc_has_redundant_receiver(node).each do |assoc|
+            rails_assoc_with_redundant_receiver(node).each do |assoc|
               add_offense(assoc, location: assoc.receiver.loc.expression)
             end
           end

--- a/spec/rubocop/cop/rails/redundant_receiver_in_with_options_spec.rb
+++ b/spec/rubocop/cop/rails/redundant_receiver_in_with_options_spec.rb
@@ -9,30 +9,44 @@ describe RuboCop::Cop::Rails::RedundantReceiverInWithOptions, :config do
     it 'registers an offense when using explicit receiver in `with_options`' do
       expect_offense(<<-RUBY.strip_indent)
         class Account < ApplicationRecord
-          with_options dependent: :destroy do |assoc|
+          with_options dependent: :restrict_with_error do |assoc|
             assoc.has_many :customers
             ^^^^^ Redundant receiver in `with_options`.
             assoc.has_many :products
             ^^^^^ Redundant receiver in `with_options`.
-            assoc.has_many :invoices
+            assoc.has_one :owner
             ^^^^^ Redundant receiver in `with_options`.
-            assoc.has_many :expenses
+            assoc.belongs_to :company
+            ^^^^^ Redundant receiver in `with_options`.
+            assoc.has_and_belongs_to_many :clients
             ^^^^^ Redundant receiver in `with_options`.
           end
         end
       RUBY
     end
 
-    it 'does not register an offense when using inplicit receiver ' \
+    it 'does not register an offense when using implicit receiver ' \
        'in `with_options`' do
       expect_no_offenses(<<-RUBY.strip_indent)
         class Account < ApplicationRecord
-          with_options dependent: :destroy do
+          with_options dependent: :restrict_with_error do
             has_many :customers
             has_many :products
-            has_many :invoices
-            has_many :expenses
+            has_one :owner
+            belongs_to :company
+            has_and_belongs_to_many :clients
           end
+        end
+      RUBY
+    end
+
+    it 'accepts with_options block that uses non-rails methods' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        with_options foo do |qux|
+          qux.plants_seed
+          qux.waters_soil
+          qux.waits
+          qux.watches_grow
         end
       RUBY
     end
@@ -40,22 +54,24 @@ describe RuboCop::Cop::Rails::RedundantReceiverInWithOptions, :config do
     it 'autocorrects to implicit receiver in `with_options`' do
       new_source = autocorrect_source(<<-RUBY.strip_indent)
         class Account < ApplicationRecord
-          with_options dependent: :destroy do |assoc|
+          with_options dependent: :restrict_with_error do |assoc|
             assoc.has_many :customers
             assoc.has_many :products
-            assoc.has_many :invoices
-            assoc.has_many :expenses
+            assoc.has_one :owner
+            assoc.belongs_to :company
+            has_and_belongs_to_many :clients
           end
         end
       RUBY
 
       expect(new_source).to eq(<<-RUBY.strip_indent)
         class Account < ApplicationRecord
-          with_options dependent: :destroy do
+          with_options dependent: :restrict_with_error do
             has_many :customers
             has_many :products
-            has_many :invoices
-            has_many :expenses
+            has_one :owner
+            belongs_to :company
+            has_and_belongs_to_many :clients
           end
         end
       RUBY
@@ -65,14 +81,15 @@ describe RuboCop::Cop::Rails::RedundantReceiverInWithOptions, :config do
   context 'rails <= 4.1' do
     let(:rails_version) { 4.1 }
 
-    it 'registers an offense when using explicit receiver in `with_options`' do
+    it 'accepts using explicit receiver in `with_options`' do
       expect_no_offenses(<<-RUBY.strip_indent)
         class Account < ApplicationRecord
-          with_options dependent: :destroy do |assoc|
+          with_options dependent: :restrict_with_error do |assoc|
             assoc.has_many :customers
             assoc.has_many :products
-            assoc.has_many :invoices
-            assoc.has_many :expenses
+            assoc.has_one :owner
+            assoc.belongs_to :company
+            has_and_belongs_to_many :clients
           end
         end
       RUBY


### PR DESCRIPTION
Issue #5226 's example passes with this change, but I've boiled the example down to something more minimal. I don't think the example should actually be autocorrected from the issue, as it seems outside of the scope of this Cop. Based on the documentation examples and the test examples, this looks focused on Rails associations defined in a Model.  

This change narrows the `def_node_search` to only gather `with_options` that use Rails association method names.

-----------------

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
