### PR TITLE
[Fix #5343] Fix offense detection in Style/TrailingMethodEndStatement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Bug fixes
 
+* [#5343](https://github.com/bbatsov/rubocop/issues/5343): Fix offense detection in `Style/TrailingMethodEndStatement`. ([@garettarrowood][])
 * [#5334](https://github.com/bbatsov/rubocop/issues/5334): Fix semicolon removal for `Style/TrailingBodyOnMethodDefinition` autocorrection. ([@garettarrowood][])
 
 ### Changes

--- a/spec/rubocop/cop/style/trailing_method_end_statement_spec.rb
+++ b/spec/rubocop/cop/style/trailing_method_end_statement_spec.rb
@@ -43,6 +43,16 @@ RSpec.describe RuboCop::Cop::Style::TrailingMethodEndStatement do
     RUBY
   end
 
+  it 'register offense with trailing end inside class' do
+    expect_offense(<<-RUBY.strip_indent)
+      class Foo
+        def some_method
+        foo; end
+             ^^^ Place the end statement of a multi-line method on its own line.
+      end
+    RUBY
+  end
+
   it 'does not register on single line no op' do
     expect_no_offenses(<<-RUBY.strip_indent)
       def no_op; end
@@ -93,5 +103,17 @@ RSpec.describe RuboCop::Cop::Style::TrailingMethodEndStatement do
                              '      foo',
                              '    end ',
                              '  end'].join("\n")
+  end
+
+  it 'auto-corrects trailing end for larger example' do
+    corrected = autocorrect_source(['class Foo',
+                                    '  def some_method',
+                                    '    []; end',
+                                    'end'].join("\n"))
+    expect(corrected).to eq ['class Foo',
+                             '  def some_method',
+                             '    [] ',
+                             '  end',
+                             'end'].join("\n")
   end
 end


### PR DESCRIPTION
Similar to #5334 , this PR resolves the issue raised in #5343 . Instead of referencing tokens by first/last occurrence in the `processed_source`, this cop needs to grab them in terms of the `node` itself.

Autocorrection never had a chance to misfire because these offenses were simply getting missed.

-----------------

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
