### PR TITLE
[Fix #5383] Fix locally defined `blank?` & `present?` false positives in `Rails/Presence`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * [#5350](https://github.com/bbatsov/rubocop/issues/5350): Fix `Metric/LineLength` false offenses for URLs in double quotes. ([@garettarrowood][])
 * [#5333](https://github.com/bbatsov/rubocop/issues/5333): Fix `Layout/EmptyLinesAroundArguments` false positives for inline access modifiers. ([@garettarrowood][])
 * [#5339](https://github.com/bbatsov/rubocop/issues/5339): Fix `Layout/EmptyLinesAroundArguments` false positives for multiline heredoc arguments. ([@garettarrowood][])
+* [#5383](https://github.com/bbatsov/rubocop/issues/5383): Fix `Rails/Presence` false detection of receiver for locally defined `blank?` & `present?` methods. ([@garettarrowood][])
 * [#5314](https://github.com/bbatsov/rubocop/issues/5314): Fix false positives for `Lint/NestedPercentLiteral` when percent characters are nested. ([@asherkach][])
 
 ### Changes

--- a/lib/rubocop/cop/rails/presence.rb
+++ b/lib/rubocop/cop/rails/presence.rb
@@ -72,13 +72,13 @@ module RuboCop
 
         def on_if(node)
           redundant_receiver_and_other(node) do |receiver, other|
-            unless ignore_other_node?(other)
+            unless ignore_other_node?(other) || receiver.nil?
               add_offense(node, message: message(node, receiver, other))
             end
           end
 
           redundant_negative_receiver_and_other(node) do |receiver, other|
-            unless ignore_other_node?(other)
+            unless ignore_other_node?(other) || receiver.nil?
               add_offense(node, message: message(node, receiver, other))
             end
           end

--- a/spec/rubocop/cop/rails/presence_spec.rb
+++ b/spec/rubocop/cop/rails/presence_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe RuboCop::Cop::Rails::Presence do
 
   it_behaves_like :offense, 'a if a.present?', 'a.presence', 1, 1
   it_behaves_like :offense, 'a unless a.blank?', 'a.presence', 1, 1
-  it_behaves_like :offense, <<-RUBY.strip_indent.chomp, <<-FIXED.strip_indent.chomp, 1, 7 ## rubocop:disable Metrics/LineLength
+  it_behaves_like :offense, <<-RUBY.strip_indent.chomp, <<-FIXED.strip_indent.chomp, 1, 7 # rubocop:disable Metrics/LineLength
     if [1, 2, 3].map { |num| num + 1 }
                 .map { |num| num + 2 }
                 .present?
@@ -71,15 +71,27 @@ RSpec.describe RuboCop::Cop::Rails::Presence do
     RUBY
   end
 
-  it 'does not register an offense when the expression does not return the receiver of `#present?`' do # rubocop:disable Metrics/LineLength
+  it 'does not register an offense when the expression does not ' \
+     'return the receiver of `#present?`' do
     expect_no_offenses(<<-RUBY.strip_indent)
       a.present? ? b : nil
     RUBY
+
+    expect_no_offenses(<<-RUBY.strip_indent)
+      puts foo if present?
+      puts foo if !present?
+    RUBY
   end
 
-  it 'does not register an offense when the expression does not return the receiver of `#blank?`' do # rubocop:disable Metrics/LineLength
+  it 'does not register an offense when the expression does not ' \
+     'return the receiver of `#blank?`' do
     expect_no_offenses(<<-RUBY.strip_indent)
       a.blank? ? nil : b
+    RUBY
+
+    expect_no_offenses(<<-RUBY.strip_indent)
+      puts foo if blank?
+      puts foo if !blank?
     RUBY
   end
 
@@ -102,7 +114,8 @@ RSpec.describe RuboCop::Cop::Rails::Presence do
     RUBY
   end
 
-  it 'does not register an offense when the else block has multiple statements' do # rubocop:disable Metrics/LineLength
+  it 'does not register an offense when the else block has multiple ' \
+     'statements' do
     expect_no_offenses(<<-RUBY.strip_indent)
       if a.present?
         a


### PR DESCRIPTION
I was able to reproduce the issue from #5383 for locally defined `blank?` and `!present?` (but not `!blank?` & `present?`) with these tests. Guaranteeing there is a receiver solved the bug.

This also resolves a couple `LineLength` offenses in the spec file.

-----------------

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
