### PR TITLE
Restyle example formatting for `Layout/MultilineMethodDefinitionBraceLayout`

### DIFF
--- a/lib/rubocop/cop/layout/multiline_method_definition_brace_layout.rb
+++ b/lib/rubocop/cop/layout/multiline_method_definition_brace_layout.rb
@@ -26,39 +26,80 @@ module RuboCop
       # The closing brace of a multi-line method definition must be on the same
       # line as the last parameter of the definition.
       #
-      # @example
+      # @example EnforcedStyle: symmetrical (default)
+      #   # bad
+      #   def foo(a,
+      #     b
+      #   )
+      #   end
       #
-      #     # symmetrical: bad
-      #     # new_line: good
-      #     # same_line: bad
-      #     def foo(a,
-      #       b
-      #     )
-      #     end
+      #   # bad
+      #   def foo(
+      #     a,
+      #     b)
+      #   end
       #
-      #     # symmetrical: bad
-      #     # new_line: bad
-      #     # same_line: good
-      #     def foo(
-      #       a,
-      #       b)
-      #     end
+      #   # good
+      #   def foo(a,
+      #     b)
+      #   end
       #
-      #     # symmetrical: good
-      #     # new_line: bad
-      #     # same_line: good
-      #     def foo(a,
-      #       b)
-      #     end
+      #   # good
+      #   def foo(
+      #     a,
+      #     b
+      #   )
+      #   end
       #
-      #     # symmetrical: good
-      #     # new_line: good
-      #     # same_line: bad
-      #     def foo(
-      #       a,
-      #       b
-      #     )
-      #     end
+      # @example EnforcedStyle: new_line
+      #   # bad
+      #   def foo(
+      #     a,
+      #     b)
+      #   end
+      #
+      #   # bad
+      #   def foo(a,
+      #     b)
+      #   end
+      #
+      #   # good
+      #   def foo(a,
+      #     b
+      #   )
+      #   end
+      #
+      #   # good
+      #   def foo(
+      #     a,
+      #     b
+      #   )
+      #   end
+      #
+      # @example EnforcedStyle: same_line
+      #   # bad
+      #   def foo(a,
+      #     b
+      #   )
+      #   end
+      #
+      #   # bad
+      #   def foo(
+      #     a,
+      #     b
+      #   )
+      #   end
+      #
+      #   # good
+      #   def foo(
+      #     a,
+      #     b)
+      #   end
+      #
+      #   # good
+      #   def foo(a,
+      #     b)
+      #   end
       class MultilineMethodDefinitionBraceLayout < Cop
         include MultilineLiteralBraceLayout
 

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -2176,37 +2176,85 @@ line as the last parameter of the definition.
 
 ### Examples
 
+#### EnforcedStyle: symmetrical (default)
+
 ```ruby
-# symmetrical: bad
-# new_line: good
-# same_line: bad
+# bad
 def foo(a,
   b
 )
 end
 
-# symmetrical: bad
-# new_line: bad
-# same_line: good
+# bad
 def foo(
   a,
   b)
 end
 
-# symmetrical: good
-# new_line: bad
-# same_line: good
+# good
 def foo(a,
   b)
 end
 
-# symmetrical: good
-# new_line: good
-# same_line: bad
+# good
 def foo(
   a,
   b
 )
+end
+```
+#### EnforcedStyle: new_line
+
+```ruby
+# bad
+def foo(
+  a,
+  b)
+end
+
+# bad
+def foo(a,
+  b)
+end
+
+# good
+def foo(a,
+  b
+)
+end
+
+# good
+def foo(
+  a,
+  b
+)
+end
+```
+#### EnforcedStyle: same_line
+
+```ruby
+# bad
+def foo(a,
+  b
+)
+end
+
+# bad
+def foo(
+  a,
+  b
+)
+end
+
+# good
+def foo(
+  a,
+  b)
+end
+
+# good
+def foo(a,
+  b)
 end
 ```
 


### PR DESCRIPTION
Follow up of https://github.com/bbatsov/rubocop/pull/4880#issuecomment-338499947.

This commit is a change of document format for `Layout/MultilineMethodDefinitionBraceLayout` cop.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
