### PR TITLE
improve speed of RuboCop::Cop::Util#tokens

### DIFF
--- a/lib/rubocop/cop/util.rb
+++ b/lib/rubocop/cop/util.rb
@@ -196,9 +196,14 @@ module RuboCop
 
       def tokens(node)
         @tokens ||= {}
-        @tokens[node.object_id] ||= processed_source.tokens.select do |token|
-          token.end_pos <= node.source_range.end_pos &&
-            token.begin_pos >= node.source_range.begin_pos
+        return @tokens[node.object_id] if @tokens[node.object_id]
+
+        source_range = node.source_range
+        begin_pos = source_range.begin_pos
+        end_pos = source_range.end_pos
+
+        @tokens[node.object_id] = processed_source.tokens.select do |token|
+          token.end_pos <= end_pos && token.begin_pos >= begin_pos
         end
       end
 

--- a/lib/rubocop/token.rb
+++ b/lib/rubocop/token.rb
@@ -19,19 +19,19 @@ module RuboCop
     end
 
     def line
-      pos.line
+      @pos.line
     end
 
     def column
-      pos.column
+      @pos.column
     end
 
     def begin_pos
-      pos.begin_pos
+      @pos.begin_pos
     end
 
     def end_pos
-      pos.end_pos
+      @pos.end_pos
     end
 
     def to_s


### PR DESCRIPTION
RuboCop::Cop::Utils#tokens seems to be bottleneck.

This is a patch for profiling rubocop with stackprof

```
diff --git bin/rubocop bin/rubocop
index abf88369e..0f2406641 100755
--- bin/rubocop
+++ bin/rubocop
@@ -5,12 +5,15 @@ $LOAD_PATH.unshift("#{__dir__}/../lib")

 require 'rubocop'
 require 'benchmark'
+require 'stackprof'

 cli = RuboCop::CLI.new
 result = 0

-time = Benchmark.realtime do
-  result = cli.run
+StackProf.run(mode: :cpu, out: 'tmp/stackprof-cpu-rubocop.dump') do
+  time = Benchmark.realtime do
+    result = cli.run
+  end
 end

 puts "Finished in #{time} seconds" if cli.options[:debug]
diff --git rubocop.gemspec rubocop.gemspec
index 4e0278ceb..db5d539da 100644
--- rubocop.gemspec
+++ rubocop.gemspec
@@ -44,5 +44,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('unicode-display_width', '~> 1.0', '>= 1.0.1')

   s.add_development_dependency('bundler', '~> 1.3')
+  s.add_development_dependency('stackprof')
 end
 # rubocop:enable Metrics/BlockLength
```

This is output of stackprof result of running ./bin/rubocop -C false on master

```
==================================
  Mode: cpu(1000)
  Samples: 60932 (0.00% miss rate)
  GC: 3115 (5.11%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
     13429  (22.0%)       13429  (22.0%)     RuboCop::Token#end_pos
      3836   (6.3%)        3836   (6.3%)     RuboCop::AST::Node#source_range
      3115   (5.1%)        3115   (5.1%)     (garbage collection)
      5772   (9.5%)        3074   (5.0%)     RuboCop::AST::Node#each_child_node
      2390   (3.9%)        2390   (3.9%)     block (2 levels) in <class:Node>
      4027   (6.6%)        2147   (3.5%)     Parser::Lexer#advance
      1790   (2.9%)        1790   (2.9%)     RuboCop::Token#begin_pos
      1692   (2.8%)        1692   (2.8%)     AST::Node#to_a
      1640   (2.7%)        1640   (2.7%)     Parser::Source::Buffer#slice
     20117  (33.0%)        1311   (2.2%)     RuboCop::Cop::Util#tokens
      1207   (2.0%)         931   (1.5%)     Parser::Source::Buffer#line_for_position
       762   (1.3%)         681   (1.1%)     RuboCop::ConfigStore#for
      1168   (1.9%)         668   (1.1%)     RuboCop::Cop::Cop#cop_config
       606   (1.0%)         606   (1.0%)     RuboCop::Formatter::ProgressFormatter#report_file_as_mark
       444   (0.7%)         397   (0.7%)     RuboCop::Cop::RSpec::Cop#rspec_pattern
       387   (0.6%)         387   (0.6%)     Parser::Source::Range#initialize
       379   (0.6%)         379   (0.6%)     #<Module:0x00007fba5788eaf0>.of
       385   (0.6%)         368   (0.6%)     RuboCop::Cop::VariableForce#scanned_node?
       632   (1.0%)         362   (0.6%)     Parser::Source::Buffer#column_for_position
       757   (1.2%)         345   (0.6%)     AST::Node#initialize
       478   (0.8%)         335   (0.5%)     RuboCop::Cop::Cop#cop_name
       412   (0.7%)         316   (0.5%)     Parser::AST::Node#assign_properties
       546   (0.9%)         285   (0.5%)     Parser::Source::Buffer#line_for
       261   (0.4%)         261   (0.4%)     Parser::Source::Buffer#line_begins
       257   (0.4%)         257   (0.4%)     AST::Node#eql?
     34171  (56.1%)         257   (0.4%)     RuboCop::Cop::Commissioner#on_send
       256   (0.4%)         256   (0.4%)     RuboCop::Cop::Cop#initialize
       243   (0.4%)         243   (0.4%)     Parser::Lexer::Literal#coerce_encoding
       231   (0.4%)         231   (0.4%)     RuboCop::Cop::IgnoredNode#ignored_nodes
       228   (0.4%)         228   (0.4%)     RuboCop::AST::Node#parent
```

