### PR TITLE
Workaround for broke Travis with RubyGems 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,8 @@ matrix:
     - rvm: jruby-head
   fast_finish: true
 before_install:
+  - gem update --system 2.6.14
   - gem update --remote bundler
-  - gem update --system
 install:
   - bundle install --retry=3
 script:


### PR DESCRIPTION
This is a workaround patch to Travis CI.
This change attempts to resolve the following error.

```console
$ gem update --system
Updating rubygems-update
Fetching: rubygems-update-2.7.3.gem (100%)
Successfully installed rubygems-update-2.7.3
Installing RubyGems 2.7.3
Bundler 1.16.0 installed
RubyGems 2.7.3 installed
Regenerating binstubs
`/home/travis/.rvm/gems/ruby-2.4.3@global/gems/bundler-1.16.1/exe/bundle`
does not exist, maybe `gem pristine bundler` will fix it?
`/home/travis/.rvm/gems/ruby-2.4.3@global/gems/bundler-1.16.1/exe/bundler`
does not exist, maybe `gem pristine bundler` will fix it?
RubyGems system software updated

$ bundle install --retry=3
/home/travis/.rvm/gems/ruby-2.4.3@global/bin/bundle:23:in `load': cannot
load such file -- /home/travis/.rvm/gems/ruby-2.4.3@global/gems/bundler-1.16.1/exe/bundle (LoadError)
        from /home/travis/.rvm/gems/ruby-2.4.3@global/bin/bundle:23:in `<main>'
        from /home/travis/.rvm/gems/ruby-2.4.3/bin/ruby_executable_hooks:15:in `eval'
        from /home/travis/.rvm/gems/ruby-2.4.3/bin/ruby_executable_hooks:15:in `<main>'
```

https://travis-ci.org/bbatsov/rubocop/builds/320099302

This causes the following RubyGems's issue.
https://github.com/rubygems/rubygems/issues/2123

This change attempt to solve by forcibly updating the RubyGems by using RubyGems 2.6.14 (This version is lower than 2.7) .
