### PR TITLE
Restyle example formatting for `Style/MissingElse` cop

### DIFF
--- a/lib/rubocop/cop/style/missing_else.rb
+++ b/lib/rubocop/cop/style/missing_else.rb
@@ -4,29 +4,94 @@ module RuboCop
   module Cop
     module Style
       # Checks for `if` expressions that do not have an `else` branch.
-      # SupportedStyles
       #
-      # if
-      # @example
+      # Supported styles are: if, case, both.
+      #
+      # @example EnforcedStyle: if
+      #   # warn when an `if` expression is missing an `else` branch.
+      #
       #   # bad
       #   if condition
       #     statement
       #   end
       #
-      # case
-      # @example
+      #   # good
+      #   if condition
+      #     statement
+      #   else
+      #     # the content of `else` branch will be determined by Style/EmptyElse
+      #   end
+      #
+      #   # good
+      #   case var
+      #   when condition
+      #     statement
+      #   end
+      #
+      #   # good
+      #   case var
+      #   when condition
+      #     statement
+      #   else
+      #     # the content of `else` branch will be determined by Style/EmptyElse
+      #   end
+      #
+      # @example EnforcedStyle: case
+      #   # warn when a `case` expression is missing an `else` branch.
+      #
       #   # bad
       #   case var
       #   when condition
       #     statement
       #   end
       #
-      # @example
+      #   # good
+      #   case var
+      #   when condition
+      #     statement
+      #   else
+      #     # the content of `else` branch will be determined by Style/EmptyElse
+      #   end
+      #
+      #   # good
+      #   if condition
+      #     statement
+      #   end
+      #
       #   # good
       #   if condition
       #     statement
       #   else
-      #   # the content of the else branch will be determined by Style/EmptyElse
+      #     # the content of `else` branch will be determined by Style/EmptyElse
+      #   end
+      #
+      # @example EnforcedStyle: both (default)
+      #   # warn when an `if` or `case` expression is missing an `else` branch.
+      #
+      #   # bad
+      #   if condition
+      #     statement
+      #   end
+      #
+      #   # bad
+      #   case var
+      #   when condition
+      #     statement
+      #   end
+      #
+      #   # good
+      #   if condition
+      #     statement
+      #   else
+      #     # the content of `else` branch will be determined by Style/EmptyElse
+      #   end
+      #
+      #   # good
+      #   case var
+      #   when condition
+      #     statement
+      #   else
+      #     # the content of `else` branch will be determined by Style/EmptyElse
       #   end
       class MissingElse < Cop
         include OnNormalIfUnless

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -2766,32 +2766,102 @@ Enabled by default | Supports autocorrection
 Disabled | No
 
 Checks for `if` expressions that do not have an `else` branch.
-SupportedStyles
 
-if
-case
+Supported styles are: if, case, both.
 
 ### Examples
 
+#### EnforcedStyle: if
+
 ```ruby
+# warn when an `if` expression is missing an `else` branch.
+
 # bad
 if condition
   statement
 end
+
+# good
+if condition
+  statement
+else
+  # the content of `else` branch will be determined by Style/EmptyElse
+end
+
+# good
+case var
+when condition
+  statement
+end
+
+# good
+case var
+when condition
+  statement
+else
+  # the content of `else` branch will be determined by Style/EmptyElse
+end
 ```
+#### EnforcedStyle: case
+
 ```ruby
+# warn when a `case` expression is missing an `else` branch.
+
 # bad
 case var
 when condition
   statement
 end
-```
-```ruby
+
+# good
+case var
+when condition
+  statement
+else
+  # the content of `else` branch will be determined by Style/EmptyElse
+end
+
+# good
+if condition
+  statement
+end
+
 # good
 if condition
   statement
 else
-# the content of the else branch will be determined by Style/EmptyElse
+  # the content of `else` branch will be determined by Style/EmptyElse
+end
+```
+#### EnforcedStyle: both (default)
+
+```ruby
+# warn when an `if` or `case` expression is missing an `else` branch.
+
+# bad
+if condition
+  statement
+end
+
+# bad
+case var
+when condition
+  statement
+end
+
+# good
+if condition
+  statement
+else
+  # the content of `else` branch will be determined by Style/EmptyElse
+end
+
+# good
+case var
+when condition
+  statement
+else
+  # the content of `else` branch will be determined by Style/EmptyElse
 end
 ```
 


### PR DESCRIPTION
Follow up of https://github.com/bbatsov/rubocop/pull/4880#issuecomment-338499947.

This commit is a change of document format for `Style/MissingElse` cop.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
