### PR TITLE
fix multiline indent for Style/BracesAroundHashParameters autocorrect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * [#5313](https://github.com/bbatsov/rubocop/issues/5313): Fix `Style/HashSyntax` from stripping quotes off of symbols during autocorrection for ruby22+. ([@garettarrowood][])
 * [#5315](https://github.com/bbatsov/rubocop/issues/5315): Fix a false positive of `Layout/RescueEnsureAlignment` in Ruby 2.5. ([@pocke][])
 * [#5236](https://github.com/bbatsov/rubocop/issues/5236): Fix false positives for `Rails/InverseOf` when using `with_options`. ([@wata727][])
+* [#5291](https://github.com/bbatsov/rubocop/issues/5291): Fix multiline indent for `Style/BracesAroundHashParameters` autocorrect. ([@flyerhzm][])
 
 ### Changes
 
@@ -3115,3 +3116,4 @@
 [@nattfodd]: https://github.com/nattfodd
 [@nattfodd]: https://github.com/nattfodd
 [@melch]: https://github.com/melch
+[@flyerhzm]: https://github.com/flyerhzm

--- a/spec/rubocop/cop/style/braces_around_hash_parameters_spec.rb
+++ b/spec/rubocop/cop/style/braces_around_hash_parameters_spec.rb
@@ -138,6 +138,22 @@ RSpec.describe RuboCop::Cop::Style::BracesAroundHashParameters, :config do
       expect(corrected).to eq('get :i, q: { x: 1 }')
     end
 
+    it 'does not break indent' do
+      src = <<-RUBY
+      foo({
+        a: 1,
+        b: 2
+      })
+      RUBY
+      corrected = autocorrect_source(src)
+      expect(corrected).to eq(<<-RUBY)
+      foo(
+        a: 1,
+        b: 2
+      )
+      RUBY
+    end
+
     it 'does not remove trailing comma nor realign args' do
       src = <<-RUBY.strip_indent
       foo({
@@ -165,7 +181,7 @@ RSpec.describe RuboCop::Cop::Style::BracesAroundHashParameters, :config do
       corrected = autocorrect_source(src)
       expect(corrected).to eq(<<-RUBY.strip_indent)
       foo(
-        baz: 10
+          baz: 10
       )
       RUBY
     end
@@ -183,7 +199,7 @@ RSpec.describe RuboCop::Cop::Style::BracesAroundHashParameters, :config do
       corrected = autocorrect_source(src)
       expect(corrected).to eq(<<-RUBY.strip_indent)
       foo(
-        qux: "bar",
+          qux: "bar",
           baz: "bar",
           thud: "bar"
       )
@@ -215,7 +231,7 @@ RSpec.describe RuboCop::Cop::Style::BracesAroundHashParameters, :config do
       corrected = autocorrect_source(src)
       expect(corrected).to eq(<<-RUBY.strip_indent)
       foo(
-        baz: 5
+          baz: 5
       )
       RUBY
     end
@@ -296,7 +312,7 @@ RSpec.describe RuboCop::Cop::Style::BracesAroundHashParameters, :config do
           {
             qux: 9
           },
-          bar: 0
+            bar: 0
         )
         RUBY
       end


### PR DESCRIPTION
See https://github.com/bbatsov/rubocop/issues/5291

It breaks some existing test cases, but I think the my case happens more in real code. cc @garettarrowood 

I removed `strip_indent` in test code, most of time we have indent in real code.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
