### PR TITLE
Add `.gemfile` to `TargetFinder::RUBY_EXTENSIONS`

### DIFF
--- a/lib/rubocop/target_finder.rb
+++ b/lib/rubocop/target_finder.rb
@@ -6,6 +6,7 @@ module RuboCop
   RUBY_EXTENSIONS = %w[.rb
                        .builder
                        .fcgi
+                       .gemfile
                        .gemspec
                        .god
                        .jb


### PR DESCRIPTION
Follow #5365

BTW, I think we should reconsider the list of extensions. Maybe we can remove the extension list from `TargetFinder` class, and `TargetFinder` reads the extension list from `.rubocop.yml`.

