### PR TITLE
Display correction candidate if an incorrect cop name is given

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### Changes
 
+* [#5300](https://github.com/bbatsov/rubocop/pull/5300): Display correction candidate if an incorrect cop name is given. ([@yhirano55][])
 * [#5233](https://github.com/bbatsov/rubocop/pull/5233): Remove `Style/ExtendSelf` cop. ([@pocke][])
 * [#5221](https://github.com/bbatsov/rubocop/issues/5221): Change `Layout/SpaceBeforeBlockBraces`'s `EnforcedStyleForEmptyBraces` from `no_space` to `space`. ([@garettarrowood][])
 * [#3558](https://github.com/bbatsov/rubocop/pull/3558): Create `Corrector` classes and move all `autocorrect` methods out of mixin Modules. ([@garettarrowood][])

--- a/spec/rubocop/cli/cli_options_spec.rb
+++ b/spec/rubocop/cli/cli_options_spec.rb
@@ -143,6 +143,15 @@ describe RuboCop::CLI, :isolated_environment do
           .to include('Unrecognized cop or department: Style/123.')
       end
 
+      it 'displays correction candidate if an incorrect cop name is given' do
+        create_file('example.rb', ['x'])
+        expect(cli.run(['--only', 'Style/BlockComment'])).to eq(2)
+        expect($stderr.string)
+          .to include('Unrecognized cop or department: Style/BlockComment.')
+        expect($stderr.string)
+          .to include('Did you mean? Style/BlockComments')
+      end
+
       it 'exits with error if an empty string is given' do
         create_file('example.rb', 'x')
         expect(cli.run(['--only', ''])).to eq(2)
@@ -357,6 +366,15 @@ describe RuboCop::CLI, :isolated_environment do
         create_file('example.rb', 'x')
         expect(cli.run(['--except', ''])).to eq(2)
         expect($stderr.string).to include('Unrecognized cop or department: .')
+      end
+
+      it 'displays correction candidate if an incorrect cop name is given' do
+        create_file('example.rb', 'x')
+        expect(cli.run(['--except', 'Style/BlockComment'])).to eq(2)
+        expect($stderr.string)
+          .to include('Unrecognized cop or department: Style/BlockComment.')
+        expect($stderr.string)
+          .to include('Did you mean? Style/BlockComments')
       end
 
       %w[Syntax Lint/Syntax].each do |name|


### PR DESCRIPTION
Maybe we cannot memorize correctly cop names.

if an incorrect cop name is given with `--only` or `--except` options on CLI option,
it just only raises exception. I think it's not friendly.

So I've added its error message to correction candidate.

Example:

```
$ bundle exec rubocop --only Lint/Li
Inspecting 1081 files

0 files inspected, no offenses detected
Unrecognized cop or department: Lint/Li.
Did you mean? Lint/LiteralAsCondition, Lint/LiteralInInterpolation
...
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
