### PR TITLE
[Fix #5226] Suppress false positives for `Rails/RedundantReceiverInWithOptions`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [#5234](https://github.com/bbatsov/rubocop/issues/5234): Fix a false positive for `Rails/HasManyOrHasOneDependent` when using `class_name` option. ([@koic][])
 * [#5273](https://github.com/bbatsov/rubocop/issues/5273): Fix `Style/EvalWithLocation` reporting bad line offset. ([@pocke][])
 * [#5228](https://github.com/bbatsov/rubocop/issues/5228): Handle overridden `Metrics/LineLength:Max` for `--auto-gen-config`. ([@jonas054][])
+* [#5226](https://github.com/bbatsov/rubocop/issues/5226): Suppress false positives for `Rails/RedundantReceiverInWithOptions` when including another receiver in `with_options`. ([@wata727][])
 
 ### Changes
 

--- a/lib/rubocop/cop/rails/redundant_receiver_in_with_options.rb
+++ b/lib/rubocop/cop/rails/redundant_receiver_in_with_options.rb
@@ -26,6 +26,34 @@ module RuboCop
       #       has_many :expenses
       #     end
       #   end
+      #
+      # @example
+      #   # bad
+      #   with_options options: false do |merger|
+      #     merger.invoke(merger.something)
+      #   end
+      #
+      #   # good
+      #   with_options options: false do
+      #     invoke(something)
+      #   end
+      #
+      #   # good
+      #   client = Client.new
+      #   with_options options: false do |merger|
+      #     client.invoke(merger.something, something)
+      #   end
+      #
+      #   # ok
+      #   # When `with_options` includes a block, all scoping scenarios
+      #   # cannot be evaluated. Thus, it is ok to include the explicit
+      #   # receiver.
+      #   with_options options: false do |merger|
+      #     merger.invoke
+      #     with_another_method do |another_receiver|
+      #       merger.invoke(another_receiver)
+      #     end
+      #   end
       class RedundantReceiverInWithOptions < Cop
         extend TargetRailsVersion
 
@@ -38,26 +66,35 @@ module RuboCop
             (send nil? :with_options
               (...))
             (args
-              (...))
-            ...)
+              $_arg)
+            $_body)
         PATTERN
 
-        def_node_search :assoc_has_redundant_receiver, <<-PATTERN
-          (send
-            (lvar _) ...)
+        def_node_search :all_block_nodes_in, <<-PATTERN
+          (block ...)
+        PATTERN
+
+        def_node_search :all_send_nodes_in, <<-PATTERN
+          (send ...)
         PATTERN
 
         def on_block(node)
-          with_options?(node) do
-            assoc_has_redundant_receiver(node).each do |assoc|
-              add_offense(assoc, location: assoc.receiver.loc.expression)
+          with_options?(node) do |arg, body|
+            return unless all_block_nodes_in(body).count.zero?
+            send_nodes = all_send_nodes_in(body)
+
+            if send_nodes.all? { |n| same_value?(arg, n.receiver) }
+              send_nodes.each do |send_node|
+                receiver = send_node.receiver
+                add_offense(send_node, location: receiver.source_range)
+              end
             end
           end
         end
 
         def autocorrect(node)
           lambda do |corrector|
-            corrector.remove(node.receiver.loc.expression)
+            corrector.remove(node.receiver.source_range)
             corrector.remove(node.loc.dot)
             corrector.remove(block_argument_range(node))
           end
@@ -66,7 +103,8 @@ module RuboCop
         private
 
         def block_argument_range(node)
-          block_argument = node.parent.parent.children[1].loc.expression
+          block_node = node.each_ancestor(:block).first
+          block_argument = block_node.children[1].source_range
 
           range_between(
             search_begin_pos_of_space_before_block_argument(
@@ -84,6 +122,10 @@ module RuboCop
           else
             begin_pos
           end
+        end
+
+        def same_value?(arg_node, recv_node)
+          recv_node && recv_node.children[0] == arg_node.children[0]
         end
       end
     end

--- a/manual/cops_rails.md
+++ b/manual/cops_rails.md
@@ -1048,6 +1048,34 @@ class Account < ApplicationRecord
   end
 end
 ```
+```ruby
+# bad
+with_options options: false do |merger|
+  merger.invoke(merger.something)
+end
+
+# good
+with_options options: false do
+  invoke(something)
+end
+
+# good
+client = Client.new
+with_options options: false do |merger|
+  client.invoke(merger.something, something)
+end
+
+# ok
+# When `with_options` includes a block, all scoping scenarios
+# cannot be evaluated. Thus, it is ok to include the explicit
+# receiver.
+with_options options: false do |merger|
+  merger.invoke
+  with_another_method do |another_receiver|
+    merger.invoke(another_receiver)
+  end
+end
+```
 
 ## Rails/RelativeDateConstant
 


### PR DESCRIPTION
Fixes #5226

For example, if it has another receiver in `with_options`, should not omit the receiver of argument.

```ruby
require 'active_support'
require 'active_support/core_ext'

def self.options(opts = {})
  opts
end

with_options hello: :world do |merger|
  self.class     # => Object
  merger.options # => {:hello=>:world}
  options        # => {}
end

with_options hello: :world do
  self.class # => ActiveSupport::OptionMerger
  options    # => {:hello=>:world}
end
```

Therefore, all method calls in `with_options` must check for the same receiver.

Also, this Cop can get the position of the argument regardless of the position of receivers for auto-correct.

-----------------

Before submitting the PR make sure the following are checked:

* [ ] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
