### PR TITLE
Improve inspection for `Rails/InverseOf`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * [#5293](https://github.com/bbatsov/rubocop/issues/5293): Fix a regression for `Rails/HasManyOrHasOneDependent` when using a option of `has_many` or `has_one` association. ([@koic][])
 * [#5223](https://github.com/bbatsov/rubocop/issues/5223): False offences in :unannotated Style/FormatStringToken. ([@nattfodd][])
 * [#5258](https://github.com/bbatsov/rubocop/issues/5258): Fix incorrect autocorrection for `Rails/Presence` when the else block is multiline. ([@wata727][])
+* [#5297](https://github.com/bbatsov/rubocop/pull/5297): Improve inspection for `Rails/InverseOf` when including `through` or `polymorphic` options. ([@wata727][])
 
 ### Changes
 

--- a/manual/cops_rails.md
+++ b/manual/cops_rails.md
@@ -689,17 +689,96 @@ for associations to work in both ways, or set to `false` to opt-out.
 ### Examples
 
 ```ruby
+# good
+class Blog < ApplicationRecord
+  has_many :posts
+end
+
+class Post < ApplicationRecord
+  belongs_to :blog
+end
+```
+```ruby
 # bad
 class Blog < ApplicationRecord
-  has_many :recent_posts, -> { order(published_at: :desc) }
+  has_many :posts, -> { order(published_at: :desc) }
+end
+
+class Post < ApplicationRecord
+  belongs_to :blog
 end
 
 # good
 class Blog < ApplicationRecord
-  has_many(:recent_posts,
+  has_many(:posts,
     -> { order(published_at: :desc) },
     inverse_of: :blog
   )
+end
+
+class Post < ApplicationRecord
+  belongs_to :blog
+end
+```
+```ruby
+# bad
+class Picture < ApplicationRecord
+  belongs_to :imageable, polymorphic: true
+end
+
+class Employee < ApplicationRecord
+  has_many :pictures, as: :imageable
+end
+
+class Product < ApplicationRecord
+  has_many :pictures, as: :imageable
+end
+
+# good
+class Picture < ApplicationRecord
+  belongs_to :imageable, polymorphic: true
+end
+
+class Employee < ApplicationRecord
+  has_many :pictures, as: :imageable, inverse_of: :imageable
+end
+
+class Product < ApplicationRecord
+  has_many :pictures, as: :imageable, inverse_of: :imageable
+end
+```
+```ruby
+# bad
+# However, RuboCop can not detect this pattern...
+class Physician < ApplicationRecord
+  has_many :appointments
+  has_many :patients, through: :appointments
+end
+
+class Appointment < ApplicationRecord
+  belongs_to :physician
+  belongs_to :patient
+end
+
+class Patient < ApplicationRecord
+  has_many :appointments
+  has_many :physicians, through: :appointments
+end
+
+# good
+class Physician < ApplicationRecord
+  has_many :appointments
+  has_many :patients, through: :appointments
+end
+
+class Appointment < ApplicationRecord
+  belongs_to :physician, inverse_of: :appointments
+  belongs_to :patient, inverse_of: :appointments
+end
+
+class Patient < ApplicationRecord
+  has_many :appointments
+  has_many :physicians, through: :appointments
 end
 ```
 


### PR DESCRIPTION
See #5236 

Currently, `Rails/InverseOf` Cop checks associations unspecified `inverse_of` and included `conditions`, `through`, `polymorphic`, or `foreign_key`. However, this inspection is incorrect.

For example, for `through` and `polymorphic` you have to add `inverse_of` to the inverse association of them.

```ruby
# bad
class Physician < ApplicationRecord
  has_many :appointments
  has_many :patients, through: :appointments, inverse_of: physicians
end

class Appointment < ApplicationRecord
  belongs_to :physician
  belongs_to :patient
end

class Patient < ApplicationRecord
  has_many :appointments
  has_many :physicians, through: :appointments, inverse_of: :patients
end

# good
class Physician < ApplicationRecord
  has_many :appointments
  has_many :patients, through: :appointments
end

class Appointment < ApplicationRecord
  belongs_to :physician, inverse_of: :appointments
  belongs_to :patient, inverse_of: :appointments
end

class Patient < ApplicationRecord
  has_many :appointments
  has_many :physicians, through: :appointments
end
```

```ruby
# bad
class Picture < ApplicationRecord
  belongs_to :imageable, polymorphic: true, inverse_of: :pictures
end

class Employee < ApplicationRecord
  has_many :pictures, as: :imageable
end

class Product < ApplicationRecord
  has_many :pictures, as: :imageable
end

# good
class Picture < ApplicationRecord
  belongs_to :imageable, polymorphic: true
end

class Employee < ApplicationRecord
  has_many :pictures, as: :imageable, inverse_of: :imageable
end

class Product < ApplicationRecord
  has_many :pictures, as: :imageable, inverse_of: :imageable
end
```

Unfortunately, even if this Cop looks at the structure of the `send` node, it can't check for `through` associations. So, it ignores them. In the case of `polymorphic`, this Cop should check on the inverse `as` associations. In addition, I added the check of `class_name` option.

This Cop still includes false positives when using `Object#with_options`. Perhaps I will fix this problem as another pull request.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
