### PR TITLE
Add an example of `EnforcedStyle` for `Layout/SpaceAroundEqualsInParameterDefault`

### DIFF
--- a/lib/rubocop/cop/layout/space_around_equals_in_parameter_default.rb
+++ b/lib/rubocop/cop/layout/space_around_equals_in_parameter_default.rb
@@ -5,7 +5,8 @@ module RuboCop
     module Layout
       # Checks that the equals signs in parameter default assignments
       # have or don't have surrounding space depending on configuration.
-      # @example
+      #
+      # @example EnforcedStyle: space (default)
       #   # bad
       #   def some_method(arg1=:default, arg2=nil, arg3=[])
       #     # do something...
@@ -13,6 +14,17 @@ module RuboCop
       #
       #   # good
       #   def some_method(arg1 = :default, arg2 = nil, arg3 = [])
+      #     # do something...
+      #   end
+      #
+      # @example EnforcedStyle: no_space
+      #   # bad
+      #   def some_method(arg1 = :default, arg2 = nil, arg3 = [])
+      #     # do something...
+      #   end
+      #
+      #   # good
+      #   def some_method(arg1=:default, arg2=nil, arg3=[])
       #     # do something...
       #   end
       class SpaceAroundEqualsInParameterDefault < Cop

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -2529,6 +2529,8 @@ have or don't have surrounding space depending on configuration.
 
 ### Examples
 
+#### EnforcedStyle: space (default)
+
 ```ruby
 # bad
 def some_method(arg1=:default, arg2=nil, arg3=[])
@@ -2537,6 +2539,19 @@ end
 
 # good
 def some_method(arg1 = :default, arg2 = nil, arg3 = [])
+  # do something...
+end
+```
+#### EnforcedStyle: no_space
+
+```ruby
+# bad
+def some_method(arg1 = :default, arg2 = nil, arg3 = [])
+  # do something...
+end
+
+# good
+def some_method(arg1=:default, arg2=nil, arg3=[])
   # do something...
 end
 ```


### PR DESCRIPTION
Follow up of https://github.com/bbatsov/rubocop/pull/4880#issuecomment-338499947.

This is only document change.

This commit adds an example of `EnforcedStyle` to `Layout/SpaceAroundEqualsInParameterDefault`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
