### PR TITLE
[Fix #4910] Add examples for `Style/For` cop

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -954,8 +954,8 @@ Style/EmptyMethod:
 Style/For:
   EnforcedStyle: each
   SupportedStyles:
-    - for
     - each
+    - for
 
 # Enforce the method used for string formatting.
 Style/FormatString:

--- a/lib/rubocop/cop/style/for.rb
+++ b/lib/rubocop/cop/style/for.rb
@@ -7,6 +7,37 @@ module RuboCop
       # preferred alternative is set in the EnforcedStyle configuration
       # parameter. An *each* call with a block on a single line is always
       # allowed, however.
+      #
+      # @example EnforcedStyle: each (default)
+      #   # bad
+      #   def foo
+      #     for n in [1, 2, 3] do
+      #       puts n
+      #     end
+      #   end
+      #
+      #   # good
+      #   def foo
+      #     [1, 2, 3].each do |n|
+      #       puts n
+      #     end
+      #   end
+      #
+      # @example EnforcedStyle: for
+      #   # bad
+      #   def foo
+      #     [1, 2, 3].each do |n|
+      #       puts n
+      #     end
+      #   end
+      #
+      #   # good
+      #   def foo
+      #     for n in [1, 2, 3] do
+      #       puts n
+      #     end
+      #   end
+      #
       class For < Cop
         include ConfigurableEnforcedStyle
         include RangeHelp

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -1709,11 +1709,48 @@ preferred alternative is set in the EnforcedStyle configuration
 parameter. An *each* call with a block on a single line is always
 allowed, however.
 
+### Examples
+
+#### EnforcedStyle: each (default)
+
+```ruby
+# bad
+def foo
+  for n in [1, 2, 3] do
+    puts n
+  end
+end
+
+# good
+def foo
+  [1, 2, 3].each do |n|
+    puts n
+  end
+end
+```
+#### EnforcedStyle: for
+
+```ruby
+# bad
+def foo
+  [1, 2, 3].each do |n|
+    puts n
+  end
+end
+
+# good
+def foo
+  for n in [1, 2, 3] do
+    puts n
+  end
+end
+```
+
 ### Configurable attributes
 
 Name | Default value | Configurable values
 --- | --- | ---
-EnforcedStyle | `each` | `for`, `each`
+EnforcedStyle | `each` | `each`, `for`
 
 ### References
 


### PR DESCRIPTION
Related to issue #4910.
This commit adds an examples to `Style/For` cop.

About changing the config/default.yml. It is early in alphabetical order, and the default supported style `each` is set to the head position.
Refer: https://github.com/bbatsov/rubocop/pull/5375#issuecomment-355285270

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
