### PR TITLE
Use latest Rubies on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,9 @@ rvm:
   - jruby-9.1.15.0
   - jruby-head
   - 2.1.10
-  - 2.2.8
-  - 2.3.5
-  - 2.4.2
+  - 2.2.9
+  - 2.3.6
+  - 2.4.3
   - ruby-head
 env:
   global:


### PR DESCRIPTION
These Rubies has been released and available on Travis CI.

- https://www.ruby-lang.org/en/news/2017/12/14/ruby-2-2-9-released/
- https://www.ruby-lang.org/en/news/2017/12/14/ruby-2-3-6-released/
- https://www.ruby-lang.org/en/news/2017/12/14/ruby-2-4-3-released/
