### PR TITLE
Add examples to 4 Style cops

### DIFF
--- a/lib/rubocop/cop/style/frozen_string_literal_comment.rb
+++ b/lib/rubocop/cop/style/frozen_string_literal_comment.rb
@@ -8,6 +8,52 @@ module RuboCop
       # enable frozen string literals. Frozen string literals may be default
       # in Ruby 3.0. The comment will be added below a shebang and encoding
       # comment. The frozen string literal comment is only valid in Ruby 2.3+.
+      #
+      # @example EnforcedStyle: when_needed (default)
+      #   # The `when_needed` style will add the frozen string literal comment
+      #   # to files only when the `TargetRubyVersion` is set to 2.3+.
+      #   # bad
+      #   module Foo
+      #     # ...
+      #   end
+      #
+      #   # good
+      #   # frozen_string_literal: true
+      #
+      #   module Foo
+      #     # ...
+      #   end
+      #
+      # @example EnforcedStyle: always
+      #   # The `always` style will always add the frozen string literal comment
+      #   # to a file, regardless of the Ruby version or if `freeze` or `<<` are
+      #   # called on a string literal.
+      #   # bad
+      #   module Bar
+      #     # ...
+      #   end
+      #
+      #   # good
+      #   # frozen_string_literal: true
+      #
+      #   module Bar
+      #     # ...
+      #   end
+      #
+      # @example EnforcedStyle: never
+      #   # The `never` will enforce that the frozen string literal comment does
+      #   # not exist in a file.
+      #   # bad
+      #   # frozen_string_literal: true
+      #
+      #   module Baz
+      #     # ...
+      #   end
+      #
+      #   # good
+      #   module Baz
+      #     # ...
+      #   end
       class FrozenStringLiteralComment < Cop
         include ConfigurableEnforcedStyle
         include FrozenStringLiteral

--- a/lib/rubocop/cop/style/if_unless_modifier.rb
+++ b/lib/rubocop/cop/style/if_unless_modifier.rb
@@ -6,6 +6,20 @@ module RuboCop
       # Checks for if and unless statements that would fit on one line
       # if written as a modifier if/unless. The maximum line length is
       # configured in the `Metrics/LineLength` cop.
+      #
+      # @example
+      #   # bad
+      #   if condition
+      #     do_stuff(bar)
+      #   end
+      #
+      #   unless qux.empty?
+      #     Foo.do_something
+      #   end
+      #
+      #   # good
+      #   do_stuff(bar) if condition
+      #   Foo.do_something unless qux.empty?
       class IfUnlessModifier < Cop
         include StatementModifier
 

--- a/lib/rubocop/cop/style/method_def_parentheses.rb
+++ b/lib/rubocop/cop/style/method_def_parentheses.rb
@@ -5,6 +5,85 @@ module RuboCop
     module Style
       # This cops checks for parentheses around the arguments in method
       # definitions. Both instance and class/singleton methods are checked.
+      #
+      # @example EnforcedStyle: require_parentheses (default)
+      #   # The `require_parentheses` style requires method definitions
+      #   # to always use parentheses
+      #
+      #   # bad
+      #   def bar num1, num2
+      #     num1 + num2
+      #   end
+      #
+      #   def foo descriptive_var_name,
+      #           another_descriptive_var_name,
+      #           last_descriptive_var_name
+      #     do_something
+      #   end
+      #
+      #   # good
+      #   def bar(num1, num2)
+      #     num1 + num2
+      #   end
+      #
+      #   def foo(descriptive_var_name,
+      #           another_descriptive_var_name,
+      #           last_descriptive_var_name)
+      #     do_something
+      #   end
+      #
+      # @example EnforcedStyle: require_no_parentheses
+      #   # The `require_no_parentheses` style requires method definitions
+      #   # to never use parentheses
+      #
+      #   # bad
+      #   def bar(num1, num2)
+      #     num1 + num2
+      #   end
+      #
+      #   def foo(descriptive_var_name,
+      #           another_descriptive_var_name,
+      #           last_descriptive_var_name)
+      #     do_something
+      #   end
+      #
+      #   # good
+      #   def bar num1, num2
+      #     num1 + num2
+      #   end
+      #
+      #   def foo descriptive_var_name,
+      #           another_descriptive_var_name,
+      #           last_descriptive_var_name
+      #     do_something
+      #   end
+      #
+      # @example EnforcedStyle: require_no_parentheses_except_multiline
+      #   # The `require_no_parentheses_except_multiline` style prefers no
+      #   # parantheses when method definition arguments fit on single line,
+      #   # but prefers parantheses when arguments span multiple lines.
+      #
+      #   # bad
+      #   def bar(num1, num2)
+      #     num1 + num2
+      #   end
+      #
+      #   def foo descriptive_var_name,
+      #           another_descriptive_var_name,
+      #           last_descriptive_var_name
+      #     do_something
+      #   end
+      #
+      #   # good
+      #   def bar num1, num2
+      #     num1 + num2
+      #   end
+      #
+      #   def foo(descriptive_var_name,
+      #           another_descriptive_var_name,
+      #           last_descriptive_var_name)
+      #     do_something
+      #   end
       class MethodDefParentheses < Cop
         include ConfigurableEnforcedStyle
 

--- a/lib/rubocop/cop/style/multiline_ternary_operator.rb
+++ b/lib/rubocop/cop/style/multiline_ternary_operator.rb
@@ -4,6 +4,25 @@ module RuboCop
   module Cop
     module Style
       # This cop checks for multi-line ternary op expressions.
