### PR TITLE
Better EmptyBracket offense ranges for `SpaceInsideReferenceBrackets`

### DIFF
--- a/lib/rubocop/cop/mixin/surrounding_space.rb
+++ b/lib/rubocop/cop/mixin/surrounding_space.rb
@@ -4,6 +4,8 @@ module RuboCop
   module Cop
     # Common functionality for checking and correcting surrounding whitespace.
     module SurroundingSpace
+      include RangeHelp
+
       NO_SPACE_COMMAND = 'Do not use'.freeze
       SPACE_COMMAND = 'Use'.freeze
 
@@ -99,15 +101,17 @@ module RuboCop
       end
 
       def empty_offenses(node, left, right, message)
+        range = range_between(left.begin_pos, right.end_pos)
         if offending_empty_space?(empty_config, left, right)
-          empty_offense(node, message, 'Use one')
+          empty_offense(node, range, message, 'Use one')
         end
         return unless offending_empty_no_space?(empty_config, left, right)
-        empty_offense(node, message, 'Do not use')
+        empty_offense(node, range, message, 'Do not use')
       end
 
-      def empty_offense(node, message, command)
-        add_offense(node, message: format(message, command: command))
+      def empty_offense(node, range, message, command)
+        add_offense(node, location: range,
+                          message: format(message, command: command))
       end
 
       def empty_brackets?(left_bracket_token, right_bracket_token)

--- a/spec/rubocop/cop/layout/space_inside_reference_brackets_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_reference_brackets_spec.rb
@@ -12,15 +12,15 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideReferenceBrackets, :config do
 
     it 'registers an offense for empty brackets with one space inside' do
       expect_offense(<<-RUBY.strip_indent)
-        a[ ]
-        ^^^^ Do not use space inside empty reference brackets.
+        foo[ ]
+           ^^^ Do not use space inside empty reference brackets.
       RUBY
     end
 
     it 'registers an offense for empty brackets with lots of space inside' do
       expect_offense(<<-RUBY.strip_indent)
         a[     ]
-        ^^^^^^^^ Do not use space inside empty reference brackets.
+         ^^^^^^^ Do not use space inside empty reference brackets.
       RUBY
     end
 
@@ -49,15 +49,15 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideReferenceBrackets, :config do
 
     it 'registers offense for empty brackets with no space inside' do
       expect_offense(<<-RUBY.strip_indent)
-        a[]
-        ^^^ Use one space inside empty reference brackets.
+        foo[]
+           ^^ Use one space inside empty reference brackets.
       RUBY
     end
 
     it 'registers offense for empty brackets with more than one space inside' do
       expect_offense(<<-RUBY.strip_indent)
         a[      ]
-        ^^^^^^^^^ Use one space inside empty reference brackets.
+         ^^^^^^^^ Use one space inside empty reference brackets.
       RUBY
     end
 


### PR DESCRIPTION
Since the `EnforcedStyleForEmptyBrackets` addition to `SpaceInsideReferenceBrackets` is not yet released, this change doesn't warrant a CHANGELOG entry.  Apologies for missing this in the last PR.

### Before

```
variable[ ]
^^^^^^^^^^^ Do not use space inside empty reference brackets.
```

### After

```
variable[ ]
        ^^^ Do not use space inside empty reference brackets.
```

-----------------

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Adjusted tests.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/

  