### PR TITLE
Restyle example formatting for `Rails/RequestReferer`

### DIFF
--- a/lib/rubocop/cop/rails/request_referer.rb
+++ b/lib/rubocop/cop/rails/request_referer.rb
@@ -6,15 +6,14 @@ module RuboCop
       # This cop checks for consistent uses of `request.referer` or
       # `request.referrer`, depending on the cop's configuration.
       #
-      # @example
-      #   # EnforcedStyle: referer
+      # @example EnforcedStyle: referer (default)
       #   # bad
       #   request.referrer
       #
       #   # good
       #   request.referer
       #
-      #   # EnforcedStyle: referrer
+      # @example EnforcedStyle: referrer
       #   # bad
       #   request.referer
       #

--- a/manual/cops_rails.md
+++ b/manual/cops_rails.md
@@ -1125,15 +1125,18 @@ This cop checks for consistent uses of `request.referer` or
 
 ### Examples
 
+#### EnforcedStyle: referer (default)
+
 ```ruby
-# EnforcedStyle: referer
 # bad
 request.referrer
 
 # good
 request.referer
+```
+#### EnforcedStyle: referrer
 
-# EnforcedStyle: referrer
+```ruby
 # bad
 request.referer
 


### PR DESCRIPTION
Follow up of https://github.com/bbatsov/rubocop/pull/4880#issuecomment-338499947.

This commit is a change of document format for `Rails/RequestReferer` cop.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
