### PR TITLE
[Fix #4477] Warn when user config overrides other user config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * [#3394](https://github.com/bbatsov/rubocop/issues/3394): Remove `Style/TrailingCommmaInLiteral` in favor of two new cops. ([@garettarrowood][])
 * Rename `Lint/UnneededDisable` to `Lint/UnneededCopDisableDirective`. ([@garettarrowood][])
 * [#5365](https://github.com/bbatsov/rubocop/pull/5365): Add *.gemfile to Bundler cop target. ([@sue445][])
+* [#4477](https://github.com/bbatsov/rubocop/issues/4477): Warn when user configuration overrides other user configuration. ([@jonas054][])
 
 ## 0.52.1 (2017-12-27)
 

--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -89,7 +89,9 @@ module RuboCop
 
       def add_excludes_from_files(config, config_file)
         found_files = config_files_in_path(config_file)
-        return unless found_files.any? && found_files.last != config_file
+        return if found_files.empty?
+        return if PathUtil.relative_path(found_files.last) ==
+                  PathUtil.relative_path(config_file)
         print 'AllCops/Exclude ' if debug?
         config.add_excludes_from_higher_level(load_file(found_files.last))
       end

--- a/spec/rubocop/cli/cli_auto_gen_config_spec.rb
+++ b/spec/rubocop/cli/cli_auto_gen_config_spec.rb
@@ -173,7 +173,9 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
           YAML
           $stdout = StringIO.new
           expect(described_class.new.run(%w[--format simple])).to eq(1)
-          expect($stderr.string).to eq('')
+          expect($stderr.string)
+            .to eq('.rubocop.yml: Metrics/LineLength:Max overrides the same ' \
+                   "parameter in .rubocop_todo.yml\n")
           expect($stdout.string).to eq(<<-OUTPUT.strip_indent)
             == example.rb ==
             C:  2: 91: Metrics/LineLength: Line is too long. [99/90]


### PR DESCRIPTION
The example given in #4477 is that an `Exclude` in `.rubocop_todo.yml` is overridden in `.rubocop.yml` and this causes some offenses to be reported because the `Exclude` in `.rubocop_todo.yml` is not in use.

Modifying the overriding/merging behavior would be a big deal, too big IMO. So I think that a stern warning is the best solution.

The warning is issued when a parameter in user configuration overrides a parameter setting that's also in user configuration. This excludes inherited files in gems and files inherited from remote locations.

Overriding settings from a higher level within the project is regarded as a legitimate use case, so there's no warning for those settings either.