### PR TITLE
Make the cop generator to work on rubocop-rspec

### DIFF
--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -74,6 +74,7 @@ require_relative 'rubocop/cop/corrector'
 require_relative 'rubocop/cop/force'
 require_relative 'rubocop/cop/severity'
 require_relative 'rubocop/cop/generator'
+require_relative 'rubocop/cop/generator/require_file_injector'
 
 require_relative 'rubocop/cop/variable_force'
 require_relative 'rubocop/cop/variable_force/branch'

--- a/lib/rubocop/cop/generator.rb
+++ b/lib/rubocop/cop/generator.rb
@@ -54,7 +54,7 @@ module RuboCop
       SPEC_TEMPLATE = <<-SPEC.strip_indent
         # frozen_string_literal: true
 
-        describe RuboCop::Cop::%<department>s::%<cop_name>s do
+        RSpec.describe RuboCop::Cop::%<department>s::%<cop_name>s do
           subject(:cop) { described_class.new(config) }
 
           let(:config) { RuboCop::Config.new }
@@ -77,9 +77,9 @@ module RuboCop
         end
       SPEC
 
-      def initialize(name)
+      def initialize(name, output: $stdout)
         @badge = Badge.parse(name)
-
+        @output = output
         return if badge.qualified?
 
         raise ArgumentError, 'Specify a cop name with Department/Name style'
@@ -93,12 +93,15 @@ module RuboCop
         write_unless_file_exists(spec_path, generated_spec)
       end
 
-      def inject_require
-        RequireFileInjector.new(require_path).inject
+      def inject_require(root_file_path: 'lib/rubocop.rb')
+        RequireFileInjector.new(
+          source_path: source_path,
+          root_file_path: root_file_path
+        ).inject
       end
 
-      def inject_config(path = 'config/enabled.yml')
-        config = File.readlines(path)
+      def inject_config(config_file_path: 'config/enabled.yml')
+        config = File.readlines(config_file_path)
         content = <<-YAML.strip_indent
           #{badge}:
             Description: 'TODO: Write a description of the cop.'
@@ -110,19 +113,15 @@ module RuboCop
           break index - 1 if badge.to_s < line
         end
         config.insert(target_line, content)
-        File.write(path, config.join)
+        File.write(config_file_path, config.join)
+        output.puts <<-MESSAGE.strip_indent
+          [modify] A configuration for the cop is added into #{config_file_path}.
+                   If you want to disable the cop by default, move the added config to config/disabled.yml
+        MESSAGE
       end
 
       def todo
         <<-TODO.strip_indent
-          Files created:
-            - #{source_path}
-            - #{spec_path}
-          File modified:
-            - `require_relative '#{require_path}'` added into lib/rubocop.rb
-            - A configuration for the cop is added into config/enabled.yml
-              - If you want to disable the cop by default, move the added config to config/disabled.yml
-
           Do 3 steps:
             1. Add an entry to the "New features" section in CHANGELOG.md,
                e.g. "Add new `#{badge}` cop. ([@your_id][])"
@@ -133,7 +132,7 @@ module RuboCop
 
       private
 
-      attr_reader :badge
+      attr_reader :badge, :output
 
       def write_unless_file_exists(path, contents)
         if File.exist?(path)
@@ -145,6 +144,7 @@ module RuboCop
         FileUtils.mkdir_p(dir) unless File.exist?(dir)
 
         File.write(path, contents)
+        output.puts "[create] #{path}"
       end
 
       def generated_source
@@ -157,10 +157,6 @@ module RuboCop
 
       def generate(template)
         format(template, department: badge.department, cop_name: badge.cop_name)
-      end
-
-      def require_path
-        source_path.sub('lib/', '').sub('.rb', '')
       end
 
       def spec_path
@@ -184,76 +180,11 @@ module RuboCop
       end
 
       def snake_case(camel_case_string)
+        return 'rspec' if camel_case_string == 'RSpec'
         camel_case_string
           .gsub(/([^A-Z])([A-Z]+)/, '\1_\2')
           .gsub(/([A-Z])([A-Z][^A-Z\d]+)/, '\1_\2')
           .downcase
