### PR TITLE
Revert `Workaround for broke Travis with RubyGems 2.7`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
     - rvm: jruby-head
   fast_finish: true
 before_install:
-  - gem update --system 2.6.14
+  - gem update --system
   - gem update --remote bundler
 install:
   - bundle install --retry=3


### PR DESCRIPTION
rubygems/rubygems#2123 has been resolved and fixed version RubyGems 2.7.4 released.
Version specification to `gem update --system` is no longer necessary.

Related rails/rails#31558.
