### PR TITLE
CI against Ruby 2.5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ rvm:
   - 2.2.9
   - 2.3.6
   - 2.4.3
+  - 2.5.0
   - ruby-head
 env:
   global:


### PR DESCRIPTION
Ruby 2.5.0 has been released and available on Travis CI.
https://www.ruby-lang.org/en/news/2017/12/25/ruby-2-5-0-released/
