### PR TITLE
Fix config#check to use loaded_path in warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [#5273](https://github.com/bbatsov/rubocop/issues/5273): Fix `Style/EvalWithLocation` reporting bad line offset. ([@pocke][])
 * [#5228](https://github.com/bbatsov/rubocop/issues/5228): Handle overridden `Metrics/LineLength:Max` for `--auto-gen-config`. ([@jonas054][])
 * [#5261](https://github.com/bbatsov/rubocop/issues/5261): Fix a false positive for `Style/MixinUsage` when using inside class or module. ([@koic][])
+* [#5278](https://github.com/bbatsov/rubocop/pull/5278): Fix deprecation check to use `loaded_path` in warning. ([@chrishulton][])
 
 ### Changes
 
@@ -3092,3 +3093,4 @@
 [@marcandre]: https://github.com/marcandre
 [@walf443]: https://github.com/walf443
 [@reitermarkus]: https://github.com/reitermarkus
+[@chrishulton]: https://github.com/chrishulton

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -195,7 +195,7 @@ module RuboCop
 
     def check
       deprecation_check do |deprecation_message|
-        warn("#{path} - #{deprecation_message}")
+        warn("#{loaded_path} - #{deprecation_message}")
       end
       validate
       make_excludes_absolute

--- a/spec/rubocop/config_spec.rb
+++ b/spec/rubocop/config_spec.rb
@@ -516,6 +516,28 @@ describe RuboCop::Config do
     end
   end
 
+  describe '#check' do
+    subject(:configuration) do
+      described_class.new(hash, loaded_path)
+    end
+
+    let(:loaded_path) { 'example/.rubocop.yml' }
+
+    context 'when a deprecated configuration is detected' do
+      let(:hash) { { 'AllCops' => { 'Includes' => [] } } }
+
+      before { $stderr = StringIO.new }
+      after { $stderr = STDERR }
+
+      it 'prints a warning message for the loaded path' do
+        configuration.check
+        expect($stderr.string).to include(
+          "#{loaded_path} - AllCops/Includes was renamed"
+        )
+      end
+    end
+  end
+
   describe '#deprecation_check' do
     context 'when there is no AllCops configuration' do
       let(:hash) { {} }


### PR DESCRIPTION
Due to a configuration refactor, the `#path` variable is no longer
available in `config#check`, which causes rubocop to crash with
`NameError: undefined local variable or method path` if the deprecation
check yields a deprecation warning.

This replaces the warning to use the instance variable `#loaded_path`
and adds a spec to cover the behavior.

-----------------

This is a small bug that looks to have been introduced with [this commit](https://github.com/bbatsov/rubocop/commit/a8dac501c1361d4e7e92e75cd18326ea27ae68fd
) and is impacting version 0.52.

Without the code change, the spec fails with:
```
 NameError:
   undefined local variable or method `path' for #<RuboCop::Config:0x007fe191cc9a00>
 # ./lib/rubocop/config.rb:198:in `block in check'
 # ./lib/rubocop/config.rb:288:in `block in deprecation_check'
 # ./lib/rubocop/config.rb:282:in `each'
 # ./lib/rubocop/config.rb:282:in `deprecation_check'
 # ./lib/rubocop/config.rb:197:in `check'
 # ./spec/rubocop/config_spec.rb:533:in `block (4 levels) in <top (required)>'
```

This is also reproducible by defining the configuration:
```
AllCops:
  Excludes:
    - 'path'
```
which results in an exit with the `NameError` described above.

Please let me know if I should add anything else to this PR!  Thanks!

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
