### PR TITLE
BUGFIX - MethodLength Cop offense on master

### DIFF
--- a/lib/rubocop/options.rb
+++ b/lib/rubocop/options.rb
@@ -230,7 +230,7 @@ module RuboCop
       @options = options
     end
 
-    def validate_compatibility
+    def validate_compatibility # rubocop:disable Metrics/MethodLength
       if only_includes_unneeded_disable?
         raise ArgumentError, 'Lint/UnneededCopDisableDirective can not ' \
                              'be used with --only.'


### PR DESCRIPTION
I believe renaming `Lint/UnneededDisable` in combination with removing a `rubocop:disable` that was previously on this method in the no-auto-gen-timestamp PR [here](https://github.com/bbatsov/rubocop/pull/5358/files#diff-a533b255d2dfd2cb88d774f52b8a19e2R233) caused this lint failure on master. The longer Cop name required change a 1-line string into a 2-line string. This will get master green once again.

Related failure:

```
Offenses:

lib/rubocop/options.rb:233:5: C: Metrics/MethodLength: Method has too many lines. [15/14]
    def validate_compatibility ...
    ^^^^^^^^^^^^^^^^^^^^^^^^^^

1096 files inspected, 1 offense detected
RuboCop failed!
```

Found on Travis here:  https://travis-ci.org/bbatsov/rubocop/jobs/323184899

-----------------

* [x] Wrote [good commit messages][1].
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
