### PR TITLE
Style/FormatStringToken false positives

### DIFF
--- a/spec/rubocop/cop/style/format_string_token_spec.rb
+++ b/spec/rubocop/cop/style/format_string_token_spec.rb
@@ -12,6 +12,32 @@ describe RuboCop::Cop::Style::FormatStringToken, :config do
     }
   end
 
+  it 'false positives for SQL string matches' do
+    inspect_source(<<~EOS)
+      ActiveRecord::Base.connection.execute(
+        "select * from comments where text like '%search_string%'"
+      )
+    EOS
+
+    expect(cop.highlights).to be_empty
+  end
+
+  it 'false positives for HAML literals' do
+    inspect_source(<<~EOS)
+      raw_haml = "%div.some-class hello I'm a div"
+    EOS
+
+    expect(cop.highlights).to be_empty
+  end
+
+  it 'false positives for %-encoded URL literals' do
+    inspect_source(<<~EOS)
+      expect(response.request.fullpath).to eq '/status?some_param=%EF%BF%BD'
+    EOS
+
+    expect(cop.highlights).to be_empty
+  end
+
   shared_examples 'format string token style' do |name, good, bad|
     bad_style1 = bad
 


### PR DESCRIPTION
**Not for merge:** this is submitted as a PR only to include failing tests.

## Expected behavior

The `Style/FormatStringToken` cop should not warn about strings that aren't used as format strings.

## Actual Behaviour

Many other uses of `%` characters in other types of string literals are matched:

```ruby
# SQL string matches
ActiveRecord::Base.connection.execute("select * from comments where text like '%search_string%'")
                                                                               ^^      

# HAML literals
raw_haml = "%div.some-class hello I'm a div"
            ^^

# %-encoded URLs
expect(response.request.fullpath).to eq '/status?some_param=%EF%BF%BD'
                                                            ^^ ^^ ^^
```

## Steps to reproduce the problem

Failing tests are attached:

    $ rspec spec/rubocop/cop/style/format_string_token_spec.rb

## Rubocop version

This is on current master as of 6fb5a8497:

```
$ bundle exec rubocop -V
0.52.0 (using Parser 2.4.0.2, running on ruby 2.3.5 x86_64-darwin16)
```

## Discussion

This seems like it'll be a tricky one to fix, since rubocop can't know if a string is being stored to later be used in a `Kernel#format`, `Kernel#sprintf` or `String#%` call.

Given this, perhaps it's preferable to apply this rule only if a direct invocation of those methods is detected (as in the `Style/FormatString` cop)? It means the rule won't catch memoised string formats, but would avoid the many false positives.