### PR TITLE
CLEANUP - Util.rb

### DIFF
--- a/lib/rubocop/ast/node.rb
+++ b/lib/rubocop/ast/node.rb
@@ -453,6 +453,10 @@ module RuboCop
           source_range.begin_pos != loc.selector.begin_pos
       end
 
+      def parenthesized_call?
+        loc.begin && loc.begin.is?('(')
+      end
+
       def chained?
         return false unless argument?
 

--- a/lib/rubocop/cop/lint/unneeded_cop_disable_directive.rb
+++ b/lib/rubocop/cop/lint/unneeded_cop_disable_directive.rb
@@ -249,6 +249,11 @@ module RuboCop
         def all_cop_names
           @all_cop_names ||= Cop.registry.names
         end
+
+        def ends_its_line?(range)
+          line = range.source_buffer.source_line(range.last_line)
+          (line =~ /\s*\z/) == range.last_column
+        end
       end
     end
   end

--- a/lib/rubocop/cop/mixin/documentation_comment.rb
+++ b/lib/rubocop/cop/mixin/documentation_comment.rb
@@ -30,6 +30,12 @@ module RuboCop
           comment_line?(node2.loc.expression.source)
       end
 
+      # The args node1 & node2 may represent a RuboCop::AST::Node
+      # or a Parser::Source::Comment. Both respond to #loc.
+      def precede?(node1, node2)
+        node2.loc.line - node1.loc.line == 1
+      end
+
       def preceding_lines(node)
         processed_source.ast_with_comments[node].select do |line|
           line.loc.line < node.loc.line

--- a/lib/rubocop/cop/mixin/end_keyword_alignment.rb
+++ b/lib/rubocop/cop/mixin/end_keyword_alignment.rb
@@ -6,6 +6,8 @@ module RuboCop
     module EndKeywordAlignment
       include ConfigurableEnforcedStyle
 
+      BYTE_ORDER_MARK = 0xfeff # The Unicode codepoint
+
       MSG = '`end` at %<end_line>d, %<end_col>d is not aligned with ' \
             '`%<source>s` at %<align_line>d, %<align_col>d.'.freeze
 
@@ -59,6 +61,19 @@ module RuboCop
 
       def line_break_before_keyword?(whole_expression, rhs)
         rhs.first_line > whole_expression.line
+      end
+
+      # Returns the column attribute of the range, except if the range is on
+      # the first line and there's a byte order mark at the beginning of that
+      # line, in which case 1 is subtracted from the column value. This gives
+      # the column as it appears when viewing the file in an editor.
+      def effective_column(range)
+        if range.line == 1 &&
+           @processed_source.raw_source.codepoints.first == BYTE_ORDER_MARK
+          range.column - 1
+        else
+          range.column
+        end
       end
     end
   end

--- a/lib/rubocop/cop/mixin/multiline_expression_indentation.rb
+++ b/lib/rubocop/cop/mixin/multiline_expression_indentation.rb
@@ -221,6 +221,12 @@ module RuboCop
         node.source_range.begin_pos > ancestor.loc.begin.begin_pos &&
           node.source_range.end_pos < ancestor.loc.end.end_pos
       end
+
+      def within_node?(inner, outer)
+        o = outer.is_a?(AST::Node) ? outer.source_range : outer
+        i = inner.is_a?(AST::Node) ? inner.source_range : inner
+        i.begin_pos >= o.begin_pos && i.end_pos <= o.end_pos
+      end
     end
   end
 end

--- a/lib/rubocop/cop/style/lambda.rb
+++ b/lib/rubocop/cop/style/lambda.rb
@@ -173,7 +173,7 @@ module RuboCop
           end
 
           return false unless parent && parent.send_type?
-          return false if parenthesized_call?(parent)
+          return false if parent.parenthesized_call?
 
           arg_node.sibling_index > 1
         end

--- a/lib/rubocop/cop/style/one_line_conditional.rb
+++ b/lib/rubocop/cop/style/one_line_conditional.rb
@@ -63,7 +63,7 @@ module RuboCop
 
         def method_call_with_changed_precedence?(node)
           return false unless node.send_type? && node.arguments?
-          return false if parenthesized_call?(node)
+          return false if node.parenthesized_call?
 
           !operator?(node.method_name)
         end
@@ -72,7 +72,7 @@ module RuboCop
           return false unless node.keyword?
           return true if node.keyword_not?
 
-          !parenthesized_call?(node)
+          !node.parenthesized_call?
         end
       end
     end

--- a/lib/rubocop/cop/style/symbol_array.rb
+++ b/lib/rubocop/cop/style/symbol_array.rb
@@ -75,6 +75,35 @@ module RuboCop
             corrector.replace(node.source_range, "[#{syms.join(', ')}]")
           end
         end
