### PR TITLE
Add EnforcedStyleForEmptyBrackets config to SpaceInsideReferenceBrackets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [#3394](https://github.com/bbatsov/rubocop/issues/3394): Add new `Style/TrailingCommmaInArrayLiteral` cop. ([@garettarrowood][])
 * [#3394](https://github.com/bbatsov/rubocop/issues/3394): Add new `Style/TrailingCommmaInHashLiteral` cop. ([@garettarrowood][])
 * [#5319](https://github.com/bbatsov/rubocop/pull/5319): Add new `Security/Open` cop. ([@mame][])
+* Add `EnforcedStyleForEmptyBrackets` configuration to `Layout/SpaceInsideReferenceBrackets`.([@garettarrowood][])
 * [#5358](https://github.com/bbatsov/rubocop/pull/5358):  `--no-auto-gen-timestamp` CLI option suppresses the inclusion of the date and time it was generated in auto-generated config. ([@dominicsayers][])
 
 ### Bug fixes

--- a/config/default.yml
+++ b/config/default.yml
@@ -545,6 +545,10 @@ Layout/SpaceInsideReferenceBrackets:
   SupportedStyles:
     - space
     - no_space
+  EnforcedStyleForEmptyBrackets: no_space
+  SupportedStylesForEmptyBrackets:
+    - space
+    - no_space
 
 Layout/SpaceInsideStringInterpolation:
   EnforcedStyle: no_space

--- a/lib/rubocop/cop/correctors/space_corrector.rb
+++ b/lib/rubocop/cop/correctors/space_corrector.rb
@@ -9,6 +9,19 @@ module RuboCop
       class << self
         attr_reader :processed_source
 
+        def empty_corrections(processed_source, corrector, empty_config,
+                              left_token, right_token)
+          @processed_source = processed_source
+          if offending_empty_space?(empty_config, left_token, right_token)
+            range = side_space_range(range: left_token.pos, side: :right)
+            corrector.remove(range)
+            corrector.insert_after(left_token.pos, ' ')
+          elsif offending_empty_no_space?(empty_config, left_token, right_token)
+            range = side_space_range(range: left_token.pos, side: :right)
+            corrector.remove(range)
+          end
+        end
+
         def remove_space(processed_source, corrector, left_token, right_token)
           @processed_source = processed_source
           if left_token.space_after?

--- a/lib/rubocop/cop/layout/space_inside_array_literal_brackets.rb
+++ b/lib/rubocop/cop/layout/space_inside_array_literal_brackets.rb
@@ -47,7 +47,7 @@ module RuboCop
           return unless node.square_brackets?
           left, right = array_brackets(node)
           if empty_brackets?(left, right)
-            return empty_offenses(node, left, right)
+            return empty_offenses(node, left, right, EMPTY_MSG)
           end
 
           start_ok = next_to_newline?(node, left)
@@ -61,7 +61,8 @@ module RuboCop
 
           lambda do |corrector|
             if empty_brackets?(left, right)
-              empty_corrections(corrector, left, right)
+              SpaceCorrector.empty_corrections(processed_source, corrector,
+                                               empty_config, left, right)
             elsif style == :no_space
               SpaceCorrector.remove_space(processed_source, corrector,
                                           left, right)
@@ -87,51 +88,8 @@ module RuboCop
           tokens(node).reverse.find(&:right_bracket?)
         end
 
-        def empty_brackets?(left_bracket_token, right_bracket_token)
-          left_index = processed_source.tokens.index(left_bracket_token)
-          right_index = processed_source.tokens.index(right_bracket_token)
-          right_index && left_index == right_index - 1
-        end
-
-        def empty_offenses(node, left, right)
-          empty_offense(node, 'Use one') if offending_empty_space?(left, right)
-          return unless offending_empty_no_space?(left, right)
-          empty_offense(node, 'Do not use')
-        end
-
-        def empty_offense(node, command)
-          add_offense(node, message: format(EMPTY_MSG, command: command))
-        end
-
-        def offending_empty_space?(left, right)
-          empty_config == 'space' && !space_between?(left, right)
-        end
-
-        def offending_empty_no_space?(left, right)
-          empty_config == 'no_space' && !no_space_between?(left, right)
-        end
-
-        def space_between?(left, right)
-          left.end_pos + 1 == right.begin_pos
-        end
-
-        def no_space_between?(left, right)
-          left.end_pos == right.begin_pos
-        end
-
         def empty_config
           cop_config['EnforcedStyleForEmptyBrackets']
-        end
-
-        def empty_corrections(corrector, left, right)
-          if offending_empty_space?(left, right)
-            range = side_space_range(range: left.pos, side: :right)
-            corrector.remove(range)
-            corrector.insert_after(left.pos, ' ')
-          elsif offending_empty_no_space?(left, right)
-            range = side_space_range(range: left.pos, side: :right)
-            corrector.remove(range)
-          end
         end
 
         def next_to_newline?(node, token)

--- a/lib/rubocop/cop/layout/space_inside_array_literal_brackets.rb
+++ b/lib/rubocop/cop/layout/space_inside_array_literal_brackets.rb
@@ -36,6 +36,32 @@ module RuboCop
       #
       #   # good
       #   array = [ a, [ b, c ]]
+      #
+      #
+      # @example EnforcedStyleForEmptyBrackets: no_space (default)
+      #   # The `no_space` EnforcedStyleForEmptyBrackets style enforces that
+      #   # empty array brackets do not contain spaces.
+      #
+      #   # bad
+      #   foo = [ ]
+      #   bar = [     ]
+      #
+      #   # good
+      #   foo = []
+      #   bar = []
+      #
+      # @example EnforcedStyleForEmptyBrackets: space
+      #   # The `space` EnforcedStyleForEmptyBrackets style enforces that
+      #   # empty array brackets contain exactly one space.
+      #
+      #   # bad
+      #   foo = []
+      #   bar = [    ]
+      #
+      #   # good
+      #   foo = [ ]
+      #   bar = [ ]
+      #
       class SpaceInsideArrayLiteralBrackets < Cop
         include SurroundingSpace
         include ConfigurableEnforcedStyle

--- a/lib/rubocop/cop/layout/space_inside_block_braces.rb
+++ b/lib/rubocop/cop/layout/space_inside_block_braces.rb
@@ -43,7 +43,7 @@ module RuboCop
       #
       # @example EnforcedStyleForEmptyBraces: space
       #   # The `space` EnforcedStyleForEmptyBraces style enforces that
-      #   # block braces have at least a spece in between when empty.
+      #   # block braces have at least a space in between when empty.
       #
       #   # bad
       #   some_array.each {}
@@ -65,7 +65,7 @@ module RuboCop
       #   # good
       #   [1, 2, 3].each { |n| n * 2 }
       #
-      # @example SpaceBeforeBlockParameters: true
+      # @example SpaceBeforeBlockParameters: false
       #   # The SpaceBeforeBlockParameters style set to `false` enforces that
       #   # there is no space between `{` and `|`. Overrides `EnforcedStyle`
       #   # if there is a conflict.

--- a/lib/rubocop/cop/layout/space_inside_hash_literal_braces.rb
+++ b/lib/rubocop/cop/layout/space_inside_hash_literal_braces.rb
@@ -36,6 +36,32 @@ module RuboCop
       #
       #   # good
       #   h = { a: { b: 2 }}
+      #
+      #
+      # @example EnforcedStyleForEmptyBraces: no_space (default)
+      #   # The `no_space` EnforcedStyleForEmptyBraces style enforces that
+      #   # empty hash braces do not contain spaces.
+      #
+      #   # bad
+      #   foo = { }
+      #   bar = {    }
+      #
+      #   # good
+      #   foo = {}
+      #   bar = {}
+      #
+      # @example EnforcedStyleForEmptyBraces: space
+      #   # The `space` EnforcedStyleForEmptyBraces style enforces that
+      #   # empty hash braces contain space.
+      #
+      #   # bad
+      #   foo = {}
+      #
+      #   # good
+      #   foo = { }
+      #   foo = {  }
+      #   foo = {     }
+      #
       class SpaceInsideHashLiteralBraces < Cop
         include SurroundingSpace
         include ConfigurableEnforcedStyle

--- a/lib/rubocop/cop/layout/space_inside_reference_brackets.rb
+++ b/lib/rubocop/cop/layout/space_inside_reference_brackets.rb
@@ -29,6 +29,30 @@ module RuboCop
       #   # good
       #   hash[ :key ]
       #   array[ index ]
+      #
+      #
+      # @example EnforcedStyleForEmptyBrackets: no_space (default)
+      #   # The `no_space` EnforcedStyleForEmptyBrackets style enforces that
+      #   # empty reference brackets do not contain spaces.
+      #
+      #   # bad
+      #   foo[ ]
+      #   foo[     ]
+      #
+      #   # good
+      #   foo[]
+      #
+      # @example EnforcedStyleForEmptyBrackets: space
+      #   # The `space` EnforcedStyleForEmptyBrackets style enforces that
+      #   # empty reference brackets contain exactly one space.
+      #
+      #   # bad
+      #   foo[]
+      #   foo[    ]
+      #
+      #   # good
+      #   foo[ ]
+      #
       class SpaceInsideReferenceBrackets < Cop
         include SurroundingSpace
         include ConfigurableEnforcedStyle

--- a/lib/rubocop/cop/mixin/surrounding_space.rb
+++ b/lib/rubocop/cop/mixin/surrounding_space.rb
@@ -97,6 +97,40 @@ module RuboCop
         add_offense(node, location: range,
                           message: format(message, command: command))
       end
+
+      def empty_offenses(node, left, right, message)
+        if offending_empty_space?(empty_config, left, right)
+          empty_offense(node, message, 'Use one')
+        end
+        return unless offending_empty_no_space?(empty_config, left, right)
+        empty_offense(node, message, 'Do not use')
+      end
+
+      def empty_offense(node, message, command)
+        add_offense(node, message: format(message, command: command))
+      end
+
+      def empty_brackets?(left_bracket_token, right_bracket_token)
+        left_index = processed_source.tokens.index(left_bracket_token)
+        right_index = processed_source.tokens.index(right_bracket_token)
+        right_index && left_index == right_index - 1
+      end
+
+      def offending_empty_space?(config, left_token, right_token)
+        config == 'space' && !space_between?(left_token, right_token)
+      end
+
+      def offending_empty_no_space?(config, left_token, right_token)
+        config == 'no_space' && !no_space_between?(left_token, right_token)
+      end
+
+      def space_between?(left_bracket_token, right_bracket_token)
+        left_bracket_token.end_pos + 1 == right_bracket_token.begin_pos
+      end
+
+      def no_space_between?(left_bracket_token, right_bracket_token)
+        left_bracket_token.end_pos == right_bracket_token.begin_pos
+      end
     end
   end
 end

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -3157,6 +3157,7 @@ array[ index ]
 Name | Default value | Configurable values
 --- | --- | ---
 EnforcedStyle | `no_space` | `space`, `no_space`
+EnforcedStyleForEmptyBrackets | `no_space` | `space`, `no_space`
 
 ## Layout/SpaceInsideStringInterpolation
 

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -2852,6 +2852,34 @@ array = [ a, [ b, c ] ]
 # good
 array = [ a, [ b, c ]]
 ```
+#### EnforcedStyleForEmptyBrackets: no_space (default)
+
+```ruby
+# The `no_space` EnforcedStyleForEmptyBrackets style enforces that
+# empty array brackets do not contain spaces.
+
+# bad
+foo = [ ]
+bar = [     ]
+
+# good
+foo = []
+bar = []
+```
+#### EnforcedStyleForEmptyBrackets: space
+
+```ruby
+# The `space` EnforcedStyleForEmptyBrackets style enforces that
+# empty array brackets contain exactly one space.
+
+# bad
+foo = []
+bar = [    ]
+
+# good
+foo = [ ]
+bar = [ ]
+```
 
 ### Configurable attributes
 
@@ -2933,7 +2961,7 @@ some_array.each {}
 
 ```ruby
 # The `space` EnforcedStyleForEmptyBraces style enforces that
-# block braces have at least a spece in between when empty.
+# block braces have at least a space in between when empty.
 
 # bad
 some_array.each {}
@@ -2956,7 +2984,7 @@ some_array.each {   }
 # good
 [1, 2, 3].each { |n| n * 2 }
 ```
-#### SpaceBeforeBlockParameters: true
+#### SpaceBeforeBlockParameters: false
 
 ```ruby
 # The SpaceBeforeBlockParameters style set to `false` enforces that
@@ -3025,6 +3053,34 @@ h = { a: { b: 2 } }
 
 # good
 h = { a: { b: 2 }}
+```
+#### EnforcedStyleForEmptyBraces: no_space (default)
+
+```ruby
+# The `no_space` EnforcedStyleForEmptyBraces style enforces that
+# empty hash braces do not contain spaces.
+
+# bad
+foo = { }
+bar = {    }
+
+# good
+foo = {}
+bar = {}
+```
+#### EnforcedStyleForEmptyBraces: space
+
+```ruby
+# The `space` EnforcedStyleForEmptyBraces style enforces that
+# empty hash braces contain space.
+
+# bad
+foo = {}
+
+# good
+foo = { }
+foo = {  }
+foo = {     }
 ```
 
 ### Configurable attributes
@@ -3150,6 +3206,32 @@ array[index]
 # good
 hash[ :key ]
 array[ index ]
+```
+#### EnforcedStyleForEmptyBrackets: no_space (default)
+
+```ruby
+# The `no_space` EnforcedStyleForEmptyBrackets style enforces that
+# empty reference brackets do not contain spaces.
+
+# bad
+foo[ ]
+foo[     ]
+
+# good
+foo[]
+```
+#### EnforcedStyleForEmptyBrackets: space
+
+```ruby
+# The `space` EnforcedStyleForEmptyBrackets style enforces that
+# empty reference brackets contain exactly one space.
+
+# bad
+foo[]
+foo[    ]
+
+# good
+foo[ ]
 ```
 
 ### Configurable attributes

--- a/spec/rubocop/cop/layout/space_inside_reference_brackets_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_reference_brackets_spec.rb
@@ -3,6 +3,80 @@
 RSpec.describe RuboCop::Cop::Layout::SpaceInsideReferenceBrackets, :config do
   subject(:cop) { described_class.new(config) }
 
+  context 'with space inside empty brackets not allowed' do
+    let(:cop_config) { { 'EnforcedStyleForEmptyBrackets' => 'no_space' } }
+
+    it 'accepts empty brackets with no space inside' do
+      expect_no_offenses('a[]')
+    end
+
+    it 'registers an offense for empty brackets with one space inside' do
+      expect_offense(<<-RUBY.strip_indent)
+        a[ ]
+        ^^^^ Do not use space inside empty reference brackets.
+      RUBY
+    end
+
+    it 'registers an offense for empty brackets with lots of space inside' do
+      expect_offense(<<-RUBY.strip_indent)
+        a[     ]
+        ^^^^^^^^ Do not use space inside empty reference brackets.
+      RUBY
+    end
+
+    it 'auto-corrects whitespaces in empty brackets' do
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
+        a[ ]
+        a[    ]
+        a[ ] = foo
+        a[   ] = bar
+      RUBY
+      expect(new_source).to eq(<<-RUBY.strip_indent)
+        a[]
+        a[]
+        a[] = foo
+        a[] = bar
+      RUBY
+    end
+  end
+
+  context 'with space inside empty braces allowed' do
+    let(:cop_config) { { 'EnforcedStyleForEmptyBrackets' => 'space' } }
+
+    it 'accepts empty brackets with space inside' do
+      expect_no_offenses('a[ ]')
+    end
+
+    it 'registers offense for empty brackets with no space inside' do
+      expect_offense(<<-RUBY.strip_indent)
+        a[]
+        ^^^ Use one space inside empty reference brackets.
+      RUBY
+    end
+
+    it 'registers offense for empty brackets with more than one space inside' do
+      expect_offense(<<-RUBY.strip_indent)
+        a[      ]
+        ^^^^^^^^^ Use one space inside empty reference brackets.
+      RUBY
+    end
+
+    it 'auto-corrects multiple offenses for empty brackets' do
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
+        a[]
+        a[    ]
+        a[] = foo
+        a[   ] = bar
+      RUBY
+      expect(new_source).to eq(<<-RUBY.strip_indent)
+        a[ ]
+        a[ ]
+        a[ ] = foo
+        a[ ] = bar
+      RUBY
+    end
+  end
+
   context 'when EnforcedStyle is no_space' do
     let(:cop_config) { { 'EnforcedStyle' => 'no_space' } }
 
@@ -110,24 +184,6 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideReferenceBrackets, :config do
         .to eq(['Do not use space inside reference brackets.'])
     end
 
-    it 'registers an offense for empty brackets with a whitespace' do
-      expect_offense(<<-RUBY.strip_indent)
-        a[ ]
-          ^ Do not use space inside reference brackets.
-        a[ ] = foo
-          ^ Do not use space inside reference brackets.
-      RUBY
-    end
-
-    it 'registers an offense for empty brackets with whitespaces' do
-      expect_offense(<<-RUBY.strip_indent)
-        a[  ]
-          ^^ Do not use space inside reference brackets.
-        a[   ] = foo
-          ^^^ Do not use space inside reference brackets.
-      RUBY
-    end
-
     context 'auto-correct' do
       it 'fixes multiple offenses in one set of ref brackets' do
         new_source = autocorrect_source(<<-RUBY.strip_indent)
@@ -155,26 +211,14 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideReferenceBrackets, :config do
           j["pop"] = [89, nil, ""    ]
         RUBY
       end
-
-      it 'removes whitespaces in empty brackets' do
-        new_source = autocorrect_source(<<-RUBY.strip_indent)
-          a[ ]
-          a[    ]
-          a[ ] = foo
-          a[   ] = bar
-        RUBY
-        expect(new_source).to eq(<<-RUBY.strip_indent)
-          a[]
-          a[]
-          a[] = foo
-          a[] = bar
-        RUBY
-      end
     end
   end
 
   context 'when EnforcedStyle is space' do
-    let(:cop_config) { { 'EnforcedStyle' => 'space' } }
+    let(:cop_config) do
+      { 'EnforcedStyle' => 'space',
+        'EnforcedStyleForEmptyBrackets' => 'space' }
+    end
 
     it 'does not register offense for array literals' do
       expect_no_offenses(<<-RUBY.strip_indent)
@@ -280,17 +324,6 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideReferenceBrackets, :config do
         .to eq(['Use space inside reference brackets.'])
     end
 
-    it 'registers an offense for empty brackets without whitespaces' do
-      expect_offense(<<-RUBY.strip_indent)
-        a[]
-         ^ Use space inside reference brackets.
-          ^ Use space inside reference brackets.
-        a[] = foo
-         ^ Use space inside reference brackets.
-          ^ Use space inside reference brackets.
-      RUBY
-    end
-
     context 'auto-correct' do
       it 'fixes multiple offenses in one set of ref brackets' do
         new_source = autocorrect_source(<<-RUBY.strip_indent)
@@ -316,18 +349,6 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideReferenceBrackets, :config do
         RUBY
         expect(new_source).to eq(<<-RUBY.strip_indent)
           j[ "pop" ] = [89, nil, ""    ]
-        RUBY
-      end
-
-      it 'fixes multiple offenses for empty brackets' do
-        pending
-        new_source = autocorrect_source(<<-RUBY.strip_indent)
-          a[]
-          a[] = foo
-        RUBY
-        expect(new_source).to eq(<<-RUBY.strip_indent)
-          a[ ]
-          a[ ] = foo
         RUBY
       end
     end


### PR DESCRIPTION
#5367 added a pending test for this functionality. @pocke wisely pointed out that while reference brackets for `Array` and `Hash` require an argument, any PORO can add reference bracket functionality that takes no arguments, and thus can be empty.

This PR moves `SpaceInsideArrayLiteralBrackets`'s `EnforcedStyleForEmptyBrackets` enforcement methods into a shared mixin, `SurroundingSpace`, and its autocorrection logic into `SpaceCorrector`.

I've modified some of the tests added in #5367 to match the test suite format/style of `SpaceInsideArrayLiteralBrackets`.  Empty brackets should only throw one offense and not two.  I've also added some more.

-----------------

* [x] Wrote [good commit messages][1].
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
