### PR TITLE
[Fix #5261] Fix false positive for `Style/MixinUsage` when using inside module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [#5234](https://github.com/bbatsov/rubocop/issues/5234): Fix a false positive for `Rails/HasManyOrHasOneDependent` when using `class_name` option. ([@koic][])
 * [#5273](https://github.com/bbatsov/rubocop/issues/5273): Fix `Style/EvalWithLocation` reporting bad line offset. ([@pocke][])
 * [#5228](https://github.com/bbatsov/rubocop/issues/5228): Handle overridden `Metrics/LineLength:Max` for `--auto-gen-config`. ([@jonas054][])
+* [#5261](https://github.com/bbatsov/rubocop/issues/5261): Fix a false positive for `Style/MixinUsage` when using inside class or module. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/mixin_usage.rb
+++ b/lib/rubocop/cop/style/mixin_usage.rb
@@ -53,8 +53,9 @@ module RuboCop
 
         def on_send(node)
           include_statement(node) do |statement|
-            return if node.argument?
-            return if accepted_include?(node)
+            return if node.argument? ||
+                      accepted_include?(node) ||
+                      belongs_to_class_or_module?(node)
 
             add_offense(node, message: format(MSG, statement: statement))
           end
@@ -64,6 +65,16 @@ module RuboCop
 
         def accepted_include?(node)
           node.parent && node.macro?
+        end
+
+        def belongs_to_class_or_module?(node)
+          if !node.parent
+            false
+          else
+            return true if node.parent.class_type? || node.parent.module_type?
+
+            belongs_to_class_or_module?(node.parent)
+          end
         end
       end
     end

--- a/spec/rubocop/cop/style/mixin_usage_spec.rb
+++ b/spec/rubocop/cop/style/mixin_usage_spec.rb
@@ -29,6 +29,16 @@ describe RuboCop::Cop::Style::MixinUsage do
       RUBY
     end
 
+    it 'registers an offense when using `include` in method definition ' \
+       'outside class or module' do
+      expect_offense(<<-RUBY.strip_indent)
+        def foo
+          include M
+          ^^^^^^^^^ `include` is used at the top level. Use inside `class` or `module`.
+        end
+      RUBY
+    end
+
     it 'does not register an offense when using outside class' do
       expect_no_offenses(<<-RUBY.strip_indent)
         Foo.include M
@@ -55,6 +65,28 @@ describe RuboCop::Cop::Style::MixinUsage do
     it "doesn't register an offense when `include` call is a method argument" do
       expect_no_offenses(<<-RUBY.strip_indent)
         do_something(include(M))
+      RUBY
+    end
+
+    it 'does not register an offense when using `include` in method ' \
+       'definition inside class' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        class X
+          def foo
+            include M
+          end
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when using `include` in method ' \
+       'definition inside module' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        module X
+          def foo
+            include M
+          end
+        end
       RUBY
     end
 


### PR DESCRIPTION
Fixes #5261.

Correspondence to use case for `include` belonging to module was insufficient. This PR added a reproduction test and fixed it.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
