### PR TITLE
CLEANUP - Token spec & CHANGELOG cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,6 @@
 ### Changes
 
 * [#3394](https://github.com/bbatsov/rubocop/issues/3394): Remove `Style/TrailingCommmaInLiteral` in favor of two new cops. ([@garettarrowood][])
-* [#5217](https://github.com/bbatsov/rubocop/pull/5217): Expand `ProcessedSource` with helper methods. ([@garettarrowood][])
 
 ## 0.52.1 (2017-12-27)
 

--- a/spec/rubocop/token_spec.rb
+++ b/spec/rubocop/token_spec.rb
@@ -14,30 +14,30 @@ RSpec.describe RuboCop::Token do
 
   let(:first_token) { processed_source.tokens.first }
   let(:comment_token) do
-    processed_source.tokens.find do |t|
+    processed_source.find_token do |t|
       t.text.start_with?('#') && t.line == 1
     end
   end
 
   let(:left_array_bracket_token) do
-    processed_source.tokens.find { |t| t.text == '[' && t.line == 3 }
+    processed_source.find_token { |t| t.text == '[' && t.line == 3 }
   end
-  let(:comma_token) { processed_source.tokens.find { |t| t.text == ',' } }
+  let(:comma_token) { processed_source.find_token { |t| t.text == ',' } }
   let(:right_array_bracket_token) do
-    processed_source.tokens.find { |t| t.text == ']' && t.line == 3 }
+    processed_source.find_token { |t| t.text == ']' && t.line == 3 }
   end
-  let(:semicolon_token) { processed_source.tokens.find { |t| t.text == ';' } }
+  let(:semicolon_token) { processed_source.find_token { |t| t.text == ';' } }
 
   let(:left_ref_bracket_token) do
-    processed_source.tokens.find { |t| t.text == '[' && t.line == 4 }
+    processed_source.find_token { |t| t.text == '[' && t.line == 4 }
   end
-  let(:zero_token) { processed_source.tokens.find { |t| t.text == '0' } }
+  let(:zero_token) { processed_source.find_token { |t| t.text == '0' } }
   let(:right_ref_bracket_token) do
-    processed_source.tokens.find { |t| t.text == ']' && t.line == 4 }
+    processed_source.find_token { |t| t.text == ']' && t.line == 4 }
   end
-  let(:equals_token) { processed_source.tokens.find { |t| t.text == '=' } }
+  let(:equals_token) { processed_source.find_token { |t| t.text == '=' } }
 
-  let(:end_token) { processed_source.tokens.find { |t| t.text == 'end' } }
+  let(:end_token) { processed_source.find_token { |t| t.text == 'end' } }
 
   describe '.from_parser_token' do
     subject(:token) { described_class.from_parser_token(parser_token) }
@@ -235,7 +235,7 @@ RSpec.describe RuboCop::Token do
       RUBY
 
       let(:rescue_modifier_token) do
-        processed_source.tokens.find { |t| t.text == 'rescue' }
+        processed_source.find_token { |t| t.text == 'rescue' }
       end
 
       it 'returns true for rescue modifier tokens' do
@@ -277,23 +277,23 @@ RSpec.describe RuboCop::Token do
       RUBY
 
       let(:left_hash_brace_token) do
-        processed_source.tokens.find { |t| t.text == '{' && t.line == 1 }
+        processed_source.find_token { |t| t.text == '{' && t.line == 1 }
       end
       let(:right_hash_brace_token) do
-        processed_source.tokens.find { |t| t.text == '}' && t.line == 1 }
+        processed_source.find_token { |t| t.text == '}' && t.line == 1 }
       end
 
       let(:left_block_brace_token) do
-        processed_source.tokens.find { |t| t.text == '{' && t.line == 2 }
+        processed_source.find_token { |t| t.text == '{' && t.line == 2 }
       end
       let(:left_parens_token) do
-        processed_source.tokens.find { |t| t.text == '(' }
+        processed_source.find_token { |t| t.text == '(' }
       end
       let(:right_parens_token) do
-        processed_source.tokens.find { |t| t.text == ')' }
+        processed_source.find_token { |t| t.text == ')' }
       end
       let(:right_block_brace_token) do
-        processed_source.tokens.find { |t| t.text == '}' && t.line == 2 }
+        processed_source.find_token { |t| t.text == '}' && t.line == 2 }
       end
 
       describe '#left_brace?' do


### PR DESCRIPTION
In between the creation & merging of the `ProcessedSource` helper methods in #5316 , the `token_spec.rb` was created with many `tokens.find()` that can be updated to `find_token`.

Also - [Jonas pointed out](https://github.com/bbatsov/rubocop/pull/5316#issuecomment-354305353) the CHANGELOG entry that accompanied the PR. He's right, I'm not sure why I added one here. So this change removes it.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
