### PR TITLE
Fix build error in cli_spec.rb

### DIFF
--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -1673,8 +1673,9 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
         expect(cli.run(['example1.rb'])).to eq(2)
         expect($stderr.string.strip).to eq(
           ['Error: The `Style/TrailingComma` cop no longer exists. Please ' \
-           'use `Style/TrailingCommaInLiteral` and/or ' \
-           '`Style/TrailingCommaInArguments` instead.',
+           'use `Style/TrailingCommaInArguments`, ' \
+           '`Style/TrailingCommaInArrayLiteral`, and/or ' \
+           '`Style/TrailingCommaInHashLiteral` instead.',
            '(obsolete configuration found in .rubocop.yml, ' \
            'please update it)'].join("\n")
         )


### PR DESCRIPTION
Follow up of #5405.

This PR fixes the following error on Travis CI.

```console
% bundle exec rake spec

(snip)

Failures:
  1) RuboCop::CLI obsolete cops when configuration for TrailingComma is
  given fails with an error message
     Failure/Error:
       expect($stderr.string.strip).to eq(
         ['Error: The `Style/TrailingComma` cop no longer exists. Please ' \
          'use `Style/TrailingCommaInLiteral` and/or ' \
          '`Style/TrailingCommaInArguments` instead.',
          '(obsolete configuration found in .rubocop.yml, ' \
          'please update it)'].join("\n")
       )

       expected: "Error: The `Style/TrailingComma` cop no longer
       exists. Please use `Style/TrailingCommaInLiteral`
       and...railingCommaInArguments` instead.\n(obsolete configuration
       found in .rubocop.yml, please update it)"
            got: "Error: The `Style/TrailingComma` cop no longer
            exists. Please use `Style/TrailingCommaInArguments`,
            ...ilingCommaInHashLiteral` instead.\n(obsolete
            configuration found in .rubocop.yml, please update it)"

       (compared using ==)

       Diff:
       @@ -1,3 +1,3 @@

       -Error: The `Style/TrailingComma` cop no longer exists. Please
       use `Style/TrailingCommaInLiteral` and/or
       `Style/TrailingCommaInArguments` instead.
       +Error: The `Style/TrailingComma` cop no longer
       exists. Please use `Style/TrailingCommaInArguments`,
       `Style/TrailingCommaInArrayLiteral`, and/or
       `Style/TrailingCommaInHashLiteral` instead.
       (obsolete configuration found in .rubocop.yml, please update it)

(snip)

Finished in 1 minute 13.03 seconds (files took 4.66 seconds to load)
18230 examples, 1 failure, 6 pending
Failed examples:
rspec ./spec/rubocop/cli_spec.rb:1667 # RuboCop::CLI obsolete cops when
configuration for TrailingComma is given fails with an error message
```

https://travis-ci.org/bbatsov/rubocop/builds/325544492

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/

  