### PR TITLE
Add `ForbiddenNames` configuration to Uncommunicative cops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [#5248](https://github.com/bbatsov/rubocop/pull/5248): Add new `Lint/BigDecimalNew` cop. ([@koic][])
 * [#3394](https://github.com/bbatsov/rubocop/issues/3394): Add new `Style/TrailingCommmaInArrayLiteral` cop. ([@garettarrowood][])
 * [#3394](https://github.com/bbatsov/rubocop/issues/3394): Add new `Style/TrailingCommmaInHashLiteral` cop. ([@garettarrowood][])
+* Add `ForbiddenNames` configuration to `Naming/Uncommunicative` cops. ([@garettarrowood][])
 * [#5319](https://github.com/bbatsov/rubocop/pull/5319): Add new `Security/Open` cop. ([@mame][])
 * [#5358](https://github.com/bbatsov/rubocop/pull/5358):  `--no-auto-gen-timestamp` CLI option suppresses the inclusion of the date and time it was generated in auto-generated config. ([@dominicsayers][])
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@
 * [#5248](https://github.com/bbatsov/rubocop/pull/5248): Add new `Lint/BigDecimalNew` cop. ([@koic][])
 * [#3394](https://github.com/bbatsov/rubocop/issues/3394): Add new `Style/TrailingCommmaInArrayLiteral` cop. ([@garettarrowood][])
 * [#3394](https://github.com/bbatsov/rubocop/issues/3394): Add new `Style/TrailingCommmaInHashLiteral` cop. ([@garettarrowood][])
-* Add `ForbiddenNames` configuration to `Naming/Uncommunicative` cops. ([@garettarrowood][])
 * [#5319](https://github.com/bbatsov/rubocop/pull/5319): Add new `Security/Open` cop. ([@mame][])
 * [#5358](https://github.com/bbatsov/rubocop/pull/5358):  `--no-auto-gen-timestamp` CLI option suppresses the inclusion of the date and time it was generated in auto-generated config. ([@dominicsayers][])
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -689,6 +689,8 @@ Naming/UncommunicativeBlockParamName:
   AllowNamesEndingInNumbers: true
   # Whitelisted names that will not register an offense
   AllowedNames: []
+  # Blacklisted names that will register an offense
+  ForbiddenNames: []
 
 Naming/UncommunicativeMethodArgName:
   # Argrument names may be equal to or greater than this value
@@ -696,6 +698,8 @@ Naming/UncommunicativeMethodArgName:
   AllowNamesEndingInNumbers: true
   # Whitelisted names that will not register an offense
   AllowedNames: []
+  # Blacklisted names that will register an offense
+  ForbiddenNames: []
 
 Naming/VariableName:
   EnforcedStyle: snake_case

--- a/lib/rubocop/cop/mixin/uncommunicative_name.rb
+++ b/lib/rubocop/cop/mixin/uncommunicative_name.rb
@@ -8,6 +8,8 @@ module RuboCop
       NUM_MSG = 'Do not end %<name_type>s with a number.'.freeze
       LENGTH_MSG = '%<name_type>s must be longer than %<min>s ' \
                    'characters.'.freeze
+      FORBIDDEN_MSG = 'Do not use %<name>s as a name for a ' \
+                      '%<name_type>s.'.freeze
 
       def check(node, args)
         args.each do |arg|
@@ -21,6 +23,7 @@ module RuboCop
       private
 
       def issue_offenses(node, range, name)
+        forbidden_offense(node, range, name) if forbidden_names.include?(name)
         case_offense(node, range) if uppercase?(name)
         length_offense(node, range) unless long_enough?(name)
         return if allow_nums
@@ -72,8 +75,20 @@ module RuboCop
                                   begin_pos + length)
       end
 
+      def forbidden_offense(node, range, name)
+        add_offense(
+          node,
+          location: range,
+          message: format(FORBIDDEN_MSG, name: name, name_type: name_type(node))
+        )
+      end
+
       def allowed_names
         cop_config['AllowedNames']
+      end
+
+      def forbidden_names
+        cop_config['ForbiddenNames']
       end
 
       def allow_nums

--- a/lib/rubocop/cop/naming/uncommunicative_block_param_name.rb
+++ b/lib/rubocop/cop/naming/uncommunicative_block_param_name.rb
@@ -3,26 +3,36 @@
 module RuboCop
   module Cop
     module Naming
-      # This cop makes sure block parameter names meet a configurable
-      # level of description
+      # This cop checks block parameter names for how descriptive they
+      # are. It is highly configurable.
+      #
+      # The `MinNameLength` config option takes an integer. It represents
+      # the minimum amount of characters the name must be. Its default is 1.
+      # The `AllowNamesEndingInNumbers` config option takes a boolean. When
+      # set to false, this cop will register offenses for names ending with
+      # numbers. Its default is false. The `AllowedNames` config option
+      # takes an array of whitelisted names that will never register an
+      # offense. The `ForbiddenNames` config option takes an array of
+      # blacklisted names that will always register an offense.
       #
       # @example
       #   # bad
-      #   foo { |num1, num2| num1 + num2 }
-      #
       #   bar do |varOne, varTwo|
       #     varOne + varTwo
       #   end
       #
+      #   # With `AllowNamesEndingInNumbers` set to false
+      #   foo { |num1, num2| num1 * num2 }
+      #
       #   # With `MinParamNameLength` set to number greater than 1
-      #   baz { |x, y, z| do_stuff(x, y, z) }
+      #   baz { |a, b, c| do_stuff(a, b, c) }
       #
       #   # good
-      #   foo { |first_num, second_num| first_num + second_num }
-      #
-      #   bar do |var_one, var_two|
-      #     var_one + var_two
+      #   bar do |thud, fred|
+      #     thud + fred
       #   end
+      #
+      #   foo { |speed, distance| speed * distance }
       #
       #   baz { |age, height, gender| do_stuff(age, height, gender) }
       class UncommunicativeBlockParamName < Cop

--- a/lib/rubocop/cop/naming/uncommunicative_method_arg_name.rb
+++ b/lib/rubocop/cop/naming/uncommunicative_method_arg_name.rb
@@ -3,34 +3,45 @@
 module RuboCop
   module Cop
     module Naming
-      # This cop makes sure method argument names meet a configurable
-      # level of description
+      # This cop checks method argument names for how descriptive they
+      # are. It is highly configurable.
+      #
+      # The `MinNameLength` config option takes an integer. It represents
+      # the minimum amount of characters the name must be. Its default is 3.
+      # The `AllowNamesEndingInNumbers` config option takes a boolean. When
+      # set to false, this cop will register offenses for names ending with
+      # numbers. Its default is false. The `AllowedNames` config option
+      # takes an array of whitelisted names that will never register an
+      # offense. The `ForbiddenNames` config option takes an array of
+      # blacklisted names that will always register an offense.
+      #
       # @example
       #   # bad
-      #   def foo(num1, num2)
-      #     num1 + num2
-      #   end
-      #
       #   def bar(varOne, varTwo)
       #     varOne + varTwo
       #   end
       #
+      #   # With `AllowNamesEndingInNumbers` set to false
+      #   def foo(num1, num2)
+      #     num1 * num2
+      #   end
+      #
       #   # With `MinArgNameLength` set to number greater than 1
-      #   def baz(x, y, z)
-      #     do_stuff(x, y, z)
+      #   def baz(a, b, c)
+      #     do_stuff(a, b, c)
       #   end
       #
       #   # good
-      #   def foo(first_num, second_num)
-      #     first_num + second_num
+      #   def bar(thud, fred)
+      #     thud + fred
       #   end
       #
-      #   def bar(var_one, var_two)
-      #     var_one + var_two
+      #   def foo(speed, distance)
+      #     speed * distance
       #   end
       #
-      #   def baz(age_x, height_y, gender_z)
-      #     do_stuff(age_x, height_y, gender_z)
+      #   def baz(age_a, height_b, gender_c)
+      #     do_stuff(age_a, height_b, gender_c)
       #   end
       class UncommunicativeMethodArgName < Cop
         include UncommunicativeName

--- a/manual/cops_naming.md
+++ b/manual/cops_naming.md
@@ -369,28 +369,38 @@ Enabled by default | Supports autocorrection
 --- | ---
 Enabled | No
 
-This cop makes sure block parameter names meet a configurable
-level of description
+This cop checks block parameter names for how descriptive they
+are. It is highly configurable.
+
+The `MinNameLength` config option takes an integer. It represents
+the minimum amount of characters the name must be. Its default is 1.
+The `AllowNamesEndingInNumbers` config option takes a boolean. When
+set to false, this cop will register offenses for names ending with
+numbers. Its default is false. The `AllowedNames` config option
+takes an array of whitelisted names that will never register an
+offense. The `ForbiddenNames` config option takes an array of
+blacklisted names that will always register an offense.
 
 ### Examples
 
 ```ruby
 # bad
-foo { |num1, num2| num1 + num2 }
-
 bar do |varOne, varTwo|
   varOne + varTwo
 end
 
+# With `AllowNamesEndingInNumbers` set to false
+foo { |num1, num2| num1 * num2 }
+
 # With `MinParamNameLength` set to number greater than 1
-baz { |x, y, z| do_stuff(x, y, z) }
+baz { |a, b, c| do_stuff(a, b, c) }
 
 # good
-foo { |first_num, second_num| first_num + second_num }
-
-bar do |var_one, var_two|
-  var_one + var_two
+bar do |thud, fred|
+  thud + fred
 end
+
+foo { |speed, distance| speed * distance }
 
 baz { |age, height, gender| do_stuff(age, height, gender) }
 ```
@@ -410,37 +420,47 @@ Enabled by default | Supports autocorrection
 --- | ---
 Enabled | No
 
-This cop makes sure method argument names meet a configurable
-level of description
+This cop checks method argument names for how descriptive they
+are. It is highly configurable.
+
+The `MinNameLength` config option takes an integer. It represents
+the minimum amount of characters the name must be. Its default is 3.
+The `AllowNamesEndingInNumbers` config option takes a boolean. When
+set to false, this cop will register offenses for names ending with
+numbers. Its default is false. The `AllowedNames` config option
+takes an array of whitelisted names that will never register an
+offense. The `ForbiddenNames` config option takes an array of
+blacklisted names that will always register an offense.
 
 ### Examples
 
 ```ruby
 # bad
-def foo(num1, num2)
-  num1 + num2
-end
-
 def bar(varOne, varTwo)
   varOne + varTwo
 end
 
+# With `AllowNamesEndingInNumbers` set to false
+def foo(num1, num2)
+  num1 * num2
+end
+
 # With `MinArgNameLength` set to number greater than 1
-def baz(x, y, z)
-  do_stuff(x, y, z)
+def baz(a, b, c)
+  do_stuff(a, b, c)
 end
 
 # good
-def foo(first_num, second_num)
-  first_num + second_num
+def bar(thud, fred)
+  thud + fred
 end
 
-def bar(var_one, var_two)
-  var_one + var_two
+def foo(speed, distance)
+  speed * distance
 end
 
-def baz(age_x, height_y, gender_z)
-  do_stuff(age_x, height_y, gender_z)
+def baz(age_a, height_b, gender_c)
+  do_stuff(age_a, height_b, gender_c)
 end
 ```
 

--- a/manual/cops_naming.md
+++ b/manual/cops_naming.md
@@ -402,6 +402,7 @@ Name | Default value | Configurable values
 MinNameLength | `1` | Integer
 AllowNamesEndingInNumbers | `true` | Boolean
 AllowedNames | `[]` | Array
+ForbiddenNames | `[]` | Array
 
 ## Naming/UncommunicativeMethodArgName
 
@@ -450,6 +451,7 @@ Name | Default value | Configurable values
 MinNameLength | `3` | Integer
 AllowNamesEndingInNumbers | `true` | Boolean
 AllowedNames | `[]` | Array
+ForbiddenNames | `[]` | Array
 
 ## Naming/VariableName
 

--- a/spec/rubocop/cop/naming/uncommunicative_block_param_name_spec.rb
+++ b/spec/rubocop/cop/naming/uncommunicative_block_param_name_spec.rb
@@ -89,6 +89,27 @@ RSpec.describe RuboCop::Cop::Naming::UncommunicativeBlockParamName, :config do
     end
   end
 
+  context 'with ForbiddenNames' do
+    let(:cop_config) do
+      {
+        'ForbiddenNames' => %w[arg]
+      }
+    end
+
+    it 'registers offense for param listed as forbidden' do
+      expect_offense(<<-RUBY.strip_indent)
+        something { |arg| do_stuff }
+                     ^^^ Do not use arg as a name for a block parameter.
+      RUBY
+    end
+
+    it "accepts param that uses a forbidden name's letters" do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        something { |foo_arg| do_stuff }
+      RUBY
+    end
+  end
+
   context 'with AllowNamesEndingInNumbers' do
     let(:cop_config) do
       {

--- a/spec/rubocop/cop/naming/uncommunicative_method_arg_name_spec.rb
+++ b/spec/rubocop/cop/naming/uncommunicative_method_arg_name_spec.rb
@@ -144,6 +144,31 @@ RSpec.describe RuboCop::Cop::Naming::UncommunicativeMethodArgName, :config do
     end
   end
 
+  context 'with ForbiddenNames' do
+    let(:cop_config) do
+      {
+        'ForbiddenNames' => %w[arg]
+      }
+    end
+
+    it 'registers offense for argument listed as forbidden' do
+      expect_offense(<<-RUBY.strip_indent)
+        def baz(arg)
+                ^^^ Do not use arg as a name for a method argument.
+          arg.do_things
+        end
+      RUBY
+    end
+
+    it "accepts argument that uses a forbidden name's letters" do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        def baz(foo_argument)
+          foo_argument.do_things
+        end
+      RUBY
+    end
+  end
+
   context 'with AllowNamesEndingInNumbers' do
     let(:cop_config) do
       {


### PR DESCRIPTION
I have a feeling that in addition to people wanting the ability to allow names that violate their `Uncommunicative` cops length/number specifications, that will also want the ability to forbid names that do not violate their length/number specifications.

This PR add a `ForbiddenNames` config option to `Naming/UncommunicativeBlockParamName` and `Naming/UncommunicativeMethodArgName`.

-----------------

* [x] Wrote [good commit messages][1].
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
