### PR TITLE
Restyle example formatting for `Rails/TimeZone`

### DIFF
--- a/lib/rubocop/cop/rails/time_zone.rb
+++ b/lib/rubocop/cop/rails/time_zone.rb
@@ -14,16 +14,34 @@ module RuboCop
       # When EnforcedStyle is 'flexible' then it's also allowed
       # to use Time.in_time_zone.
       #
-      # @example
-      #   # always offense
+      # @example EnforcedStyle: strict
+      #   # `strict` means that `Time` should be used with `zone`.
+      #
+      #   # bad
       #   Time.now
       #   Time.parse('2015-03-02 19:05:37')
       #
-      #   # no offense
+      #   # bad
+      #   Time.current
+      #   DateTime.strptime(str, "%Y-%m-%d %H:%M %Z").in_time_zone
+      #   Time.at(timestamp).in_time_zone
+      #
+      #   # good
       #   Time.zone.now
       #   Time.zone.parse('2015-03-02 19:05:37')
       #
-      #   # no offense only if style is 'flexible'
+      # @example EnforcedStyle: flexible (default)
+      #   # `flexible` allows usage of `in_time_zone` instead of `zone`.
+      #
+      #   # bad
+      #   Time.now
+      #   Time.parse('2015-03-02 19:05:37')
+      #
+      #   # good
+      #   Time.zone.now
+      #   Time.zone.parse('2015-03-02 19:05:37')
+      #
+      #   # good
       #   Time.current
       #   DateTime.strptime(str, "%Y-%m-%d %H:%M %Z").in_time_zone
       #   Time.at(timestamp).in_time_zone

--- a/manual/cops_rails.md
+++ b/manual/cops_rails.md
@@ -1561,16 +1561,38 @@ to use Time.in_time_zone.
 
 ### Examples
 
+#### EnforcedStyle: strict
+
 ```ruby
-# always offense
+# `strict` means that `Time` should be used with `zone`.
+
+# bad
 Time.now
 Time.parse('2015-03-02 19:05:37')
 
-# no offense
+# bad
+Time.current
+DateTime.strptime(str, "%Y-%m-%d %H:%M %Z").in_time_zone
+Time.at(timestamp).in_time_zone
+
+# good
+Time.zone.now
+Time.zone.parse('2015-03-02 19:05:37')
+```
+#### EnforcedStyle: flexible (default)
+
+```ruby
+# `flexible` allows usage of `in_time_zone` instead of `zone`.
+
+# bad
+Time.now
+Time.parse('2015-03-02 19:05:37')
+
+# good
 Time.zone.now
 Time.zone.parse('2015-03-02 19:05:37')
 
-# no offense only if style is 'flexible'
+# good
 Time.current
 DateTime.strptime(str, "%Y-%m-%d %H:%M %Z").in_time_zone
 Time.at(timestamp).in_time_zone


### PR DESCRIPTION
Follow up of https://github.com/bbatsov/rubocop/pull/4880#issuecomment-338499947.

This is only document change.

This commit adds an example of `EnforcedStyle` to `Rails/TimeZone`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
