### PR TITLE
Move `EnforcedStyle` and `SupportedStyles` to default.yml

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -1038,6 +1038,16 @@ Style/MethodDefParentheses:
     - require_no_parentheses
     - require_no_parentheses_except_multiline
 
+Style/MissingElse:
+  EnforcedStyle: both
+  SupportedStyles:
+    # if - warn when an if expression is missing an else branch
+    # case - warn when a case expression is missing an else branch
+    # both - warn when an if or case expression is missing an else branch
+    - if
+    - case
+    - both
+
 # Checks the grouping of mixins (`include`, `extend`, `prepend`) in `class` and
 # `module` bodies.
 Style/MixinGrouping:

--- a/config/disabled.yml
+++ b/config/disabled.yml
@@ -92,14 +92,6 @@ Style/MissingElse:
                 This will conflict with Style/EmptyElse if
                 Style/EmptyElse is configured to style "both"
   Enabled: false
-  EnforcedStyle: both
-  SupportedStyles:
-    # if - warn when an if expression is missing an else branch
-    # case - warn when a case expression is missing an else branch
-    # both - warn when an if or case expression is missing an else branch
-    - if
-    - case
-    - both
 
 Style/OptionHash:
   Description: "Don't use option hashes when you can use keyword arguments."


### PR DESCRIPTION
This commit is a change similar to #5271.
`EnforcedStyle` and `SupportedStyles` are grouped in config/default.yml. This commit unified the setting place by moving those settings of `Style/MissingElse` cop from config/disabled.yml to config/default.yml.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