After this changes, stackprof result changed followings:

```
$ bundle exec stackprof tmp/stackprof-cpu-rubocop.dump
==================================
  Mode: cpu(1000)
  Samples: 47768 (0.01% miss rate)
  GC: 2848 (5.96%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
     10700  (22.4%)       10700  (22.4%)     RuboCop::Token#end_pos
      2848   (6.0%)        2848   (6.0%)     (garbage collection)
      5170  (10.8%)        2773   (5.8%)     RuboCop::AST::Node#each_child_node
      2020   (4.2%)        2020   (4.2%)     block (2 levels) in <class:Node>
      3730   (7.8%)        1973   (4.1%)     Parser::Lexer#advance
      1457   (3.1%)        1457   (3.1%)     AST::Node#to_a
      1454   (3.0%)        1454   (3.0%)     Parser::Source::Buffer#slice
       836   (1.8%)         836   (1.8%)     RuboCop::Token#begin_pos
      1019   (2.1%)         762   (1.6%)     Parser::Source::Buffer#line_for_position
       800   (1.7%)         712   (1.5%)     RuboCop::ConfigStore#for
       617   (1.3%)         617   (1.3%)     RuboCop::Formatter::ProgressFormatter#report_file_as_mark
      1017   (2.1%)         556   (1.2%)     RuboCop::Cop::Cop#cop_config
     12034  (25.2%)         506   (1.1%)     RuboCop::Cop::Util#tokens
       459   (1.0%)         420   (0.9%)     RuboCop::Cop::RSpec::Cop#rspec_pattern
       366   (0.8%)         366   (0.8%)     Parser::Source::Range#initialize
       360   (0.8%)         360   (0.8%)     #<Module:0x00007f8f341167d0>.of
       557   (1.2%)         322   (0.7%)     Parser::Source::Buffer#column_for_position
       679   (1.4%)         308   (0.6%)     AST::Node#initialize
       319   (0.7%)         301   (0.6%)     RuboCop::Cop::VariableForce#scanned_node?
       371   (0.8%)         275   (0.6%)     Parser::AST::Node#assign_properties
       402   (0.8%)         271   (0.6%)     RuboCop::Cop::Cop#cop_name
       492   (1.0%)         267   (0.6%)     Parser::Source::Buffer#line_for
       232   (0.5%)         232   (0.5%)     AST::Node#eql?
       231   (0.5%)         231   (0.5%)     RuboCop::Cop::Cop.badge
       229   (0.5%)         229   (0.5%)     Parser::Source::Buffer#line_begins
       209   (0.4%)         209   (0.4%)     RuboCop::AST::Node#source_range
       208   (0.4%)         208   (0.4%)     Parser::Lexer::Literal#coerce_encoding
      2539   (5.3%)         207   (0.4%)     RuboCop::AST::Node#visit_descendants
       204   (0.4%)         204   (0.4%)     RuboCop::Cop::Cop#initialize
     23515  (49.2%)         197   (0.4%)     RuboCop::Cop::Commissioner#on_send
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
