### PR TITLE
[Fix #5357] Fix `Lint/InterpolationCheck` false positives on escaped interpolations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * [#5339](https://github.com/bbatsov/rubocop/issues/5339): Fix `Layout/EmptyLinesAroundArguments` false positives for multiline heredoc arguments. ([@garettarrowood][])
 * [#5383](https://github.com/bbatsov/rubocop/issues/5383): Fix `Rails/Presence` false detection of receiver for locally defined `blank?` & `present?` methods. ([@garettarrowood][])
 * [#5314](https://github.com/bbatsov/rubocop/issues/5314): Fix false positives for `Lint/NestedPercentLiteral` when percent characters are nested. ([@asherkach][])
+* [#5357](https://github.com/bbatsov/rubocop/issues/5357): Fix `Lint/InterpolationCheck` false positives on escaped interpolations. ([@pocke][])
 
 ### Changes
 

--- a/lib/rubocop/cop/lint/interpolation_check.rb
+++ b/lib/rubocop/cop/lint/interpolation_check.rb
@@ -18,12 +18,13 @@ module RuboCop
       #   foo = "something with #{interpolation} inside"
       class InterpolationCheck < Cop
         MSG = 'Interpolation in single quoted string detected. '\
-	      'Use double quoted strings if you need interpolation.'.freeze
+              'Use double quoted strings if you need interpolation.'.freeze
 
         def on_str(node)
           return if heredoc?(node)
-          return if node.parent && node.parent.dstr_type?
-          return unless node.str_content.scrub =~ /#\{.*\}/
+          parent = node.parent
+          return if parent && (parent.dstr_type? || parent.regexp_type?)
+          return unless node.source.scrub =~ /(?<!\\)#\{.*\}/
           add_offense(node)
         end
 

--- a/spec/rubocop/cop/lint/interpolation_check_spec.rb
+++ b/spec/rubocop/cop/lint/interpolation_check_spec.rb
@@ -22,6 +22,18 @@ RSpec.describe RuboCop::Cop::Lint::InterpolationCheck do
     RUBY
   end
 
+  it 'does not register an offense for interpolation in a regexp' do
+    expect_no_offenses(<<-'RUBY'.strip_indent)
+      /\#{20}/
+    RUBY
+  end
+
+  it 'does not register an offense for an escaped interpolation' do
+    expect_no_offenses(<<-'RUBY'.strip_indent)
+      "\#{msg}"
+    RUBY
+  end
+
   it 'does not crash for \xff' do
     expect_no_offenses(<<-'RUBY'.strip_indent)
       foo = "\xff"


### PR DESCRIPTION


 See https://github.com/bbatsov/rubocop/issues/5357    

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
