### PR TITLE
Add edge test cases for `Layout/SpaceInsideReferenceBrackets`

### DIFF
--- a/spec/rubocop/cop/layout/space_inside_reference_brackets_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_reference_brackets_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideReferenceBrackets, :config do
         b[index, 2]
         c["foo"]
         d[:bar]
+        e[]
       RUBY
     end
 
@@ -30,6 +31,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideReferenceBrackets, :config do
         b[345] = [ 678, var, "", nil]
         c["foo"] = "qux"
         d[:bar] = var
+        e[] = foo
       RUBY
     end
 
@@ -108,6 +110,24 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideReferenceBrackets, :config do
         .to eq(['Do not use space inside reference brackets.'])
     end
 
+    it 'registers an offense for empty brackets with a whitespace' do
+      expect_offense(<<-RUBY.strip_indent)
+        a[ ]
+          ^ Do not use space inside reference brackets.
+        a[ ] = foo
+          ^ Do not use space inside reference brackets.
+      RUBY
+    end
+
+    it 'registers an offense for empty brackets with whitespaces' do
+      expect_offense(<<-RUBY.strip_indent)
+        a[  ]
+          ^^ Do not use space inside reference brackets.
+        a[   ] = foo
+          ^^^ Do not use space inside reference brackets.
+      RUBY
+    end
+
     context 'auto-correct' do
       it 'fixes multiple offenses in one set of ref brackets' do
         new_source = autocorrect_source(<<-RUBY.strip_indent)
@@ -135,6 +155,21 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideReferenceBrackets, :config do
           j["pop"] = [89, nil, ""    ]
         RUBY
       end
+
+      it 'removes whitespaces in empty brackets' do
+        new_source = autocorrect_source(<<-RUBY.strip_indent)
+          a[ ]
+          a[    ]
+          a[ ] = foo
+          a[   ] = bar
+        RUBY
+        expect(new_source).to eq(<<-RUBY.strip_indent)
+          a[]
+          a[]
+          a[] = foo
+          a[] = bar
+        RUBY
+      end
     end
   end
 
@@ -156,6 +191,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideReferenceBrackets, :config do
         b[ index, 3 ]
         c[ "foo" ]
         d[ :bar ]
+        e[ ]
       RUBY
     end
 
@@ -165,6 +201,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideReferenceBrackets, :config do
         b[ 345 ] = [ 678, var, "", nil]
         c[ "foo" ] = "qux"
         d[ :bar ] = var
+        e[ ] = baz
       RUBY
     end
 
@@ -243,6 +280,17 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideReferenceBrackets, :config do
         .to eq(['Use space inside reference brackets.'])
     end
 
+    it 'registers an offense for empty brackets without whitespaces' do
+      expect_offense(<<-RUBY.strip_indent)
+        a[]
+         ^ Use space inside reference brackets.
+          ^ Use space inside reference brackets.
+        a[] = foo
+         ^ Use space inside reference brackets.
+          ^ Use space inside reference brackets.
+      RUBY
+    end
+
     context 'auto-correct' do
       it 'fixes multiple offenses in one set of ref brackets' do
         new_source = autocorrect_source(<<-RUBY.strip_indent)
@@ -268,6 +316,18 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideReferenceBrackets, :config do
         RUBY
         expect(new_source).to eq(<<-RUBY.strip_indent)
           j[ "pop" ] = [89, nil, ""    ]
+        RUBY
+      end
+
+      it 'fixes multiple offenses for empty brackets' do
+        pending
+        new_source = autocorrect_source(<<-RUBY.strip_indent)
+          a[]
+          a[] = foo
+        RUBY
+        expect(new_source).to eq(<<-RUBY.strip_indent)
+          a[ ]
+          a[ ] = foo
         RUBY
       end
     end


### PR DESCRIPTION
The spec for `Layout/SpaceInsideReferenceBrackets`does not check empty `[]` and `[]=` methods calls. For example: `e[]; e[]= 1`

This pull-request adds test cases for the cases.

And I added a pending spec.
https://github.com/bbatsov/rubocop/compare/master...pocke:add-test-case?expand=1#diff-c3ae03f1a9753d5a41103bc8def10383R323
I'm not sure how to fix it, can you fix it? @garettarrowood 





-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
