### PR TITLE
Update Contributing section of manual

### DIFF
--- a/manual/contributing.md
+++ b/manual/contributing.md
@@ -15,16 +15,13 @@ Patches in any form are always welcome! GitHub pull requests are even better! :-
 Before submitting a patch or a pull request make sure all tests are
 passing and that your patch is in line with the [contribution
 guidelines](https://github.com/bbatsov/rubocop/blob/master/CONTRIBUTING.md).
-
-See also. [development.md](development.md)
+Also see the [Development section](development.md).
 
 ## Documentation
 
-Good documentation is just as important as good code.
-
-Consider improving and extending the
-this manual and the
-[community wiki](https://github.com/bbatsov/rubocop/wiki).
+Good documentation is just as important as good code. Check out the
+[Documentation section](development.md#documentation) of this guide and consider
+adding or improving Cop descriptions.
 
 ### Working on the Manual
 


### PR DESCRIPTION
This PR adds a link to the new `Documentation` section of the `development.md` to the `Documentation` section of the `contributing.md` .  It also removes the link to the wiki.

Should we delete the wiki? Or just have it contain a link to the manual and remove it's other sections?  It appears to be very out of date.

-----------------

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