-      end
-
-      # A class that injects a require directive into the root RuboCop file.
-      # It looks for other directives that require files in the same (cop)
-      # namespace and injects the provided one in alpha
-      class RequireFileInjector
-        REQUIRE_PATH = /require_relative ['"](.+)['"]/
-
-        def initialize(require_path)
-          @require_path    = require_path
-          @require_entries = File.readlines(rubocop_root_file_path)
-        end
-
-        def inject
-          return if require_exists? || !target_line
-
-          File.write(rubocop_root_file_path, updated_directives)
-        end
-
-        private
-
-        attr_reader :require_path, :require_entries
-
-        def rubocop_root_file_path
-          File.join('lib', 'rubocop.rb')
-        end
-
-        def require_exists?
-          require_entries.any? do |entry|
-            entry == injectable_require_directive
-          end
-        end
-
-        def updated_directives
-          require_entries.insert(target_line,
-                                 injectable_require_directive).join
-        end
-
-        def target_line
-          @target_line ||= begin
-            in_the_same_department = false
-            inject_parts = require_path_fragments(injectable_require_directive)
-
-            require_entries.find.with_index do |entry, index|
-              current_entry_parts = require_path_fragments(entry)
-
-              if inject_parts[0..-2] == current_entry_parts[0..-2]
-                in_the_same_department = true
-
-                break index if inject_parts.last < current_entry_parts.last
-              elsif in_the_same_department
-                break index
-              end
-            end
-          end
-        end
-
-        def require_path_fragments(require_directove)
-          path = require_directove.match(REQUIRE_PATH)
-
-          path ? path.captures.first.split('/') : []
-        end
-
-        def injectable_require_directive
-          "require_relative '#{require_path}'\n"
-        end
       end
     end
   end

--- a/lib/rubocop/cop/generator/require_file_injector.rb
+++ b/lib/rubocop/cop/generator/require_file_injector.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    class Generator
+      # A class that injects a require directive into the root RuboCop file.
+      # It looks for other directives that require files in the same (cop)
+      # namespace and injects the provided one in alpha
+      class RequireFileInjector
+        REQUIRE_PATH = /require_relative ['"](.+)['"]/
+
+        def initialize(source_path:, root_file_path:, output: $stdout)
+          @source_path = Pathname(source_path)
+          @root_file_path = Pathname(root_file_path)
+          @require_entries = File.readlines(root_file_path)
+          @output = output
+        end
+
+        def inject
+          return if require_exists? || !target_line
+
+          File.write(root_file_path, updated_directives)
+          require = injectable_require_directive.chomp
+          output.puts "[modify] #{root_file_path} - `#{require}` was injected."
+        end
+
+        private
+
+        attr_reader :require_entries, :root_file_path, :source_path, :output
+
+        def require_exists?
+          require_entries.any? do |entry|
+            entry == injectable_require_directive
+          end
+        end
+
+        def updated_directives
+          require_entries.insert(target_line,
+                                 injectable_require_directive).join
+        end
+
+        def target_line
+          @target_line ||= begin
+            in_the_same_department = false
+            inject_parts = require_path_fragments(injectable_require_directive)
+
+            require_entries.find.with_index do |entry, index|
+              current_entry_parts = require_path_fragments(entry)
+
+              if inject_parts[0..-2] == current_entry_parts[0..-2]
+                in_the_same_department = true
+
+                break index if inject_parts.last < current_entry_parts.last
+              elsif in_the_same_department
+                break index
+              end
+            end
+          end
+        end
+
+        def require_path_fragments(require_directove)
+          path = require_directove.match(REQUIRE_PATH)
+
+          path ? path.captures.first.split('/') : []
+        end
+
+        def injectable_require_directive
+          "require_relative '#{require_path}'\n"
+        end
+
+        def require_path
+          path = source_path.relative_path_from(root_file_path.dirname)
+          path.to_s.sub('.rb', '')
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/generator/require_file_injector_spec.rb
+++ b/spec/rubocop/cop/generator/require_file_injector_spec.rb
@@ -1,0 +1,219 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Generator::RequireFileInjector do
+  let(:stdout) { StringIO.new }
+  let(:root_file_path) { 'lib/root.rb' }
+  let(:injector) do
+    described_class.new(
+      source_path: source_path,
+      root_file_path: root_file_path,
+      output: stdout
+    )
+  end
+
+  around do |example|
+    Dir.mktmpdir('rubocop-require_file_injector_spec-') do |dir|
+      Dir.chdir(dir) do
+        Dir.mkdir('lib')
+        example.run
+      end
+    end
+  end
+
+  context 'when a `require_relative` entry does not exist from before' do
+    let(:source_path) { 'lib/rubocop/cop/style/fake_cop.rb' }
+
+    before do
+      File.write(root_file_path, <<-RUBY.strip_indent)
+        # frozen_string_literal: true
+
+        require 'parser'
+        require 'rainbow'
+
+        require 'English'
+        require 'set'
+        require 'forwardable'
+
+        require_relative 'rubocop/version'
+
+        require_relative 'rubocop/cop/style/end_block'
+        require_relative 'rubocop/cop/style/even_odd'
+        require_relative 'rubocop/cop/style/file_name'
+        require_relative 'rubocop/cop/style/flip_flop'
+
+        require_relative 'rubocop/cop/rails/action_filter'
+
+        require_relative 'rubocop/cop/team'
+      RUBY
+    end
+
+    it 'injects a `require_relative` statement ' \
+       'on the right line in the root file' do
+      generated_source = <<-RUBY.strip_indent
+        # frozen_string_literal: true
+
+        require 'parser'
+        require 'rainbow'
+
+        require 'English'
+        require 'set'
+        require 'forwardable'
+
+        require_relative 'rubocop/version'
+
+        require_relative 'rubocop/cop/style/end_block'
+        require_relative 'rubocop/cop/style/even_odd'
+        require_relative 'rubocop/cop/style/fake_cop'
+        require_relative 'rubocop/cop/style/file_name'
+        require_relative 'rubocop/cop/style/flip_flop'
+
+        require_relative 'rubocop/cop/rails/action_filter'
+
+        require_relative 'rubocop/cop/team'
+      RUBY
+
+      injector.inject
+
+      expect(File.read(root_file_path)).to eq generated_source
+      expect(stdout.string).to eq(<<-MESSAGE.strip_indent)
+        [modify] lib/root.rb - `require_relative 'rubocop/cop/style/fake_cop'` was injected.
+      MESSAGE
+    end
+  end
+
+  context 'when a cop of style department already exists' do
+    let(:source_path) { 'lib/rubocop/cop/style/the_end_of_style.rb' }
+
+    before do
+      File.write(root_file_path, <<-RUBY.strip_indent)
+        # frozen_string_literal: true
+
+        require 'parser'
+        require 'rainbow'
+
+        require 'English'
+        require 'set'
+        require 'forwardable'
+
+        require_relative 'rubocop/version'
+
+        require_relative 'rubocop/cop/style/end_block'
+        require_relative 'rubocop/cop/style/even_odd'
+        require_relative 'rubocop/cop/style/file_name'
+        require_relative 'rubocop/cop/style/flip_flop'
+
+        require_relative 'rubocop/cop/rails/action_filter'
+
+        require_relative 'rubocop/cop/team'
+      RUBY
+    end
+
+    it 'injects a `require_relative` statement ' \
+       'on the end of style department' do
+      generated_source = <<-RUBY.strip_indent
+        # frozen_string_literal: true
+
+        require 'parser'
+        require 'rainbow'
+
+        require 'English'
+        require 'set'
+        require 'forwardable'
+
+        require_relative 'rubocop/version'
+
+        require_relative 'rubocop/cop/style/end_block'
+        require_relative 'rubocop/cop/style/even_odd'
+        require_relative 'rubocop/cop/style/file_name'
+        require_relative 'rubocop/cop/style/flip_flop'
+        require_relative 'rubocop/cop/style/the_end_of_style'
+
+        require_relative 'rubocop/cop/rails/action_filter'
+
+        require_relative 'rubocop/cop/team'
+      RUBY
+
+      injector.inject
+
+      expect(File.read(root_file_path)).to eq generated_source
+      expect(stdout.string).to eq(<<-MESSAGE.strip_indent)
+        [modify] lib/root.rb - `require_relative 'rubocop/cop/style/the_end_of_style'` was injected.
+      MESSAGE
+    end
+  end
+
+  context 'when a `require` entry already exists' do
+    let(:source_path) { 'lib/rubocop/cop/style/fake_cop.rb' }
+    let(:source) { <<-RUBY.strip_indent }
+      # frozen_string_literal: true
+
+      require 'parser'
+      require 'rainbow'
+
+      require 'English'
+      require 'set'
+      require 'forwardable'
+
+      require_relative 'rubocop/version'
+
+      require_relative 'rubocop/cop/style/end_block'
+      require_relative 'rubocop/cop/style/even_odd'
+      require_relative 'rubocop/cop/style/fake_cop'
+      require_relative 'rubocop/cop/style/file_name'
+      require_relative 'rubocop/cop/style/flip_flop'
+
+      require_relative 'rubocop/cop/rails/action_filter'
+
+      require_relative 'rubocop/cop/team'
+    RUBY
+
+    before do
+      File.write(root_file_path, source)
+    end
+
+    it 'does not write to any file' do
+      injector.inject
+
+      expect(File.read(root_file_path)).to eq source
+      expect(stdout.string.empty?).to be(true)
+    end
+  end
+
+  context 'when using an unknown department' do
+    let(:source_path) { 'lib/rubocop/cop/unknown/fake_cop.rb' }
+
+    let(:source) { <<-RUBY }
+      # frozen_string_literal: true
+
+      require 'parser'
+      require 'rainbow'
+
+      require 'English'
+      require 'set'
+      require 'forwardable'
+
+      require_relative 'rubocop/version'
+
+      require_relative 'rubocop/cop/style/end_block'
+      require_relative 'rubocop/cop/style/even_odd'
+      require_relative 'rubocop/cop/style/fake_cop'
+      require_relative 'rubocop/cop/style/file_name'
+      require_relative 'rubocop/cop/style/flip_flop'
+
+      require_relative 'rubocop/cop/rails/action_filter'
+
+      require_relative 'rubocop/cop/team'
+    RUBY
+
+    before do
+      File.write(root_file_path, source)
+    end
+
+    it 'does not write to any file' do
+      injector.inject
+
+      expect(File.read(root_file_path)).to eq source
+      expect(stdout.string.empty?).to be(true)
+    end
+  end
+end


### PR DESCRIPTION

I would like to use the cop generator in `rubocop-rspec`. However, the task does not work well on the project now.
This change will make the generator to work on rubocop-rspec.

It changes the following things.

- Make `inject_require` and `inject_config` to receive a file name that is a target of injection as a keyword argument.
- Tweak `snake_case` method. The method convert `"RSpec"` to `r_spec` now. It will be `"rspec"` by this change.
- Refactor the generator.
- Modify the output style of the generator. The new style is similar to rails generator's output.
  - The new style's implementation is easier and simpler than the old style.
  - before
    ```
    $ bundle exec rake new_cop[Style/Foo]
    Files created:
      - lib/rubocop/cop/style/foo.rb
      - spec/rubocop/cop/style/foo_spec.rb
    File modified:
      - `require_relative 'rubocop/cop/style/foo'` added into lib/rubocop.rb
      - A configuration for the cop is added into config/enabled.yml
        - If you want to disable the cop by default, move the added config to config/disabled.yml

    Do 3 steps:
      1. Add an entry to the "New features" section in CHANGELOG.md,
         e.g. "Add new `Style/Foo` cop. ([@your_id][])"
      2. Modify the description of Style/Foo in config/enabled.yml
      3. Implement your new cop in the generated file!
    ```
  - after
    ```
    $ bundle exec rake new_cop[Style/Foo]
    [create] lib/rubocop/cop/style/foo.rb
    [create] spec/rubocop/cop/style/foo_spec.rb
    [modify] lib/rubocop.rb - `require_relative 'rubocop/cop/style/foo'` was injected.
    [modify] A configuration for the cop is added into config/enabled.yml.
             If you want to disable the cop by default, move the added config to config/disabled.yml
    Do 3 steps:
      1. Add an entry to the "New features" section in CHANGELOG.md,
         e.g. "Add new `Style/Foo` cop. ([@your_id][])"
      2. Modify the description of Style/Foo in config/enabled.yml
      3. Implement your new cop in the generated file!
    ```


-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
