### PR TITLE
Suppress backtrace after correct candidate cop name

### DIFF
--- a/lib/rubocop/cli.rb
+++ b/lib/rubocop/cli.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# rubocop:disable Metrics/ClassLength
 module RuboCop
   # The CLI is a class responsible of handling all the command line interface
   # logic.
@@ -27,6 +28,8 @@ module RuboCop
     #
     # @param args [Array<String>] command line arguments
     # @return [Integer] UNIX exit code
+    #
+    # rubocop:disable Metrics/MethodLength
     def run(args = ARGV)
       @options, paths = Options.new.parse(args)
       validate_options_vs_config
@@ -38,11 +41,15 @@ module RuboCop
       return 2
     rescue Finished
       return 0
+    rescue IncorrectCopNameError => e
+      warn e.message
+      return 2
     rescue StandardError, SyntaxError, LoadError => e
       warn e.message
       warn e.backtrace
       return 2
     end
+    # rubocop:enable Metrics/MethodLength
 
     def trap_interrupt(runner)
       Signal.trap('INT') do
@@ -258,3 +265,4 @@ module RuboCop
     end
   end
 end
+# rubocop:enable Metrics/ClassLength

--- a/lib/rubocop/options.rb
+++ b/lib/rubocop/options.rb
@@ -4,6 +4,8 @@ require 'optparse'
 require 'shellwords'
 
 module RuboCop
+  class IncorrectCopNameError < StandardError; end
+
   # This class handles command line options.
   class Options
     EXITING_OPTIONS = %i[version verbose_version show_cops].freeze
@@ -197,7 +199,7 @@ module RuboCop
           next if departments.include?(name)
           next if %w[Syntax Lint/Syntax].include?(name)
 
-          raise ArgumentError, format_message_from(name, cop_names)
+          raise IncorrectCopNameError, format_message_from(name, cop_names)
         end
       end
 


### PR DESCRIPTION
Follow up of #5300.

This commit suppresses backtrace when the following case.

## Before

```console
% rubocop --only Lint/RedundantWithI
Inspecting 1081 files

0 files inspected, no offenses detected
Unrecognized cop or department: Lint/RedundantWithI.
Did you mean? Lint/RedundantWithIndex
/Users/koic/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/rubocop-0.52.0/lib/rubocop/options.rb:200:in `block in validate_cop_list'
/Users/koic/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/rubocop-0.52.0/lib/rubocop/options.rb:195:in `each'
/Users/koic/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/rubocop-0.52.0/lib/rubocop/options.rb:195:in `validate_cop_list'
/Users/koic/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/rubocop-0.52.0/lib/rubocop/runner.rb:275:in `block in mobilized_cop_classes'
/Users/koic/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/rubocop-0.52.0/lib/rubocop/runner.rb:274:in `each'
/Users/koic/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/rubocop-0.52.0/lib/rubocop/runner.rb:274:in `mobilized_cop_classes'
/Users/koic/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/rubocop-0.52.0/lib/rubocop/runner.rb:257:in `inspect_file'
/Users/koic/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/rubocop-0.52.0/lib/rubocop/runner.rb:205:in `block in do_inspection_loop'
/Users/koic/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/rubocop-0.52.0/lib/rubocop/runner.rb:237:in `block in iterate_until_no_changes'
/Users/koic/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/rubocop-0.52.0/lib/rubocop/runner.rb:230:in `loop'
/Users/koic/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/rubocop-0.52.0/lib/rubocop/runner.rb:230:in `iterate_until_no_changes'
/Users/koic/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/rubocop-0.52.0/lib/rubocop/runner.rb:201:in `do_inspection_loop'
/Users/koic/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/rubocop-0.52.0/lib/rubocop/runner.rb:111:in `block in file_offenses'
/Users/koic/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/rubocop-0.52.0/lib/rubocop/runner.rb:121:in `file_offense_cache'
/Users/koic/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/rubocop-0.52.0/lib/rubocop/runner.rb:109:in `file_offenses'
/Users/koic/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/rubocop-0.52.0/lib/rubocop/runner.rb:100:in `process_file'
/Users/koic/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/rubocop-0.52.0/lib/rubocop/runner.rb:78:in `block in each_inspected_file'
/Users/koic/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/rubocop-0.52.0/lib/rubocop/runner.rb:75:in `each'
/Users/koic/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/rubocop-0.52.0/lib/rubocop/runner.rb:75:in `reduce'
/Users/koic/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/rubocop-0.52.0/lib/rubocop/runner.rb:75:in `each_inspected_file'
/Users/koic/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/rubocop-0.52.0/lib/rubocop/runner.rb:67:in `inspect_files'
/Users/koic/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/rubocop-0.52.0/lib/rubocop/runner.rb:39:in `run'
/Users/koic/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/rubocop-0.52.0/lib/rubocop/cli.rb:143:in `execute_runner'
/Users/koic/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/rubocop-0.52.0/lib/rubocop/cli.rb:71:in `execute_runners'
/Users/koic/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/rubocop-0.52.0/lib/rubocop/cli.rb:35:in `run'
/Users/koic/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/rubocop-0.52.0/bin/rubocop:13:in `block in <top (required)>'
/Users/koic/.rbenv/versions/2.4.3/lib/ruby/2.4.0/benchmark.rb:308:in `realtime'
/Users/koic/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/rubocop-0.52.0/bin/rubocop:12:in `<top (required)>'
/Users/koic/.rbenv/versions/2.4.3/bin/rubocop:23:in `load'
/Users/koic/.rbenv/versions/2.4.3/bin/rubocop:23:in `<main>'
```

## After

```console
% rubocop --only Lint/RedundantWithI
Inspecting 1081 files

0 files inspected, no offenses detected
Unrecognized cop or department: Lint/RedundantWithI.
Did you mean? Lint/RedundantWithIndex
```

As a general RuboCop users, it is undesirable to have the correct candidate cop name buried in the backtrace.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
