### PR TITLE
[Fix #5236] Fix false positives for `Rails/InverseOf`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * [#5258](https://github.com/bbatsov/rubocop/issues/5258): Fix incorrect autocorrection for `Rails/Presence` when the else block is multiline. ([@wata727][])
 * [#5297](https://github.com/bbatsov/rubocop/pull/5297): Improve inspection for `Rails/InverseOf` when including `through` or `polymorphic` options. ([@wata727][])
 * [#5281](https://github.com/bbatsov/rubocop/issues/5281): Fix issue where `--auto-gen-config` might fail on invalid YAML. ([@bquorning][])
+* [#5236](https://github.com/bbatsov/rubocop/issues/5236): Fix false positives for `Rails/InverseOf` when using `with_options`. ([@wata727][])
 
 ### Changes
 

--- a/manual/cops_rails.md
+++ b/manual/cops_rails.md
@@ -719,6 +719,17 @@ end
 class Post < ApplicationRecord
   belongs_to :blog
 end
+
+# good
+class Blog < ApplicationRecord
+  with_options inverse_of: :blog do
+    has_many :posts, -> { order(published_at: :desc) }
+  end
+end
+
+class Post < ApplicationRecord
+  belongs_to :blog
+end
 ```
 ```ruby
 # bad

--- a/spec/rubocop/cop/rails/inverse_of_spec.rb
+++ b/spec/rubocop/cop/rails/inverse_of_spec.rb
@@ -8,10 +8,10 @@ describe RuboCop::Cop::Rails::InverseOf do
   context 'with scope' do
     it 'registers an offense when not specifying `:inverse_of`' do
       expect_offense(<<-RUBY.strip_indent)
-      class Person
-        has_one :foo, -> () { where(bar: true) }
-        ^^^^^^^ Specify an `:inverse_of` option.
-      end
+        class Person
+          has_one :foo, -> () { where(bar: true) }
+          ^^^^^^^ Specify an `:inverse_of` option.
+        end
       RUBY
     end
 
@@ -25,10 +25,10 @@ describe RuboCop::Cop::Rails::InverseOf do
   context 'with option preventing automatic inverse' do
     it 'registers an offense when not specifying `:inverse_of`' do
       expect_offense(<<-RUBY.strip_indent)
-      class Person
-        belongs_to :foo, foreign_key: 'foo_id'
-        ^^^^^^^^^^ Specify an `:inverse_of` option.
-      end
+        class Person
+          belongs_to :foo, foreign_key: 'foo_id'
+          ^^^^^^^^^^ Specify an `:inverse_of` option.
+        end
       RUBY
     end
 
@@ -46,28 +46,28 @@ describe RuboCop::Cop::Rails::InverseOf do
 
     it 'registers an offense with other option and `:inverse_of` unset' do
       expect_offense(<<-RUBY.strip_indent)
-      class Person
-        has_many :foo, dependent: :destroy, foreign_key: 'foo_id'
-        ^^^^^^^^ Specify an `:inverse_of` option.
-      end
+        class Person
+          has_many :foo, dependent: :destroy, foreign_key: 'foo_id'
+          ^^^^^^^^ Specify an `:inverse_of` option.
+        end
       RUBY
     end
 
     it 'registers an offense when including `class_name` option' do
       expect_offense(<<-RUBY.strip_indent)
-      class Book < ApplicationRecord
-        belongs_to :author, class_name: "Patron"
-        ^^^^^^^^^^ Specify an `:inverse_of` option.
-      end
+        class Book < ApplicationRecord
+          belongs_to :author, class_name: "Patron"
+          ^^^^^^^^^^ Specify an `:inverse_of` option.
+        end
       RUBY
     end
 
     it 'registers an offense when including `conditions` option' do
       expect_offense(<<-RUBY.strip_indent)
-      class Person
-        has_many :foo, conditions: -> { where(bar: true) }
-        ^^^^^^^^ Specify an `:inverse_of` option.
-      end
+        class Person
+          has_many :foo, conditions: -> { where(bar: true) }
+          ^^^^^^^^ Specify an `:inverse_of` option.
+        end
       RUBY
     end
   end
@@ -93,10 +93,10 @@ describe RuboCop::Cop::Rails::InverseOf do
     context 'Rails < 5.2', :rails5 do
       it 'registers an offense when not specifying `:inverse_of`' do
         expect_offense(<<-RUBY.strip_indent)
-        class Person
-          has_many :pictures, as: :imageable
-          ^^^^^^^^ Specify an `:inverse_of` option.
-        end
+          class Person
+            has_many :pictures, as: :imageable
+            ^^^^^^^^ Specify an `:inverse_of` option.
+          end
         RUBY
       end
     end
@@ -127,18 +127,106 @@ describe RuboCop::Cop::Rails::InverseOf do
   context 'with option ignoring `:inverse_of`' do
     it 'does not register an offense when including `through` option' do
       expect_no_offenses(<<-RUBY.strip_indent)
-      class Physician < ApplicationRecord
-        has_many :appointments
-        has_many :patients, -> () { where(bar: true) }, through: :appointments
-      end
+        class Physician < ApplicationRecord
+          has_many :appointments
+          has_many :patients, -> () { where(bar: true) }, through: :appointments
+        end
       RUBY
     end
 
     it 'does not register an offense when including `polymorphic` option' do
       expect_no_offenses(<<-RUBY.strip_indent)
-      class Picture < ApplicationRecord
-        belongs_to :imageable, -> () { where(bar: true) }, polymorphic: true
-      end
+        class Picture < ApplicationRecord
+          belongs_to :imageable, -> () { where(bar: true) }, polymorphic: true
+        end
+      RUBY
+    end
+  end
+
+  context 'with valid options in `with_options`' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        class Person
+          with_options inverse_of: false do
+            has_one :foo, -> () { where(bar: true) }
+          end
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when using the explicit receiver' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        class Person
+          with_options inverse_of: :bar do |assoc|
+            assoc.belongs_to :foo, foreign_key: 'foo_id'
+          end
+        end
+      RUBY
+    end
+
+    it 'registers an offense when using the invalid explicit receiver' do
+      expect_offense(<<-RUBY.strip_indent)
+        class Person
+          with_options inverse_of: :bar do |_assoc|
+            belongs_to :foo, foreign_key: 'foo_id'
+            ^^^^^^^^^^ Specify an `:inverse_of` option.
+          end
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when using multiple blocks' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        class Book < ApplicationRecord
+          with_options inverse_of: :book do
+            with_helper do |helper|
+              helper.define_assoc
+              with_options class_name: "Patron" do
+                belongs_to :author
+              end
+            end
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'with invalid options in `with_options`' do
+    it 'registers an offense' do
+      expect_offense(<<-RUBY.strip_indent)
+        class Person
+          with_options class_name: "hoge" do
+            has_one :foo
+            ^^^^^^^ Specify an `:inverse_of` option.
+          end
+        end
+      RUBY
+    end
+
+    it 'registers an offense when using the explicit receiver' do
+      expect_offense(<<-RUBY.strip_indent)
+        class Person
+          with_options class_name: "baz" do |assoc|
+            assoc.belongs_to :foo, foreign_key: 'foo_id'
+                  ^^^^^^^^^^ Specify an `:inverse_of` option.
+          end
+        end
+      RUBY
+    end
+
+    it 'registers an offense when using multiple blocks' do
+      expect_offense(<<-RUBY.strip_indent)
+        class Book < ApplicationRecord
+          with_options class_name: "Patron" do
+            with_helper do |helper|
+              helper.define_assoc
+              with_options foreign_key: "patron_id" do
+                belongs_to :author
+                ^^^^^^^^^^ Specify an `:inverse_of` option.
+              end
+            end
+          end
+        end
       RUBY
     end
   end


### PR DESCRIPTION
Fixes #5236

When using `Object#with_options`, `:inverse_of` works even if doesn't declare it directly in associations.

```ruby
class Blog < ApplicationRecord
  with_options inverse_of: :blog do # good
    has_many :posts, -> { order(published_at: :desc) }
  end
end
```

So if the association is in a block with `with_options`, this Cop check that options.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
