### PR TITLE
Always exit 2 when specified configuration file does not exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 * [#5365](https://github.com/bbatsov/rubocop/pull/5365): Add `*.gemfile` to Bundler cop target. ([@sue445][])
 * [#4477](https://github.com/bbatsov/rubocop/issues/4477): Warn when user configuration overrides other user configuration. ([@jonas054][])
 * [#5240](https://github.com/bbatsov/rubocop/pull/5240): Make `Style/StringHashKeys` to accepts environment variables. ([@pocke][])
+* [#5395](https://github.com/bbatsov/rubocop/pull/5395): Always exit 2 when specified configuration file does not exist. ([@pocke][])
 
 ## 0.52.1 (2017-12-27)
 

--- a/lib/rubocop/cli.rb
+++ b/lib/rubocop/cli.rb
@@ -10,6 +10,9 @@ module RuboCop
     SKIPPED_PHASE_1 = 'Phase 1 of 2: run Metrics/LineLength cop (skipped ' \
                       'because the default Metrics/LineLength:Max is ' \
                       'overridden)'.freeze
+    STATUS_SUCCESS  = 0
+    STATUS_OFFENSES = 1
+    STATUS_ERROR    = 2
 
     class Finished < RuntimeError; end
 
@@ -41,16 +44,16 @@ module RuboCop
       return e.status
     rescue RuboCop::Error => e
       warn Rainbow("Error: #{e.message}").red
-      return 2
+      return STATUS_ERROR
     rescue Finished
-      return 0
+      return STATUS_SUCCESS
     rescue IncorrectCopNameError => e
       warn e.message
-      return 2
+      return STATUS_ERROR
     rescue StandardError, SyntaxError, LoadError => e
       warn e.message
       warn e.backtrace
-      return 2
+      return STATUS_ERROR
     end
     # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
 
@@ -155,7 +158,11 @@ module RuboCop
       display_error_summary(runner.errors)
       maybe_print_corrected_source
 
-      all_passed && !runner.aborting? && runner.errors.empty? ? 0 : 1
+      if all_passed && !runner.aborting? && runner.errors.empty?
+        STATUS_SUCCESS
+      else
+        STATUS_OFFENSES
+      end
     end
 
     def handle_exiting_options

--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -6,12 +6,6 @@ require 'pathname'
 module RuboCop
   # Raised when a RuboCop configuration file is not found.
   class ConfigNotFoundError < Error
-    attr_reader :status
-
-    def initialize(path, status)
-      super("Configuration file not found: #{path}")
-      @status = status
-    end
   end
 
   # This class represents the configuration of the RuboCop application
@@ -179,8 +173,9 @@ module RuboCop
       # found" error.
       def read_file(absolute_path)
         IO.read(absolute_path, encoding: Encoding::UTF_8)
-      rescue Errno::ENOENT => e
-        raise ConfigNotFoundError.new(absolute_path, e.errno)
+      rescue Errno::ENOENT
+        raise ConfigNotFoundError,
+              "Configuration file not found: #{absolute_path}"
       end
 
       def yaml_safe_load(yaml_code, filename)

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -828,7 +828,6 @@ RSpec.describe RuboCop::ConfigLoader do
       it 'prints a friendly (concise) message to stderr and exits' do
         expect { load_file }.to(
           raise_error(RuboCop::ConfigNotFoundError) do |e|
-            expect(e.status).to(eq(Errno::ENOENT::Errno))
             expect(e.message).to(match(/\AConfiguration file not found: .+\z/))
           end
         )


### PR DESCRIPTION
RuboCop exits with 2 status code on an error.

> - 2 if RuboCop terminates abnormally due to invalid configuration, invalid CLI
>   options, or an internal error.
> https://github.com/bbatsov/rubocop/blob/e7cb0e84ee55dcc475001f90b4cfe5aedc2a53f9/manual/basic_usage.md#exit-codes

However when a specified configuration file does not exist, RuboCop exit with a status code that depends on environments. Because `errno` depends on the environment in which Ruby runs.
https://ruby-doc.org/core-2.5.0/Errno.html

https://github.com/bbatsov/rubocop/blob/e7cb0e84ee55dcc475001f90b4cfe5aedc2a53f9/lib/rubocop/config_loader.rb#L183
https://github.com/bbatsov/rubocop/blob/e7cb0e84ee55dcc475001f90b4cfe5aedc2a53f9/lib/rubocop/cli.rb#L39-L41

I think it exits with 2 also in the case. This pull-request replace the `errno` with `STATUS_ERROR`.

---

And this pull-request replace magic numbers with constants.

---

Note: In my environment (Linux), `Errno::ENOENT::Errno` is `2`. So this pull-request has nothing changes in my environment (and maybe in Linux).



-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
