### PR TITLE
Add an example of `EnforcedStyle` for `Layout/SpaceBeforeBlockBraces`

### DIFF
--- a/lib/rubocop/cop/layout/space_before_block_braces.rb
+++ b/lib/rubocop/cop/layout/space_before_block_braces.rb
@@ -6,7 +6,7 @@ module RuboCop
       # Checks that block braces have or don't have a space before the opening
       # brace depending on configuration.
       #
-      # @example
+      # @example EnforcedStyle: space (default)
       #   # bad
       #   foo.map{ |a|
       #     a.bar.to_s
@@ -14,6 +14,17 @@ module RuboCop
       #
       #   # good
       #   foo.map { |a|
+      #     a.bar.to_s
+      #   }
+      #
+      # @example EnforcedStyle: no_space
+      #   # bad
+      #   foo.map { |a|
+      #     a.bar.to_s
+      #   }
+      #
+      #   # good
+      #   foo.map{ |a|
       #     a.bar.to_s
       #   }
       class SpaceBeforeBlockBraces < Cop

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -2642,6 +2642,8 @@ brace depending on configuration.
 
 ### Examples
 
+#### EnforcedStyle: space (default)
+
 ```ruby
 # bad
 foo.map{ |a|
@@ -2650,6 +2652,19 @@ foo.map{ |a|
 
 # good
 foo.map { |a|
+  a.bar.to_s
+}
+```
+#### EnforcedStyle: no_space
+
+```ruby
+# bad
+foo.map { |a|
+  a.bar.to_s
+}
+
+# good
+foo.map{ |a|
   a.bar.to_s
 }
 ```


### PR DESCRIPTION
Follow up of https://github.com/bbatsov/rubocop/pull/4880#issuecomment-338499947.

This is only document change.

This commit adds an example of `EnforcedStyle` to `Layout/SpaceBeforeBlockBraces`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
