### PR TITLE
Remove the undefined `TimeZone#strftime` from `Rails/TimeZone`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 * [#4477](https://github.com/bbatsov/rubocop/issues/4477): Warn when user configuration overrides other user configuration. ([@jonas054][])
 * [#5240](https://github.com/bbatsov/rubocop/pull/5240): Make `Style/StringHashKeys` to accepts environment variables. ([@pocke][])
 * [#5395](https://github.com/bbatsov/rubocop/pull/5395): Always exit 2 when specified configuration file does not exist. ([@pocke][])
+* [#5402](https://github.com/bbatsov/rubocop/pull/5402): Remove undefined `ActiveSupport::TimeZone#strftime` method from defined dangerous methods of `Rails/TimeZone` cop. ([@koic][])
 
 ## 0.52.1 (2017-12-27)
 

--- a/lib/rubocop/cop/rails/time_zone.rb
+++ b/lib/rubocop/cop/rails/time_zone.rb
@@ -23,7 +23,6 @@ module RuboCop
       #
       #   # bad
       #   Time.current
-      #   DateTime.strptime(str, "%Y-%m-%d %H:%M %Z").in_time_zone
       #   Time.at(timestamp).in_time_zone
       #
       #   # good
@@ -43,7 +42,6 @@ module RuboCop
       #
       #   # good
       #   Time.current
-      #   DateTime.strptime(str, "%Y-%m-%d %H:%M %Z").in_time_zone
       #   Time.at(timestamp).in_time_zone
       class TimeZone < Cop
         include ConfigurableEnforcedStyle
@@ -64,7 +62,7 @@ module RuboCop
 
         GOOD_METHODS = %i[zone zone_default find_zone find_zone!].freeze
 
-        DANGEROUS_METHODS = %i[now local new strftime
+        DANGEROUS_METHODS = %i[now local new
                                parse at current].freeze
 
         ACCEPTED_METHODS = %i[in_time_zone utc getlocal

--- a/manual/cops_rails.md
+++ b/manual/cops_rails.md
@@ -1572,7 +1572,6 @@ Time.parse('2015-03-02 19:05:37')
 
 # bad
 Time.current
-DateTime.strptime(str, "%Y-%m-%d %H:%M %Z").in_time_zone
 Time.at(timestamp).in_time_zone
 
 # good
@@ -1594,7 +1593,6 @@ Time.zone.parse('2015-03-02 19:05:37')
 
 # good
 Time.current
-DateTime.strptime(str, "%Y-%m-%d %H:%M %Z").in_time_zone
 Time.at(timestamp).in_time_zone
 ```
 

--- a/spec/rubocop/cop/rails/time_zone_spec.rb
+++ b/spec/rubocop/cop/rails/time_zone_spec.rb
@@ -68,34 +68,6 @@ RSpec.describe RuboCop::Cop::Rails::TimeZone, :config do
       RUBY
     end
 
-    it 'registers an offense for Time.strftime' do
-      expect_offense(<<-RUBY.strip_indent)
-        Time.strftime(time_string, "%Y-%m-%dT%H:%M:%S%z")
-             ^^^^^^^^ Do not use `Time.strftime` without zone. Use `Time.zone.strftime` instead.
-      RUBY
-    end
-
-    it 'registers an offense for Time.strftime.in_time_zone' do
-      expect_offense(<<-RUBY.strip_indent)
-        Time.strftime(time_string, "%Y-%m-%dT%H:%M:%S%z").in_time_zone
-             ^^^^^^^^ Do not use `Time.strftime` without zone. Use `Time.zone.strftime` instead.
-      RUBY
-    end
-
-    it 'registers an offense for Time.strftime with nested Time.zone' do
-      expect_offense(<<-RUBY.strip_indent)
-        Time.strftime(Time.zone.now.to_s, "%Y-%m-%dT%H:%M:%S%z")
-             ^^^^^^^^ Do not use `Time.strftime` without zone. Use `Time.zone.strftime` instead.
-      RUBY
-    end
-
-    it 'registers an offense for Time.zone.strftime with nested Time.now' do
-      expect_offense(<<-RUBY.strip_indent)
-        Time.zone.strftime(Time.now.to_s, "%Y-%m-%dT%H:%M:%S%z")
-                                ^^^ Do not use `Time.now.strftime` without zone. Use `Time.zone.now.strftime` instead.
-      RUBY
-    end
-
     it 'registers an offense for Time.at' do
       expect_offense(<<-RUBY.strip_indent)
         Time.at(ts)
@@ -149,16 +121,6 @@ RSpec.describe RuboCop::Cop::Rails::TimeZone, :config do
 
     it 'accepts Time.zone.at' do
       expect_no_offenses('Time.zone.at(ts)')
-    end
-
-    it 'accepts Time.strptime' do
-      expect_no_offenses('Time.strptime(datetime, format).in_time_zone')
-    end
-
-    it 'accepts Time.zone.strftime' do
-      expect_no_offenses(
-        'Time.zone.strftime(time_string, "%Y-%m-%dT%H:%M:%S%z")'
-      )
     end
 
     it 'accepts Time.zone.parse.localtime' do
@@ -269,12 +231,6 @@ RSpec.describe RuboCop::Cop::Rails::TimeZone, :config do
           expect(cop.offenses.empty?).to be(true)
         end
       end
-    end
-
-    it 'accepts Time.strftime.in_time_zone' do
-      expect_no_offenses(
-        'Time.strftime(time_string, "%Y-%m-%dT%H:%M:%S%z").in_time_zone'
-      )
     end
 
     it 'accepts Time.parse.localtime(offset)' do


### PR DESCRIPTION
Follow up of https://github.com/bbatsov/rubocop/pull/5381#discussion_r159365679.

It seems that there is a mistake in solving the Issue below.
https://github.com/bbatsov/rubocop/issues/1773

From Rails 4.2 to Rails 5.2 (beta), The following code will result in an error.

```console
> str = '2015-03-02 19:05:37'
> Time.zone.strftime(str, "%Y-%m-%d %H:%M%Z")
NoMethodError: undefined method `strftime' for #<ActiveSupport::TimeZone:0x00007fdaed438c88>
```

AFIAK, `ActiveSupport::TimeZone#strftime` does not exist in Rails 4.2 at least.

Previously, #1773 was thought to mistype `Time.zone.strftime` to `Time.zone.strptime`. However, I think that it was false positives because `ActiveSupport::TimeZone#strptime` introduced in Rails 5.0 does not exist in Rails 4.2.
https://github.com/rails/rails/commit/a5e507fa0b8180c3d97458a9b86c195e9857d8f6

In this PR, `ActiveSupport::TimeZone#strftime` which does not exist is removed from detection targets.

I'm judging that this change has no effect on codes that works as expected.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/

  