### PR TITLE
Restyle examples formatting for `Layout/AlignHash` cop

### DIFF
--- a/lib/rubocop/cop/layout/align_hash.rb
+++ b/lib/rubocop/cop/layout/align_hash.rb
@@ -19,84 +19,88 @@ module RuboCop
       #   - ignore_implicit (without curly braces)
       #   - ignore_explicit (with curly braces)
       #
-      # @example
+      # @example EnforcedHashRocketStyle: key (default)
+      #   # bad
+      #   {
+      #     :foo => bar,
+      #      :ba => baz
+      #   }
       #
-      #   # EnforcedHashRocketStyle: key (default)
-      #   # EnforcedColonStyle: key (default)
+      #   # good
+      #   {
+      #     :foo => bar,
+      #     :ba => baz
+      #   }
+      #
+      # @example EnforcedHashRocketStyle: separator
+      #   # bad
+      #   {
+      #     :foo => bar,
+      #     :ba => baz
+      #   }
+      #   {
+      #     :foo => bar,
+      #     :ba  => baz
+      #   }
+      #
+      #   # good
+      #   {
+      #     :foo => bar,
+      #      :ba => baz
+      #   }
+      #
+      # @example EnforcedHashRocketStyle: table
+      #   # bad
+      #   {
+      #     :foo => bar,
+      #      :ba => baz
+      #   }
+      #
+      #   # good
+      #   {
+      #     :foo => bar,
+      #     :ba  => baz
+      #   }
+      #
+      # @example EnforcedColonStyle: key (default)
+      #   # bad
+      #   {
+      #     foo: bar,
+      #      ba: baz
+      #   }
       #
       #   # good
       #   {
       #     foo: bar,
       #     ba: baz
       #   }
-      #   {
-      #     :foo => bar,
-      #     :ba => baz
-      #   }
       #
+      # @example EnforcedColonStyle: separator
       #   # bad
-      #   {
-      #     foo: bar,
-      #      ba: baz
-      #   }
-      #   {
-      #     :foo => bar,
-      #      :ba => baz
-      #   }
-      #
-      # @example
-      #
-      #   # EnforcedHashRocketStyle: separator
-      #   # EnforcedColonStyle: separator
-      #
-      #   #good
-      #   {
-      #     foo: bar,
-      #      ba: baz
-      #   }
-      #   {
-      #     :foo => bar,
-      #      :ba => baz
-      #   }
-      #
-      #   #bad
       #   {
       #     foo: bar,
       #     ba: baz
       #   }
+      #
+      #   # good
       #   {
-      #     :foo => bar,
-      #     :ba => baz
-      #   }
-      #   {
-      #     :foo => bar,
-      #     :ba  => baz
+      #     foo: bar,
+      #      ba: baz
       #   }
       #
-      # @example
+      # @example EnforcedColonStyle: table
+      #   # bad
+      #   {
+      #     foo: bar,
+      #     ba: baz
+      #   }
       #
-      #   # EnforcedHashRocketStyle: table
-      #   # EnforcedColonStyle: table
-      #
-      #   #good
+      #   # good
       #   {
       #     foo: bar,
       #     ba:  baz
       #   }
-      #   {
-      #     :foo => bar,
-      #     :ba  => baz
-      #   }
       #
-      #   #bad
-      #   {
-      #     foo: bar,
-      #     ba: baz
-      #   }
-      #   {
-      #     :foo => bar,
-      #      :ba => baz
-      #   }
       class AlignHash < Cop
         include HashAlignment
         include RangeHelp

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -108,80 +108,98 @@ can also be configured. The options are:
 
 ### Examples
 
+#### EnforcedHashRocketStyle: key (default)
+
 ```ruby
-# EnforcedHashRocketStyle: key (default)
-# EnforcedColonStyle: key (default)
+# bad
+{
+  :foo => bar,
+   :ba => baz
+}
+
+# good
+{
+  :foo => bar,
+  :ba => baz
+}
+```
+#### EnforcedHashRocketStyle: separator
+
+```ruby
+# bad
+{
+  :foo => bar,
+  :ba => baz
+}
+{
+  :foo => bar,
+  :ba  => baz
+}
+
+# good
+{
+  :foo => bar,
+   :ba => baz
+}
+```
+#### EnforcedHashRocketStyle: table
+
+```ruby
+# bad
+{
+  :foo => bar,
+   :ba => baz
+}
+
+# good
+{
+  :foo => bar,
+  :ba  => baz
+}
+```
+#### EnforcedColonStyle: key (default)
+
+```ruby
+# bad
+{
+  foo: bar,
+   ba: baz
+}
 
 # good
 {
   foo: bar,
   ba: baz
 }
-{
-  :foo => bar,
-  :ba => baz
-}
+```
+#### EnforcedColonStyle: separator
 
+```ruby
 # bad
 {
   foo: bar,
-   ba: baz
+  ba: baz
 }
-{
-  :foo => bar,
-   :ba => baz
-}
-```
-```ruby
-# EnforcedHashRocketStyle: separator
-# EnforcedColonStyle: separator
 
-#good
+# good
 {
   foo: bar,
    ba: baz
 }
-{
-  :foo => bar,
-   :ba => baz
-}
+```
+#### EnforcedColonStyle: table
 
-#bad
+```ruby
+# bad
 {
   foo: bar,
   ba: baz
 }
-{
-  :foo => bar,
-  :ba => baz
-}
-{
-  :foo => bar,
-  :ba  => baz
-}
-```
-```ruby
-# EnforcedHashRocketStyle: table
-# EnforcedColonStyle: table
 
-#good
+# good
 {
   foo: bar,
   ba:  baz
-}
-{
-  :foo => bar,
-  :ba  => baz
-}
-
-#bad
-{
-  foo: bar,
-  ba: baz
-}
-{
-  :foo => bar,
-   :ba => baz
 }
 ```
 


### PR DESCRIPTION
Follow up of https://github.com/bbatsov/rubocop/pull/4880#issuecomment-338499947.

This commit is a change of document format for `Layout/AlignHash` cop.

And this commit applies only the already documented `EnforcedHashRocketStyle` and `EnforcedColonStyle` reformatting.

Additional descriptions about `EnforcedLastArgumentHashStyle` will be applied in another PR.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
