### PR TITLE
[Fix #5333 & 5339] Resolve false positives in EmptyLineAroundArguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 * [#5334](https://github.com/bbatsov/rubocop/issues/5334): Fix semicolon removal for `Style/TrailingBodyOnMethodDefinition` autocorrection. ([@garettarrowood][])
 # [#5333](https://github.com/bbatsov/rubocop/issues/5333): Fix `Layout/EmptyLinesAroundArguments` false positives for inline access modifiers. ([@garettarrowood][])
+# [#5339](https://github.com/bbatsov/rubocop/issues/5339): Fix `Layout/EmptyLinesAroundArguments` false positives for multiline heredoc arguments. ([@garettarrowood][])
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Bug fixes
 
 * [#5334](https://github.com/bbatsov/rubocop/issues/5334): Fix semicolon removal for `Style/TrailingBodyOnMethodDefinition` autocorrection. ([@garettarrowood][])
+# [#5333](https://github.com/bbatsov/rubocop/issues/5333): Fix `Layout/EmptyLinesAroundArguments` false positives for inline access modifiers. ([@garettarrowood][])
 
 ### Changes
 

--- a/lib/rubocop/cop/layout/empty_lines_around_arguments.rb
+++ b/lib/rubocop/cop/layout/empty_lines_around_arguments.rb
@@ -76,8 +76,8 @@ module RuboCop
 
         def line_numbers(node)
           line_nums = node.arguments.each_with_object([]) do |arg, array|
-            array << arg.source_range.line - 1
-            array << arg.source_range.end.line + 1
+            array << arg.first_line - 1
+            array << arg.last_line + 1
           end
           stay_inbounds(node, line_nums.uniq)
         end

--- a/spec/rubocop/cop/layout/empty_lines_around_arguments_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_arguments_spec.rb
@@ -254,5 +254,16 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundArguments, :config do
       RUBY
       expect(cop.offenses.empty?).to be(true)
     end
+
+    it 'accepts method with argument that trails off heredoc' do
+      inspect_source(<<-RUBY.strip_indent)
+        bar(<<-DOCS)
+          foo
+
+        DOCS
+          .call!(true)
+      RUBY
+      expect(cop.offenses.empty?).to be(true)
+    end
   end
 end

--- a/spec/rubocop/cop/layout/empty_lines_around_arguments_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_arguments_spec.rb
@@ -38,18 +38,6 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundArguments, :config do
         .to eq(['Empty line detected around arguments.'])
     end
 
-    it 'registers offense for empty line in-between one arg' do
-      inspect_source(<<-RUBY.strip_indent)
-        do_stuff([
-          "some text",
-
-          "some more text"
-        ])
-      RUBY
-      expect(cop.messages)
-        .to eq(['Empty line detected around arguments.'])
-    end
-
     it 'registers offenses when multiple empty lines are detected' do
       inspect_source(<<-RUBY.strip_indent)
         foo(
@@ -169,18 +157,6 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundArguments, :config do
                                ')'].join("\n")
     end
 
-    it 'autocorrects empty line in-between one arg' do
-      corrected = autocorrect_source(['do_stuff([',
-                                      "  'some text',",
-                                      '',
-                                      "  'some more text'",
-                                      '])'].join("\n"))
-      expect(corrected).to eq ['do_stuff([',
-                               "  'some text',",
-                               "  'some more text'",
-                               '])'].join("\n")
-    end
-
     it 'autocorrects multiple empty lines' do
       corrected = autocorrect_source(['do_stuff(',
                                       '  baz,',
@@ -265,6 +241,16 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundArguments, :config do
 
           bar
         end.compact
+      RUBY
+      expect(cop.offenses.empty?).to be(true)
+    end
+
+    it 'ignores empty lines inside of method arguments' do
+      inspect_source(<<-RUBY.strip_indent)
+        private(def bar
+
+          baz
+        end)
       RUBY
       expect(cop.offenses.empty?).to be(true)
     end

--- a/spec/rubocop/cop/layout/empty_lines_around_arguments_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_arguments_spec.rb
@@ -245,16 +245,6 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundArguments, :config do
       expect(cop.offenses.empty?).to be(true)
     end
 
-    it 'ignores empty lines inside of method arguments' do
-      inspect_source(<<-RUBY.strip_indent)
-        private(def bar
-
-          baz
-        end)
-      RUBY
-      expect(cop.offenses.empty?).to be(true)
-    end
-
     it 'accepts method with argument that trails off heredoc' do
       inspect_source(<<-RUBY.strip_indent)
         bar(<<-DOCS)
@@ -264,6 +254,30 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundArguments, :config do
           .call!(true)
       RUBY
       expect(cop.offenses.empty?).to be(true)
+    end
+
+    context 'with one argument' do
+      it 'ignores empty lines inside of method arguments' do
+        inspect_source(<<-RUBY.strip_indent)
+          private(def bar
+
+            baz
+          end)
+        RUBY
+        expect(cop.offenses.empty?).to be(true)
+      end
+    end
+
+    context 'with multiple arguments' do
+      it 'ignores empty lines inside of method arguments' do
+        inspect_source(<<-RUBY.strip_indent)
+          foo(:bar, [1,
+
+                     2]
+          )
+        RUBY
+        expect(cop.offenses.empty?).to be(true)
+      end
     end
   end
 end


### PR DESCRIPTION
The two issues resolved here were two different problems in `Style/EmptyLineAroundArguments`, but this change resolves both. Check #5333 and #5339 for false positive details.

Currently, `Style/EmptyLineAroundArguments` checks for empty lines within the range of lines a method's arguments span. In addition to the issues linked here, this required special block argument logic. 

With this change, `Style/EmptyLineAroundArguments` will look for empty lines before and after arguments, but _NOT_ look inside an argument itself.

-----------------

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
