### PR TITLE
[Fix #5315] Fix a false positive of `Layout/RescueEnsureAlignment` in Ruby 2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * [#5258](https://github.com/bbatsov/rubocop/issues/5258): Fix incorrect autocorrection for `Rails/Presence` when the else block is multiline. ([@wata727][])
 * [#5297](https://github.com/bbatsov/rubocop/pull/5297): Improve inspection for `Rails/InverseOf` when including `through` or `polymorphic` options. ([@wata727][])
 * [#5281](https://github.com/bbatsov/rubocop/issues/5281): Fix issue where `--auto-gen-config` might fail on invalid YAML. ([@bquorning][])
+* [#5315](https://github.com/bbatsov/rubocop/issues/5315): Fix a false positive of `Layout/RescueEnsureAlignment` in Ruby 2.5. ([@pocke][])
 
 ### Changes
 

--- a/lib/rubocop/cop/layout/rescue_ensure_alignment.rb
+++ b/lib/rubocop/cop/layout/rescue_ensure_alignment.rb
@@ -86,7 +86,9 @@ module RuboCop
         end
 
         def ancestor_node(node)
-          node.each_ancestor(:kwbegin, :def, :defs, :class, :module).first
+          types = %i[kwbegin def defs class module]
+          types << :block if target_ruby_version >= 2.5
+          node.each_ancestor(*types).first
         end
       end
     end

--- a/spec/rubocop/cop/layout/rescue_ensure_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/rescue_ensure_alignment_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::Layout::RescueEnsureAlignment do
-  subject(:cop) { described_class.new }
+RSpec.describe RuboCop::Cop::Layout::RescueEnsureAlignment, :config do
+  subject(:cop) { described_class.new(config) }
 
   shared_examples 'common behavior' do |keyword|
     context 'bad alignment' do
@@ -96,6 +96,43 @@ RSpec.describe RuboCop::Cop::Layout::RescueEnsureAlignment do
                       '    error',
                       'end'])
       expect(cop.messages.empty?).to be(true)
+    end
+
+    context '>= Ruby 2.5', :ruby25 do
+      it "accepts aligned #{keyword} in do-end block" do
+        expect_no_offenses(<<-RUBY.strip_indent)
+          [1, 2, 3].each do |el|
+            el.to_s
+          rescue StandardError => _exception
+            next
+          end
+        RUBY
+      end
+
+      it "accepts aligned #{keyword} in do-end block in a method" do
+        expect_no_offenses(<<-RUBY.strip_indent)
+          def foo
+            [1, 2, 3].each do |el|
+              el.to_s
+            rescue StandardError => _exception
+              next
+            end
+          end
+        RUBY
+      end
+
+      it "registers an offense for not aligned #{keyword} in do-end block" do
+        expect_offense(<<-RUBY.strip_indent)
+          def foo
+            [1, 2, 3].each do |el|
+              el.to_s
+          rescue StandardError => _exception
+          ^^^^^^ `rescue` at 4, 0 is not aligned with `end` at 6, 2.
+              next
+            end
+          end
+        RUBY
+      end
     end
   end
 


### PR DESCRIPTION
See #5315 



-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
