### PR TITLE
[Fix #5259] Resolve Style/CommentedKeyword false positives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [#5273](https://github.com/bbatsov/rubocop/issues/5273): Fix `Style/EvalWithLocation` reporting bad line offset. ([@pocke][])
 * [#5228](https://github.com/bbatsov/rubocop/issues/5228): Handle overridden `Metrics/LineLength:Max` for `--auto-gen-config`. ([@jonas054][])
 * [#5226](https://github.com/bbatsov/rubocop/issues/5226): Suppress false positives for `Rails/RedundantReceiverInWithOptions` when including another receiver in `with_options`. ([@wata727][])
+* [#5259](https://github.com/bbatsov/rubocop/pull/5259): Fix false positives in `Style/CommentedKeyword`. ([@garettarrowood][])
 * [#5238](https://github.com/bbatsov/rubocop/pull/5238): Fix error when #present? or #blank? is used in if or unless modifier. ([@eitoball][])
 * [#5261](https://github.com/bbatsov/rubocop/issues/5261): Fix a false positive for `Style/MixinUsage` when using inside class or module. ([@koic][])
 * [#4444](https://github.com/bbatsov/rubocop/issues/4444): Fix `Style/AutoResourceCleanup` shouldn't flag `File.open(...).close`. ([@dpostorivo][])

--- a/lib/rubocop/cop/style/commented_keyword.rb
+++ b/lib/rubocop/cop/style/commented_keyword.rb
@@ -60,7 +60,7 @@ module RuboCop
 
         def offensive?(line)
           line = line.lstrip
-          line.start_with?(*KEYWORDS) &&
+          KEYWORDS.any? { |word| line =~ /^#{word}\s/ } &&
             ALLOWED_COMMENTS.none? { |c| line =~ /#\s*#{c}/ }
         end
 

--- a/spec/rubocop/cop/style/commented_keyword_spec.rb
+++ b/spec/rubocop/cop/style/commented_keyword_spec.rb
@@ -155,4 +155,18 @@ describe RuboCop::Cop::Style::CommentedKeyword do
       end
     RUBY
   end
+
+  it 'accepts keyword letter sequences that are not keywords' do
+    expect_no_offenses(<<-RUBY.strip_indent)
+      options = {
+        end_buttons: true, # comment
+      }
+    RUBY
+    expect_no_offenses(<<-RUBY.strip_indent)
+      defined?(SomeModule).should be_nil # comment
+    RUBY
+    expect_no_offenses(<<-RUBY.strip_indent)
+      foo = beginning_statement # comment
+    RUBY
+  end
 end


### PR DESCRIPTION
Fixes false positives reported for Style/CommentedKeyword in #5259 .

Ruby keywords are not keywords unless they are followed by whitespace :p .

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
