### PR TITLE
[Fix #5350] Resolve Metrics/LineLength false offenses with double quotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 * [#5343](https://github.com/bbatsov/rubocop/issues/5343): Fix offense detection in `Style/TrailingMethodEndStatement`. ([@garettarrowood][])
 * [#5334](https://github.com/bbatsov/rubocop/issues/5334): Fix semicolon removal for `Style/TrailingBodyOnMethodDefinition` autocorrection. ([@garettarrowood][])
+* [#5350](https://github.com/bbatsov/rubocop/issues/5350): Fix `Metric/LineLength` false offenses for URLs in double quotes. ([@garettarrowood][])
 * [#5333](https://github.com/bbatsov/rubocop/issues/5333): Fix `Layout/EmptyLinesAroundArguments` false positives for inline access modifiers. ([@garettarrowood][])
 * [#5339](https://github.com/bbatsov/rubocop/issues/5339): Fix `Layout/EmptyLinesAroundArguments` false positives for multiline heredoc arguments. ([@garettarrowood][])
 

--- a/lib/rubocop/cop/metrics/line_length.rb
+++ b/lib/rubocop/cop/metrics/line_length.rb
@@ -99,7 +99,8 @@ module RuboCop
         end
 
         def allowed_uri_position?(line, uri_range)
-          uri_range.begin < max && uri_range.end == line.length
+          uri_range.begin < max &&
+            (uri_range.end == line.length || uri_range.end == line.length - 1)
         end
 
         def find_excessive_uri_range(line)

--- a/spec/rubocop/cop/metrics/line_length_spec.rb
+++ b/spec/rubocop/cop/metrics/line_length_spec.rb
@@ -43,6 +43,28 @@ RSpec.describe RuboCop::Cop::Metrics::LineLength, :config do
         inspect_source(source)
         expect(cop.offenses.empty?).to be(true)
       end
+
+      context 'and the URL is wrapped in single quotes' do
+        let(:source) { <<-RUBY }
+          # See: 'https://github.com/bbatsov/rubocop/commit/3b48d8bdf5b1c2e05e35061837309890f04ab08c'
+        RUBY
+
+        it 'accepts the line' do
+          inspect_source(source)
+          expect(cop.offenses.empty?).to be(true)
+        end
+      end
+
+      context 'and the URL is wrapped in double quotes' do
+        let(:source) { <<-RUBY }
+          # See: "https://github.com/bbatsov/rubocop/commit/3b48d8bdf5b1c2e05e35061837309890f04ab08c"
+        RUBY
+
+        it 'accepts the line' do
+          inspect_source(source)
+          expect(cop.offenses.empty?).to be(true)
+        end
+      end
     end
 
     context 'and the excessive characters include a complete URL' do


### PR DESCRIPTION
See #5350 for description of bug.

[Here is the root of the problem](https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/cop/metrics/line_length.rb#L129). For some reason, when `URI::DEFAULT_PARSER.make_regexp` is passed a double quoted string, it returns MatchData [here](https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/cop/metrics/line_length.rb#L116) that is one character shorter.  When this finally reaches `allowed_uri_position?`, the two test examples report different ending characters.

Here are the <MatchData> objects themselves:

#### Single quotes

```
=> #<MatchData
 "https://github.com/bbatsov/rubocop/commit/3b48d8bdf5b1c2e05e35061837309890f04ab08c'"
 1:"https"
 2:nil
 3:nil
 4:"github.com"
 5:nil
 6:nil
 7:"/bbatsov/rubocop/commit/3b48d8bdf5b1c2e05e35061837309890f04ab08c'"
 8:nil
 9:nil>
```

#### Double quotes

```
=> #<MatchData
 "https://github.com/bbatsov/rubocop/commit/3b48d8bdf5b1c2e05e35061837309890f04ab08c"
 1:"https"
 2:nil
 3:nil
 4:"github.com"
 5:nil
 6:nil
 7:"/bbatsov/rubocop/commit/3b48d8bdf5b1c2e05e35061837309890f04ab08c"
 8:nil
 9:nil>
```


-----------------

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