+
+        def to_symbol_literal(string)
+          if symbol_without_quote?(string)
+            ":#{string}"
+          else
+            ":#{to_string_literal(string)}"
+          end
+        end
+
+        def symbol_without_quote?(string)
+          special_gvars = %w[
+            $! $" $$ $& $' $* $+ $, $/ $; $: $. $< $= $> $? $@ $\\ $_ $` $~ $0
+            $-0 $-F $-I $-K $-W $-a $-d $-i $-l $-p $-v $-w
+          ]
+          redefinable_operators = %w(
+            | ^ & <=> == === =~ > >= < <= << >>
+            + - * / % ** ~ +@ -@ [] []= ` ! != !~
+          )
+
+          # method name
+          string =~ /\A[a-zA-Z_]\w*[!?]?\z/ ||
+            # instance / class variable
+            string =~ /\A\@\@?[a-zA-Z_]\w*\z/ ||
+            # global variable
+            string =~ /\A\$[1-9]\d*\z/ ||
+            string =~ /\A\$[a-zA-Z_]\w*\z/ ||
+            special_gvars.include?(string) ||
+            redefinable_operators.include?(string)
+        end
       end
     end
   end

--- a/lib/rubocop/cop/util.rb
+++ b/lib/rubocop/cop/util.rb
@@ -36,18 +36,6 @@ module RuboCop
         OPERATOR_METHODS.include?(symbol)
       end
 
-      def strip_quotes(str)
-        if str[0] == '"' || str[0] == "'"
-          str[0] = ''
-        else
-          # we're dealing with %q or %Q
-          str[0, 3] = ''
-        end
-        str[-1] = ''
-
-        str
-      end
-
       def comment_line?(line_source)
         line_source =~ /^\s*#/
       end

--- a/lib/rubocop/cop/util.rb
+++ b/lib/rubocop/cop/util.rb
@@ -178,35 +178,6 @@ module RuboCop
         end
       end
 
-      def to_symbol_literal(string)
-        if symbol_without_quote?(string)
-          ":#{string}"
-        else
-          ":#{to_string_literal(string)}"
-        end
-      end
-
-      def symbol_without_quote?(string)
-        special_gvars = %w[
-          $! $" $$ $& $' $* $+ $, $/ $; $: $. $< $= $> $? $@ $\\ $_ $` $~ $0
-          $-0 $-F $-I $-K $-W $-a $-d $-i $-l $-p $-v $-w
-        ]
-        redefinable_operators = %w(
-          | ^ & <=> == === =~ > >= < <= << >>
-          + - * / % ** ~ +@ -@ [] []= ` ! != !~
-        )
-
-        # method name
-        string =~ /\A[a-zA-Z_]\w*[!?]?\z/ ||
-          # instance / class variable
-          string =~ /\A\@\@?[a-zA-Z_]\w*\z/ ||
-          # global variable
-          string =~ /\A\$[1-9]\d*\z/ ||
-          string =~ /\A\$[a-zA-Z_]\w*\z/ ||
-          special_gvars.include?(string) ||
-          redefinable_operators.include?(string)
-      end
-
       def interpret_string_escapes(string)
         StringInterpreter.interpret(string)
       end

--- a/lib/rubocop/cop/util.rb
+++ b/lib/rubocop/cop/util.rb
@@ -49,10 +49,6 @@ module RuboCop
           node.loc.end.is?(')'.freeze)
       end
 
-      def parenthesized_call?(send)
-        send.loc.begin && send.loc.begin.is?('(')
-      end
-
       def on_node(syms, sexp, excludes = [], &block)
         return to_enum(:on_node, syms, sexp, excludes) unless block_given?
 

--- a/lib/rubocop/cop/util.rb
+++ b/lib/rubocop/cop/util.rb
@@ -8,8 +8,6 @@ module RuboCop
       include PathUtil
       extend RuboCop::AST::Sexp
 
-      BYTE_ORDER_MARK = 0xfeff # The Unicode codepoint
-
       EQUALS_ASGN_NODES = %i[lvasgn ivasgn cvasgn gvasgn
                              casgn masgn].freeze
       SHORTHAND_ASGN_NODES = %i[op_asgn or_asgn and_asgn].freeze
@@ -75,19 +73,6 @@ module RuboCop
         end_pos = begin_pos + length
 
         Parser::Source::Range.new(source_buffer, begin_pos, end_pos)
-      end
-
-      # Returns the column attribute of the range, except if the range is on
-      # the first line and there's a byte order mark at the beginning of that
-      # line, in which case 1 is subtracted from the column value. This gives
-      # the column as it appears when viewing the file in an editor.
-      def effective_column(range)
-        if range.line == 1 &&
-           @processed_source.raw_source.codepoints.first == BYTE_ORDER_MARK
-          range.column - 1
-        else
-          range.column
-        end
       end
 
       def range_between(start_pos, end_pos)

--- a/lib/rubocop/cop/util.rb
+++ b/lib/rubocop/cop/util.rb
@@ -188,12 +188,6 @@ module RuboCop
           node1.loc.line == node2.loc.line
       end
 
-      # The args node1 & node2 may represent a RuboCop::AST::Node
-      # or a Parser::Source::Comment. Both respond to #loc.
-      def precede?(node1, node2)
-        line_distance(node1, node2) == 1
-      end
-
       def to_supported_styles(enforced_style)
         enforced_style
           .sub(/^Enforced/, 'Supported')
@@ -233,12 +227,6 @@ module RuboCop
       def compatible_external_encoding_for?(src)
         src = src.dup if RUBY_VERSION < '2.3' || RUBY_ENGINE == 'jruby'
         src.force_encoding(Encoding.default_external).valid_encoding?
-      end
-
-      # The args node1 & node2 may represent a RuboCop::AST::Node
-      # or a Parser::Source::Comment. Both respond to #loc.
-      def line_distance(node1, node2)
-        node2.loc.line - node1.loc.line
       end
     end
   end

--- a/lib/rubocop/cop/util.rb
+++ b/lib/rubocop/cop/util.rb
@@ -40,17 +40,8 @@ module RuboCop
         line_source =~ /^\s*#/
       end
 
-      def line_range(arg)
-        source_range = case arg
-                       when Parser::Source::Range
-                         arg
-                       when Parser::AST::Node
-                         arg.source_range
-                       else
-                         raise ArgumentError, "Invalid argument #{arg}"
-                       end
-
-        source_range.begin.line..source_range.end.line
+      def line_range(node)
+        node.first_line..node.last_line
       end
 
       def parentheses?(node)

--- a/lib/rubocop/cop/util.rb
+++ b/lib/rubocop/cop/util.rb
@@ -132,12 +132,6 @@ module RuboCop
         (range.source_line =~ /\S/) == range.column
       end
 
-      def within_node?(inner, outer)
-        o = outer.is_a?(AST::Node) ? outer.source_range : outer
-        i = inner.is_a?(AST::Node) ? inner.source_range : inner
-        i.begin_pos >= o.begin_pos && i.end_pos <= o.end_pos
-      end
-
       # Returns, for example, a bare `if` node if the given node is an `if`
       # with calls chained to the end of it.
       def first_part_of_call_chain(node)

--- a/lib/rubocop/cop/util.rb
+++ b/lib/rubocop/cop/util.rb
@@ -132,11 +132,6 @@ module RuboCop
         (range.source_line =~ /\S/) == range.column
       end
 
-      def ends_its_line?(range)
-        line = range.source_buffer.source_line(range.last_line)
-        (line =~ /\s*\z/) == range.last_column
-      end
-
       def within_node?(inner, outer)
         o = outer.is_a?(AST::Node) ? outer.source_range : outer
         i = inner.is_a?(AST::Node) ? inner.source_range : inner

--- a/spec/rubocop/cop/util_spec.rb
+++ b/spec/rubocop/cop/util_spec.rb
@@ -209,26 +209,6 @@ RSpec.describe RuboCop::Cop::Util do
     end
   end
 
-  describe '#to_symbol_literal' do
-    [
-      ['foo', ':foo'],
-      ['foo?', ':foo?'],
-      ['foo!', ':foo!'],
-      ['@foo', ':@foo'],
-      ['@@foo', ':@@foo'],
-      ['$\\', ':$\\'],
-      ['$a', ':$a'],
-      ['==', ':=='],
-      ['a-b', ":'a-b'"]
-    ].each do |string, expectation|
-      context "when #{string}" do
-        it "returns #{expectation}" do
-          expect(described_class.to_symbol_literal(string)).to eq(expectation)
-        end
-      end
-    end
-  end
-
   describe '#to_supported_styles' do
     subject { described_class.to_supported_styles(enforced_style) }
 

--- a/spec/rubocop/cop/util_spec.rb
+++ b/spec/rubocop/cop/util_spec.rb
@@ -24,18 +24,9 @@ RSpec.describe RuboCop::Cop::Util do
 
     let(:node) { ast.each_node.find(&:class_type?) }
 
-    context 'when Source::Range object is passed' do
-      it 'returns line range of that' do
-        line_range = described_class.line_range(node.loc.expression)
-        expect(line_range).to eq(3..7)
-      end
-    end
-
-    context 'when AST::Node object is passed' do
-      it 'returns line range of the expression' do
-        line_range = described_class.line_range(node)
-        expect(line_range).to eq(3..7)
-      end
+    it 'returns line range of the expression' do
+      line_range = described_class.line_range(node)
+      expect(line_range).to eq(3..7)
     end
   end
 


### PR DESCRIPTION
This PR shaves 100 lines out of `util.rb`.  Each commit contains a description of why a method removal works. This was inspired by @Drenmi 's comment -
 https://github.com/bbatsov/rubocop/pull/5066#discussion_r153192001 , and a convo about the need to start shaving down on how many things our God-like `Cop` class is responsible for - 
https://github.com/bbatsov/rubocop/pull/5323#issuecomment-354133681 .

Every commit should have a green CI run. So if there is a method we'd like to keep in `Util`, I can drop that commit.

-----------------

* [x] Wrote [good commit messages][1].
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
