### PR TITLE
3rd round of optimizing `Util#tokens(node)`

### DIFF
--- a/lib/rubocop/cop/layout/space_inside_array_literal_brackets.rb
+++ b/lib/rubocop/cop/layout/space_inside_array_literal_brackets.rb
@@ -88,8 +88,9 @@ module RuboCop
         end
 
         def empty_brackets?(left_bracket_token, right_bracket_token)
-          processed_source.tokens.index(left_bracket_token) ==
-            processed_source.tokens.index(right_bracket_token) - 1
+          left_index = processed_source.tokens.index(left_bracket_token)
+          right_index = processed_source.tokens.index(right_bracket_token)
+          right_index && left_index == right_index - 1
         end
 
         def empty_offenses(node, left, right)

--- a/lib/rubocop/cop/util.rb
+++ b/lib/rubocop/cop/util.rb
@@ -121,7 +121,7 @@ module RuboCop
           .sub('Style', 'Styles')
       end
 
-      def tokens(node)
+      def tokens(node) # rubocop:disable Metrics/AbcSize
         @tokens ||= {}
         return @tokens[node.object_id] if @tokens[node.object_id]
 
@@ -129,9 +129,17 @@ module RuboCop
         begin_pos = source_range.begin_pos
         end_pos = source_range.end_pos
 
-        @tokens[node.object_id] = processed_source.tokens.select do |token|
-          token.end_pos <= end_pos && token.begin_pos >= begin_pos
+        tokens_to_node_end = processed_source.tokens.take_while do |token|
+          token.end_pos <= end_pos
         end
+
+        node_tokens = []
+        tokens_to_node_end.reverse_each do |token|
+          break unless token.begin_pos >= begin_pos
+          node_tokens.unshift(token)
+        end
+
+        @tokens[node.object_id] = node_tokens
       end
 
       private


### PR DESCRIPTION
There have been 2 awesome PRs that benchmarked and sped `tokens(node)` up already.  #5282 & #5363 . This is one more pass at optimizing this expensive method. Details are in the comments.

Running `time bundle exec ruby -I lib ./bin/rubocop -C false` on an up-to-date master 3 times:

real | user | sys
--- | --- | ---
1m51.189s | 1m48.632s | 0m1.037s
1m43.522s | 1m42.035s | 0m0.769s
1m46.765s | 1m44.333s | 0m1.041s

Then on this PR:

real | user | sys
--- | --- | ---
1m39.415s | 1m36.523s | 0m1.045s
1m35.140s | 1m33.381s | 0m0.785s
1m36.666s | 1m34.664s | 0m0.803s

Overall speed up: 10 seconds / 10 %

-----------------

* [x] Wrote [good commit messages][1].
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
