### PR TITLE
[Fix #5313] Do not strip quotes from symbol in Style/HashSytax autocorrection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,9 @@
 * [#5258](https://github.com/bbatsov/rubocop/issues/5258): Fix incorrect autocorrection for `Rails/Presence` when the else block is multiline. ([@wata727][])
 * [#5297](https://github.com/bbatsov/rubocop/pull/5297): Improve inspection for `Rails/InverseOf` when including `through` or `polymorphic` options. ([@wata727][])
 * [#5281](https://github.com/bbatsov/rubocop/issues/5281): Fix issue where `--auto-gen-config` might fail on invalid YAML. ([@bquorning][])
+* [#5313](https://github.com/bbatsov/rubocop/issues/5313): Fix `Style/HashSyntax` from stripping quotes off of symbols during autocorrection for ruby22+. ([@garettarrowood][])
 * [#5315](https://github.com/bbatsov/rubocop/issues/5315): Fix a false positive of `Layout/RescueEnsureAlignment` in Ruby 2.5. ([@pocke][])
-* [#5236](https://github.com/bbatsov/rubocop/issues/5236): Fix false positives for `Rails/InverseOf` when using `with_options`. ([@wata727][]) 
+* [#5236](https://github.com/bbatsov/rubocop/issues/5236): Fix false positives for `Rails/InverseOf` when using `with_options`. ([@wata727][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/hash_syntax.rb
+++ b/lib/rubocop/cop/style/hash_syntax.rb
@@ -173,11 +173,12 @@ module RuboCop
           range = range_between(key.source_range.begin_pos, op.end_pos)
           range = range_with_surrounding_space(range: range, side: :right)
 
-          new_key = key.sym_type? ? key.value : key.source
-
           space = argument_without_space?(pair_node.parent) ? ' ' : ''
 
-          corrector.replace(range, "#{space}#{new_key}: ")
+          corrector.replace(
+            range,
+            range.source.sub(/^:(.*\S)\s*=>\s*$/, space.to_s + '\1: ')
+          )
         end
 
         def argument_without_space?(node)

--- a/spec/rubocop/cop/style/hash_syntax_spec.rb
+++ b/spec/rubocop/cop/style/hash_syntax_spec.rb
@@ -67,6 +67,11 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
                   ^^^^^^^^^^^^ Use the new Ruby 1.9 hash syntax.
           RUBY
         end
+
+        it 'preserves quotes during autocorrection' do
+          new_source = autocorrect_source("{ :'&&' => foo }")
+          expect(new_source).to eq("{ '&&': foo }")
+        end
       end
 
       context 'if PreferHashRocketsForNonAlnumEndingSymbols is false' do


### PR DESCRIPTION
See #5313 . 

-----------------

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
