### PR TITLE
Fix typos in spec descriptions

### DIFF
--- a/spec/rubocop/config_spec.rb
+++ b/spec/rubocop/config_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe RuboCop::Config do
       end
     end
 
-    context 'when the configration includes an invalid EnforcedStyle' do
+    context 'when the configuration includes an invalid EnforcedStyle' do
       before do
         create_file(configuration_path, <<-YAML.strip_indent)
           Style/AndOr:
@@ -144,7 +144,7 @@ RSpec.describe RuboCop::Config do
       end
     end
 
-    context 'when the configration includes a valid Enforced.+Style' do
+    context 'when the configuration includes a valid EnforcedStyle' do
       before do
         create_file(configuration_path, <<-YAML.strip_indent)
           Layout/SpaceAroundBlockParameters:
@@ -157,7 +157,7 @@ RSpec.describe RuboCop::Config do
       end
     end
 
-    context 'when the configration includes an invalid Enforced.+Style' do
+    context 'when the configuration includes an invalid EnforcedStyle' do
       before do
         create_file(configuration_path, <<-YAML.strip_indent)
           Layout/SpaceAroundBlockParameters:


### PR DESCRIPTION
- `configration` -> `configuration`
- `Enforced.+Style` -> `EnforcedStyle`

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
