### PR TITLE
Add *.gemfile to Bundler cop target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 * [#3394](https://github.com/bbatsov/rubocop/issues/3394): Remove `Style/TrailingCommmaInLiteral` in favor of two new cops. ([@garettarrowood][])
 * Rename `Lint/UnneededDisable` to `Lint/UnneededCopDisableDirective`. ([@garettarrowood][])
+* [#5365](https://github.com/bbatsov/rubocop/pull/5365): Add *.gemfile to Bundler cop target. ([@sue445][])
 
 ## 0.52.1 (2017-12-27)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -11,6 +11,7 @@ AllCops:
   Include:
     - '**/*.builder'
     - '**/*.fcgi'
+    - '**/*.gemfile'
     - '**/*.gemspec'
     - '**/*.god'
     - '**/*.jb'

--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -6,6 +6,7 @@ Bundler/DuplicatedGem:
   Description: 'Checks for duplicate gem entries in Gemfile.'
   Enabled: true
   Include:
+    - '**/*.gemfile'
     - '**/Gemfile'
     - '**/gems.rb'
 
@@ -16,6 +17,7 @@ Bundler/InsecureProtocolSource:
                  'https://rubygems.org' if possible, or 'http://rubygems.org' if not.
   Enabled: true
   Include:
+    - '**/*.gemfile'
     - '**/Gemfile'
     - '**/gems.rb'
 
@@ -24,6 +26,7 @@ Bundler/OrderedGems:
                  Gems within groups in the Gemfile should be alphabetically sorted.
   Enabled: true
   Include:
+    - '**/*.gemfile'
     - '**/Gemfile'
     - '**/gems.rb'
 

--- a/manual/cops_bundler.md
+++ b/manual/cops_bundler.md
@@ -37,7 +37,7 @@ gem 'rubocop', groups: [:development, :test]
 
 Name | Default value | Configurable values
 --- | --- | ---
-Include | `**/Gemfile`, `**/gems.rb` | Array
+Include | `**/*.gemfile`, `**/Gemfile`, `**/gems.rb` | Array
 
 ## Bundler/InsecureProtocolSource
 
@@ -75,7 +75,7 @@ source 'http://rubygems.org'
 
 Name | Default value | Configurable values
 --- | --- | ---
-Include | `**/Gemfile`, `**/gems.rb` | Array
+Include | `**/*.gemfile`, `**/Gemfile`, `**/gems.rb` | Array
 
 ## Bundler/OrderedGems
 
@@ -112,5 +112,5 @@ gem 'rspec'
 
 Name | Default value | Configurable values
 --- | --- | ---
-Include | `**/Gemfile`, `**/gems.rb` | Array
+Include | `**/*.gemfile`, `**/Gemfile`, `**/gems.rb` | Array
 TreatCommentsAsGroupSeparators | `true` | Boolean


### PR DESCRIPTION
Creating files with the `.gemfile` extension is well done.

e.g)

* https://github.com/kaminari/kaminari/tree/master/gemfiles
* https://github.com/activeadmin/activeadmin/tree/master/gemfiles
* https://github.com/charliesome/better_errors/tree/master/gemfiles
* https://github.com/thoughtbot/factory_bot_rails/tree/master/gemfiles

So I thought good that rubocop will check `.gemfile`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
