### PR TITLE
[Fix #5314] Tighten Lint/NestedPercentLiteral regex to prevent false positives.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 * [#3394](https://github.com/bbatsov/rubocop/issues/3394): Add new `Style/TrailingCommmaInArrayLiteral` cop. ([@garettarrowood][])
 * [#3394](https://github.com/bbatsov/rubocop/issues/3394): Add new `Style/TrailingCommmaInHashLiteral` cop. ([@garettarrowood][])
 
+### Bug fixes
+
+* [#5314](https://github.com/bbatsov/rubocop/issues/5314): Fix false positives for `Lint/NestedPercentLiteral` when percent characters are nested. ([@asherkach][])
+
 ### Changes
 
 * [#3394](https://github.com/bbatsov/rubocop/issues/3394): Remove `Style/TrailingCommmaInLiteral` in favor of two new cops. ([@garettarrowood][])

--- a/lib/rubocop/cop/lint/nested_percent_literal.rb
+++ b/lib/rubocop/cop/lint/nested_percent_literal.rb
@@ -25,7 +25,7 @@ module RuboCop
         # if found within a percent literal expression, will cause a
         # NestedPercentLiteral violation to be emitted.
         REGEXES = PercentLiteral::PERCENT_LITERAL_TYPES.map do |percent_literal|
-          /#{percent_literal}\W/
+          /\A#{percent_literal}\W/
         end.freeze
 
         def on_array(node)

--- a/spec/rubocop/cop/lint/nested_percent_literal_spec.rb
+++ b/spec/rubocop/cop/lint/nested_percent_literal_spec.rb
@@ -32,6 +32,10 @@ RSpec.describe RuboCop::Cop::Lint::NestedPercentLiteral do
     expect_no_offenses('%[a b %i[c d] xyz]')
   end
 
+  it 'registers no offense for percents in the middle of literals' do
+    expect_no_offenses('%w[1%+ 2]')
+  end
+
   it 'registers offense for nested percent literals' do
     expect_offense('%i[a b %i[c d] xyz]')
   end


### PR DESCRIPTION
In particular, tighten the regular expression to require that the percent character begin at the start of the string (token). This prevents false positives such as `%w[1%+ 2]`. 

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
