### PR TITLE
Restyle example formatting for `Layout/MultilineMethodCallBraceLayout`

### DIFF
--- a/lib/rubocop/cop/layout/multiline_method_call_brace_layout.rb
+++ b/lib/rubocop/cop/layout/multiline_method_call_brace_layout.rb
@@ -26,35 +26,68 @@ module RuboCop
       # The closing brace of a multi-line method call must be on the same
       # line as the last argument of the call.
       #
-      # @example
+      # @example EnforcedStyle: symmetrical (default)
+      #   # bad
+      #   foo(a,
+      #     b
+      #   )
       #
-      #     # symmetrical: bad
-      #     # new_line: good
-      #     # same_line: bad
-      #     foo(a,
-      #       b
-      #     )
+      #   # bad
+      #   foo(
+      #     a,
+      #     b)
       #
-      #     # symmetrical: bad
-      #     # new_line: bad
-      #     # same_line: good
-      #     foo(
-      #       a,
-      #       b)
+      #   # good
+      #   foo(a,
+      #     b)
       #
-      #     # symmetrical: good
-      #     # new_line: bad
-      #     # same_line: good
-      #     foo(a,
-      #       b)
+      #   # good
+      #   foo(
+      #     a,
+      #     b
+      #   )
       #
-      #     # symmetrical: good
-      #     # new_line: good
-      #     # same_line: bad
-      #     foo(
-      #       a,
-      #       b
-      #     )
+      # @example EnforcedStyle: new_line
+      #   # bad
+      #   foo(
+      #     a,
+      #     b)
+      #
+      #   # bad
+      #   foo(a,
+      #     b)
+      #
+      #   # good
+      #   foo(a,
+      #     b
+      #   )
+      #
+      #   # good
+      #   foo(
+      #     a,
+      #     b
+      #   )
+      #
+      # @example EnforcedStyle: same_line
+      #   # bad
+      #   foo(a,
+      #     b
+      #   )
+      #
+      #   # bad
+      #   foo(
+      #     a,
+      #     b
+      #   )
+      #
+      #   # good
+      #   foo(
+      #     a,
+      #     b)
+      #
+      #   # good
+      #   foo(a,
+      #     b)
       class MultilineMethodCallBraceLayout < Cop
         include MultilineLiteralBraceLayout
 

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -2043,34 +2043,74 @@ line as the last argument of the call.
 
 ### Examples
 
+#### EnforcedStyle: symmetrical (default)
+
 ```ruby
-# symmetrical: bad
-# new_line: good
-# same_line: bad
+# bad
 foo(a,
   b
 )
 
-# symmetrical: bad
-# new_line: bad
-# same_line: good
+# bad
 foo(
   a,
   b)
 
-# symmetrical: good
-# new_line: bad
-# same_line: good
+# good
 foo(a,
   b)
 
-# symmetrical: good
-# new_line: good
-# same_line: bad
+# good
 foo(
   a,
   b
 )
+```
+#### EnforcedStyle: new_line
+
+```ruby
+# bad
+foo(
+  a,
+  b)
+
+# bad
+foo(a,
+  b)
+
+# good
+foo(a,
+  b
+)
+
+# good
+foo(
+  a,
+  b
+)
+```
+#### EnforcedStyle: same_line
+
+```ruby
+# bad
+foo(a,
+  b
+)
+
+# bad
+foo(
+  a,
+  b
+)
+
+# good
+foo(
+  a,
+  b)
+
+# good
+foo(a,
+  b)
 ```
 
 ### Configurable attributes


### PR DESCRIPTION
Follow up of https://github.com/bbatsov/rubocop/pull/4880#issuecomment-338499947.

This commit is a change of document format for `Layout/MultilineMethodCallBraceLayout` cop.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
