### PR TITLE
[Fix #5334] Semicolon autocorrection in TrailingBodyOnMethodDefinition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 * [#3394](https://github.com/bbatsov/rubocop/issues/3394): Add new `Style/TrailingCommmaInArrayLiteral` cop. ([@garettarrowood][])
 * [#3394](https://github.com/bbatsov/rubocop/issues/3394): Add new `Style/TrailingCommmaInHashLiteral` cop. ([@garettarrowood][])
 
+### Bug fixes
+
+* [#5334](https://github.com/bbatsov/rubocop/issues/5334): Fix semicolon removal for `Style/TrailingBodyOnMethodDefinition` autocorrection. ([@garettarrowood][])
+
 ### Changes
 
 * [#3394](https://github.com/bbatsov/rubocop/issues/3394): Remove `Style/TrailingCommmaInLiteral` in favor of two new cops. ([@garettarrowood][])

--- a/lib/rubocop/cop/mixin/surrounding_space.rb
+++ b/lib/rubocop/cop/mixin/surrounding_space.rb
@@ -51,14 +51,6 @@ module RuboCop
         end
       end
 
-      def tokens(node)
-        @tokens ||= {}
-        @tokens[node.object_id] ||= processed_source.tokens.select do |token|
-          token.end_pos <= node.source_range.end_pos &&
-            token.begin_pos >= node.source_range.begin_pos
-        end
-      end
-
       def no_space_offenses(node, # rubocop:disable Metrics/ParameterLists
                             left_token,
                             right_token,

--- a/lib/rubocop/cop/style/trailing_body_on_method_definition.rb
+++ b/lib/rubocop/cop/style/trailing_body_on_method_definition.rb
@@ -41,7 +41,7 @@ module RuboCop
           lambda do |corrector|
             break_line_before_body(node, corrector)
             move_comment(node, corrector)
-            remove_semicolon(corrector)
+            remove_semicolon(node, corrector)
           end
         end
 
@@ -85,15 +85,13 @@ module RuboCop
           processed_source.comments.find { |c| c.loc.line == line }
         end
 
-        def remove_semicolon(corrector)
-          return unless semicolon
-          corrector.remove(semicolon.pos)
+        def remove_semicolon(node, corrector)
+          return unless semicolon(node)
+          corrector.remove(semicolon(node).pos)
         end
 
-        def semicolon
-          @semicolon ||= processed_source.tokens.find do |token|
-            token.line == 1 && token.semicolon?
-          end
+        def semicolon(node)
+          @semicolon ||= tokens(node).find(&:semicolon?)
         end
       end
     end

--- a/lib/rubocop/cop/util.rb
+++ b/lib/rubocop/cop/util.rb
@@ -282,6 +282,14 @@ module RuboCop
           .sub('Style', 'Styles')
       end
 
+      def tokens(node)
+        @tokens ||= {}
+        @tokens[node.object_id] ||= processed_source.tokens.select do |token|
+          token.end_pos <= node.source_range.end_pos &&
+            token.begin_pos >= node.source_range.begin_pos
+        end
+      end
+
       private
 
       def directions(side)

--- a/spec/rubocop/cop/style/trailing_body_on_method_definition_spec.rb
+++ b/spec/rubocop/cop/style/trailing_body_on_method_definition_spec.rb
@@ -128,4 +128,16 @@ RSpec.describe RuboCop::Cop::Style::TrailingBodyOnMethodDefinition do
                              '    even_more',
                              '  end'].join("\n")
   end
+
+  context 'when method not on first line of processed_source' do
+    it '' do
+      corrected = autocorrect_source(['',
+                                      '  def some_method; body',
+                                      '  end'].join("\n"))
+      expect(corrected).to eq ['',
+                               '  def some_method ',
+                               '    body',
+                               '  end'].join("\n")
+    end
+  end
 end


### PR DESCRIPTION
Fixes #5334 .

There is a similar issue in `TrailingMethodEndStatement`.  I will raise an issue for this first as well, then submit a fix.  I imagine people write offending code like this so rarely that the problem hadn't been encountered/reported.

These were brought to my attention by the initial issues encountered in `Layout/EmptyLinesAroundArguments`.  Our tests can sometimes provide false assurance when `processed_source` line numbers are hardcoded into a cop. Test code snippets almost alway start on the `first_line` of a `processed_source` and also the `first_line` of a node.


-----------------

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
