### PR TITLE
[#4910] Add examples to Tab, TrailingBlankLines & TrailingWhitespace

### DIFF
--- a/lib/rubocop/cop/layout/tab.rb
+++ b/lib/rubocop/cop/layout/tab.rb
@@ -6,6 +6,16 @@ module RuboCop
   module Cop
     module Layout
       # This cop checks for tabs inside the source code.
+      #
+      # @example
+      #   # This example uses a tab for indentation.
+      #   # bad
+      #     x = 0
+      #
+      #   # This example uses spaces for indentation.
+      #   # good
+      #     x = 0
+      #
       class Tab < Cop
         include Alignment
         include RangeHelp

--- a/lib/rubocop/cop/layout/tab.rb
+++ b/lib/rubocop/cop/layout/tab.rb
@@ -8,13 +8,17 @@ module RuboCop
       # This cop checks for tabs inside the source code.
       #
       # @example
-      #   # This example uses a tab for indentation.
       #   # bad
-      #     x = 0
+      #   # This example uses a tab to indent bar.
+      #   def foo
+      #     bar
+      #   end
       #
-      #   # This example uses spaces for indentation.
       #   # good
-      #     x = 0
+      #   # This example uses spaces to indent bar.
+      #   def foo
+      #     bar
+      #   end
       #
       class Tab < Cop
         include Alignment

--- a/lib/rubocop/cop/layout/trailing_blank_lines.rb
+++ b/lib/rubocop/cop/layout/trailing_blank_lines.rb
@@ -13,17 +13,17 @@ module RuboCop
       #   # bad
       #   class Foo; end
       #
-      #   __END__
+      #   # EOF
       #
       #   # bad
       #   class Foo; end
-      #   __END__
+      #   # EOF
       #
       #   # good
       #   class Foo; end
       #   # a blank line
       #
-      #   __END__
+      #   # EOF
       #
       # @example EnforcedStyle: final_newline (default)
       #   # `final_newline` looks for one newline at the end of files.
@@ -32,16 +32,16 @@ module RuboCop
       #   class Foo; end
       #   # a blank line
       #
-      #   __END__
+      #   # EOF
       #
       #   # bad
       #   class Foo; end
-      #   __END__
+      #   # EOF
       #
       #   # good
       #   class Foo; end
       #
-      #   __END__
+      #   # EOF
       #
       class TrailingBlankLines < Cop
         include ConfigurableEnforcedStyle

--- a/lib/rubocop/cop/layout/trailing_blank_lines.rb
+++ b/lib/rubocop/cop/layout/trailing_blank_lines.rb
@@ -5,6 +5,44 @@ module RuboCop
     module Layout
       # This cop looks for trailing blank lines and a final newline in the
       # source code.
+      #
+      # @example EnforcedStyle: final_blank_line
+      #   # `final_blank_line` looks for one blank line followed by a new line
+      #   # at the end of files.
+      #
+      #   # bad
+      #   class Foo; end
+      #
+      #   __END__
+      #
+      #   # bad
+      #   class Foo; end
+      #   __END__
+      #
+      #   # good
+      #   class Foo; end
+      #   # a blank line
+      #
+      #   __END__
+      #
+      # @example EnforcedStyle: final_newline (default)
+      #   # `final_newline` looks for one newline at the end of files.
+      #
+      #   # bad
+      #   class Foo; end
+      #   # a blank line
+      #
+      #   __END__
+      #
+      #   # bad
+      #   class Foo; end
+      #   __END__
+      #
+      #   # good
+      #   class Foo; end
+      #
+      #   __END__
+      #
       class TrailingBlankLines < Cop
         include ConfigurableEnforcedStyle
         include RangeHelp

--- a/lib/rubocop/cop/layout/trailing_whitespace.rb
+++ b/lib/rubocop/cop/layout/trailing_whitespace.rb
@@ -4,6 +4,16 @@ module RuboCop
   module Cop
     module Layout
       # This cop looks for trailing whitespace in the source code.
+      #
+      # @example
+      #   # The line in this example contains spaces after the 0.
+      #   # bad
+      #   x = 0
+      #
+      #   # The line in this example ends directly after the 0.
+      #   # good
+      #   x = 0
+      #
       class TrailingWhitespace < Cop
         include RangeHelp
 

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -3542,13 +3542,17 @@ This cop checks for tabs inside the source code.
 ### Examples
 
 ```ruby
-# This example uses a tab for indentation.
 # bad
-  x = 0
+# This example uses a tab to indent bar.
+def foo
+  bar
+end
 
-# This example uses spaces for indentation.
 # good
-  x = 0
+# This example uses spaces to indent bar.
+def foo
+  bar
+end
 ```
 
 ### Configurable attributes
@@ -3581,17 +3585,17 @@ source code.
 # bad
 class Foo; end
 
-__END__
+# EOF
 
 # bad
 class Foo; end
-__END__
+# EOF
 
 # good
 class Foo; end
 # a blank line
 
-__END__
+# EOF
 ```
 #### EnforcedStyle: final_newline (default)
 
@@ -3602,16 +3606,16 @@ __END__
 class Foo; end
 # a blank line
 
-__END__
+# EOF
 
 # bad
 class Foo; end
-__END__
+# EOF
 
 # good
 class Foo; end
 
-__END__
+# EOF
 ```
 
 ### Configurable attributes

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -3539,6 +3539,18 @@ Enabled | Yes
 
 This cop checks for tabs inside the source code.
 
+### Examples
+
+```ruby
+# This example uses a tab for indentation.
+# bad
+  x = 0
+
+# This example uses spaces for indentation.
+# good
+  x = 0
+```
+
 ### Configurable attributes
 
 Name | Default value | Configurable values

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -3632,6 +3632,18 @@ Enabled | Yes
 
 This cop looks for trailing whitespace in the source code.
 
+### Examples
+
+```ruby
+# The line in this example contains spaces after the 0.
+# bad
+x = 0
+
+# The line in this example ends directly after the 0.
+# good
+x = 0
+```
+
 ### References
 
 * [https://github.com/bbatsov/ruby-style-guide#no-trailing-whitespace](https://github.com/bbatsov/ruby-style-guide#no-trailing-whitespace)

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -3570,6 +3570,50 @@ Enabled | Yes
 This cop looks for trailing blank lines and a final newline in the
 source code.
 
+### Examples
+
+#### EnforcedStyle: final_blank_line
+
+```ruby
+# `final_blank_line` looks for one blank line followed by a new line
+# at the end of files.
+
+# bad
+class Foo; end
+
+__END__
+
+# bad
+class Foo; end
+__END__
+
+# good
+class Foo; end
+# a blank line
+
+__END__
+```
+#### EnforcedStyle: final_newline (default)
+
+```ruby
+# `final_newline` looks for one newline at the end of files.
+
+# bad
+class Foo; end
+# a blank line
+
+__END__
+
+# bad
+class Foo; end
+__END__
+
+# good
+class Foo; end
+
+__END__
+```
+
 ### Configurable attributes
 
 Name | Default value | Configurable values


### PR DESCRIPTION
As the title indicates, this PR adds example documentation to `Layout/Tab`, `Layout/TrailingBlankLines` and `Layout/TrailingWhitespace`.  Adding the examples pointed out why we likely skipped them before. None are easy to convey.  

For `Layout/Tab` and `Layout/TrailingWhitespace`, comments are added before the good and bad examples. Otherwise, they would appear identical.  In `Layout/TrailingBlankLines`, our manual generation actually removes the "blank line" from the examples. So instead of a blank line, I've inserted the comment `# a blank line` .  


-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
