### PR TITLE
[Fix #5404] Add error for deprecated Style/TrailingCommaInLiteral cop

### DIFF
--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -25,8 +25,13 @@ module RuboCop
     OBSOLETE_COPS = {
       'Style/TrailingComma' =>
         'The `Style/TrailingComma` cop no longer exists. Please use ' \
-        '`Style/TrailingCommaInLiteral` and/or ' \
-        '`Style/TrailingCommaInArguments` instead.',
+        '`Style/TrailingCommaInArguments`, ' \
+        '`Style/TrailingCommaInArrayLiteral`, and/or ' \
+        '`Style/TrailingCommaInHashLiteral` instead.',
+      'Style/TrailingCommaInLiteral' =>
+        'The `Style/TrailingCommaInLiteral` cop no longer exists. Please use ' \
+        '`Style/TrailingCommaInArrayLiteral` and/or ' \
+        '`Style/TrailingCommaInHashLiteral` instead.',
       'Rails/DefaultScope' =>
         'The `Rails/DefaultScope` cop no longer exists.',
       'Lint/InvalidCharacterLiteral' =>


### PR DESCRIPTION
This pull request adds an informative error in the case that a configuration file makes mention of the `Style/TrailingCommaInLiteral` cop, which has been split into `TrailingCommaInArrayLiteral` and `TrailingCommaInHashLiteral`. There are no specs that test for specific errors, so I did not create one for this change.