+      #
+      # @example
+      #   # bad
+      #   a = cond ?
+      #     b : c
+      #   a = cond ? b :
+      #       c
+      #   a = cond ?
+      #       b :
+      #       c
+      #
+      #   # good
+      #   a = cond ? b : c
+      #   a =
+      #     if cond
+      #       b
+      #     else
+      #       c
+      #     end
       class MultilineTernaryOperator < Cop
         MSG = 'Avoid multi-line ternary operators, ' \
               'use `if` or `unless` instead.'.freeze

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -2601,6 +2601,94 @@ Enabled | Yes
 This cops checks for parentheses around the arguments in method
 definitions. Both instance and class/singleton methods are checked.
 
+### Examples
+
+#### EnforcedStyle: require_parentheses (default)
+
+```ruby
+# The `require_parentheses` style requires method definitions
+# to always use parentheses
+
+# bad
+def bar num1, num2
+  num1 + num2
+end
+
+def foo descriptive_var_name,
+        another_descriptive_var_name,
+        last_descriptive_var_name
+  do_something
+end
+
+# good
+def bar(num1, num2)
+  num1 + num2
+end
+
+def foo(descriptive_var_name,
+        another_descriptive_var_name,
+        last_descriptive_var_name)
+  do_something
+end
+```
+#### EnforcedStyle: require_no_parentheses
+
+```ruby
+# The `require_no_parentheses` style requires method definitions
+# to never use parentheses
+
+# bad
+def bar(num1, num2)
+  num1 + num2
+end
+
+def foo(descriptive_var_name,
+        another_descriptive_var_name,
+        last_descriptive_var_name)
+  do_something
+end
+
+# good
+def bar num1, num2
+  num1 + num2
+end
+
+def foo descriptive_var_name,
+        another_descriptive_var_name,
+        last_descriptive_var_name
+  do_something
+end
+```
+#### EnforcedStyle: require_no_parentheses_except_multiline
+
+```ruby
+# The `require_no_parentheses_except_multiline` style prefers no
+# parantheses when method definition arguments fit on single line,
+# but prefers parantheses when arguments span multiple lines.
+
+# bad
+def bar(num1, num2)
+  num1 + num2
+end
+
+def foo descriptive_var_name,
+        another_descriptive_var_name,
+        last_descriptive_var_name
+  do_something
+end
+
+# good
+def bar num1, num2
+  num1 + num2
+end
+
+def foo(descriptive_var_name,
+        another_descriptive_var_name,
+        last_descriptive_var_name)
+  do_something
+end
+```
+
 ### Configurable attributes
 
 Name | Default value | Configurable values

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -2178,6 +2178,23 @@ Checks for if and unless statements that would fit on one line
 if written as a modifier if/unless. The maximum line length is
 configured in the `Metrics/LineLength` cop.
 
+### Examples
+
+```ruby
+# bad
+if condition
+  do_stuff(bar)
+end
+
+unless qux.empty?
+  Foo.do_something
+end
+
+# good
+do_stuff(bar) if condition
+Foo.do_something unless qux.empty?
+```
+
 ### References
 
 * [https://github.com/bbatsov/ruby-style-guide#if-as-a-modifier](https://github.com/bbatsov/ruby-style-guide#if-as-a-modifier)

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -1834,6 +1834,61 @@ enable frozen string literals. Frozen string literals may be default
 in Ruby 3.0. The comment will be added below a shebang and encoding
 comment. The frozen string literal comment is only valid in Ruby 2.3+.
 
+### Examples
+
+#### EnforcedStyle: when_needed (default)
+
+```ruby
+# The `when_needed` style will add the frozen string literal comment
+# to files only when the `TargetRubyVersion` is set to 2.3+.
+# bad
+module Foo
+  # ...
+end
+
+# good
+# frozen_string_literal: true
+
+module Foo
+  # ...
+end
+```
+#### EnforcedStyle: always
+
+```ruby
+# The `always` style will always add the frozen string literal comment
+# to a file, regardless of the Ruby version or if `freeze` or `<<` are
+# called on a string literal.
+# bad
+module Bar
+  # ...
+end
+
+# good
+# frozen_string_literal: true
+
+module Bar
+  # ...
+end
+```
+#### EnforcedStyle: never
+
+```ruby
+# The `never` will enforce that the frozen string literal comment does
+# not exist in a file.
+# bad
+# frozen_string_literal: true
+
+module Baz
+  # ...
+end
+
+# good
+module Baz
+  # ...
+end
+```
+
 ### Configurable attributes
 
 Name | Default value | Configurable values

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -3079,6 +3079,28 @@ Enabled | No
 
 This cop checks for multi-line ternary op expressions.
 
+### Examples
+
+```ruby
+# bad
+a = cond ?
+  b : c
+a = cond ? b :
+    c
+a = cond ?
+    b :
+    c
+
+# good
+a = cond ? b : c
+a =
+  if cond
+    b
+  else
+    c
+  end
+```
+
 ### References
 
 * [https://github.com/bbatsov/ruby-style-guide#no-multiline-ternary](https://github.com/bbatsov/ruby-style-guide#no-multiline-ternary)


### PR DESCRIPTION
This PR adds examples to four Style Cops listed in the documentation issue #4910 .  Each example set is contained to one commit.

Those Cops are:

1. `Style/FrozenStringLiteralComment`
1. `Style/IfUnlessModifier`
1. `Style/MethodDefParentheses`
1. `Style/MultilineTernaryOperator`

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
