### PR TITLE
Only write valid YAML when auto-generating config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * [#5223](https://github.com/bbatsov/rubocop/issues/5223): False offences in :unannotated Style/FormatStringToken. ([@nattfodd][])
 * [#5258](https://github.com/bbatsov/rubocop/issues/5258): Fix incorrect autocorrection for `Rails/Presence` when the else block is multiline. ([@wata727][])
 * [#5297](https://github.com/bbatsov/rubocop/pull/5297): Improve inspection for `Rails/InverseOf` when including `through` or `polymorphic` options. ([@wata727][])
+* [#5281](https://github.com/bbatsov/rubocop/issues/5281): Fix issue where `--auto-gen-config` might fail on invalid YAML. ([@bquorning][])
 
 ### Changes
 
@@ -3109,3 +3110,5 @@
 [@siggymcfried]: https://github.com/siggymcfried
 [@melch]: https://github.com/melch
 [@nattfodd]: https://github.com/nattfodd
+[@nattfodd]: https://github.com/nattfodd
+[@melch]: https://github.com/melch


### PR DESCRIPTION
Fixes #5281.

In `DisabledConfigFormatter#excludes` we may end up reading the very same YAML file that is currently being generated. It is therefore important that we always only write "chunks" of valid YAML to it, so the resulting file itself is always valid YAML.

I am not complete sure under what conditions the error occurs, so I would appreciate any help I could get in writing a test case.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
