### PR TITLE
[Fix #3318] Look for `.ruby-version` in parent directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * [#5315](https://github.com/bbatsov/rubocop/issues/5315): Fix a false positive of `Layout/RescueEnsureAlignment` in Ruby 2.5. ([@pocke][])
 * [#5236](https://github.com/bbatsov/rubocop/issues/5236): Fix false positives for `Rails/InverseOf` when using `with_options`. ([@wata727][])
 * [#5291](https://github.com/bbatsov/rubocop/issues/5291): Fix multiline indent for `Style/BracesAroundHashParameters` autocorrect. ([@flyerhzm][])
+* [#3318](https://github.com/bbatsov/rubocop/issues/3318): Look for `.ruby-version` in parent directories. ([@ybiquitous][])
 
 ### Changes
 
@@ -3117,3 +3118,4 @@
 [@nattfodd]: https://github.com/nattfodd
 [@melch]: https://github.com/melch
 [@flyerhzm]: https://github.com/flyerhzm
+[@ybiquitous]: https://github.com/ybiquitous

--- a/lib/rubocop/path_util.rb
+++ b/lib/rubocop/path_util.rb
@@ -43,6 +43,13 @@ module RuboCop
       end
     end
 
+    def find_file_upwards(filename, start_dir = PathUtil.pwd)
+      Pathname(File.expand_path(start_dir)).ascend do |dir|
+        file = File.join(dir, filename)
+        return file if File.exist?(file)
+      end
+    end
+
     # Returns true for an absolute Unix or Windows path.
     def absolute?(path)
       path =~ %r{\A([A-Z]:)?/}

--- a/spec/rubocop/path_util_spec.rb
+++ b/spec/rubocop/path_util_spec.rb
@@ -85,4 +85,28 @@ RSpec.describe RuboCop::PathUtil do
       expect(described_class.match_path?(/^d.*$/, "dir/file\xBF")).to be(false)
     end
   end
+
+  describe '#find_file_upwards', :isolated_environment do
+    include FileHelper
+
+    before do
+      create_file('file', '')
+      create_file('dir/file', '')
+    end
+
+    it 'returns a file to be found upwards' do
+      expect(described_class.find_file_upwards('file'))
+        .to eq(File.join(Dir.pwd, 'file'))
+    end
+
+    it 'returns a file when start directory is given' do
+      expect(described_class.find_file_upwards('file', 'dir'))
+        .to eq(File.join(Dir.pwd, 'dir', 'file'))
+    end
+
+    it 'returns nil when file is not found' do
+      expect(described_class.find_file_upwards('xyz')).to be(nil)
+      expect(described_class.find_file_upwards('xyz', 'dir')).to be(nil)
+    end
+  end
 end


### PR DESCRIPTION
See #3318

Changes:

- Try to look for `.ruby-version` file in parent directories
  if this file doesn't exist in current directory

- Fix `RuboCop::Config#target_ruby_version`

- Add `RuboCop::PathUtil.find_file_upwards` (utility method)

- Simplify test cases of `RuboCop::Config` by avoiding stubs

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
