### PR TITLE
Add default notation to EnforcedStyle of document

### DIFF
--- a/lib/rubocop/cop/layout/multiline_method_call_indentation.rb
+++ b/lib/rubocop/cop/layout/multiline_method_call_indentation.rb
@@ -6,7 +6,7 @@ module RuboCop
       # This cop checks the indentation of the method name part in method calls
       # that span more than one line.
       #
-      # @example EnforcedStyle: aligned
+      # @example EnforcedStyle: aligned (default)
       #   # bad
       #   while myvariable
       #   .b

--- a/lib/rubocop/cop/layout/space_inside_array_literal_brackets.rb
+++ b/lib/rubocop/cop/layout/space_inside_array_literal_brackets.rb
@@ -16,7 +16,7 @@ module RuboCop
       #   # good
       #   array = [ a, b, c, d ]
       #
-      # @example EnforcedStyle: no_space
+      # @example EnforcedStyle: no_space (default)
       #   # The `no_space` style enforces that array literals have
       #   # no surrounding space.
       #

--- a/lib/rubocop/cop/layout/space_inside_hash_literal_braces.rb
+++ b/lib/rubocop/cop/layout/space_inside_hash_literal_braces.rb
@@ -6,7 +6,7 @@ module RuboCop
       # Checks that braces used for hash literals have or don't have
       # surrounding space depending on configuration.
       #
-      # @example EnforcedStyle: space
+      # @example EnforcedStyle: space (default)
       #   # The `space` style enforces that hash literals have
       #   # surrounding space.
       #

--- a/lib/rubocop/cop/style/format_string.rb
+++ b/lib/rubocop/cop/style/format_string.rb
@@ -11,7 +11,7 @@ module RuboCop
       # if the first argument is a string literal and if the second
       # argument is an array literal.
       #
-      # @example EnforcedStyle: format(default)
+      # @example EnforcedStyle: format (default)
       #   # bad
       #   puts sprintf('%10s', 'hoge')
       #   puts '%10s' % 'hoge'

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -2090,7 +2090,7 @@ that span more than one line.
 
 ### Examples
 
-#### EnforcedStyle: aligned
+#### EnforcedStyle: aligned (default)
 
 ```ruby
 # bad
@@ -2709,7 +2709,7 @@ array = [a, b, c, d]
 # good
 array = [ a, b, c, d ]
 ```
-#### EnforcedStyle: no_space
+#### EnforcedStyle: no_space (default)
 
 ```ruby
 # The `no_space` style enforces that array literals have
@@ -2871,7 +2871,7 @@ surrounding space depending on configuration.
 
 ### Examples
 
-#### EnforcedStyle: space
+#### EnforcedStyle: space (default)
 
 ```ruby
 # The `space` style enforces that hash literals have

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -1735,7 +1735,7 @@ argument is an array literal.
 
 ### Examples
 
-#### EnforcedStyle: format(default)
+#### EnforcedStyle: format (default)
 
 ```ruby
 # bad


### PR DESCRIPTION
This is a document change similar to #5305.
It complements the missing "default" in EnforcedStyle.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
