### PR TITLE
Improve searching for correct cop candidates

### DIFF
--- a/lib/rubocop/options.rb
+++ b/lib/rubocop/options.rb
@@ -208,7 +208,10 @@ module RuboCop
       def format_message_from(name, cop_names)
         message = 'Unrecognized cop or department: %{name}.'
         message_with_candidate = "#{message}\nDid you mean? %{candidate}"
-        corrections = cop_names.select { |cn| cn =~ /\A#{name}/ }.sort
+        corrections = cop_names.select do |cn|
+          score = StringUtil.similarity(cn, name)
+          score >= NameSimilarity::MINIMUM_SIMILARITY_TO_SUGGEST
+        end.sort
 
         if corrections.empty?
           format message, name: name


### PR DESCRIPTION
Follow up of https://github.com/bbatsov/rubocop/pull/5300#issuecomment-353717122.

This commit changed the search approach of the correct cop candidates from prefix-match by regular expression to `StringUtil.similarity`.

## Before

When there is no prefix-match, candidates are not displayed.

```console
% rubocop --only Lint/RedundanWithI
Inspecting 1083 files

0 files inspected, no offenses detected
Unrecognized cop or department: Lint/RedundanWithI.
```

## After

When there is no prefix-match, candidate is displayed.

```console
% rubocop --only Lint/RedundanWithI
Inspecting 1083 files

0 files inspected, no offenses detected
Unrecognized cop or department: Lint/RedundanWithI.
Did you mean? Lint/RedundantWithIndex
```

Cop candidates different from user's expectations may be displayed, however I think that there is no problem in cop names of similarity to typing miss.

```console
% rubocop --only Lint/RedundanWithO
Inspecting 1083 files

0 files inspected, no offenses detected
Unrecognized cop or department: Lint/RedundanWithO.
Did you mean? Lint/RandOne, Lint/RedundantWithObject
```

## Other Information

Initially I thought about using the module of did_you_mean which is a standard library of Ruby 2.3 or higher. However, since the following code does not work unless it is Ruby 2.4 or higher, I decided to use`StringUtil.similarity`.

```ruby
DidYouMean::SpellChecker.new(dictionary: cop_names).correct(name)
```

Also, since it displays multiple cop candidates, this commit did not use `NameSimilarity#find_similar_name`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
