### PR TITLE
Fix build error in project_spec.rb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@
 * [#5314](https://github.com/bbatsov/rubocop/issues/5314): Fix false positives for `Lint/NestedPercentLiteral` when percent characters are nested. ([@asherkach][])
 * [#5357](https://github.com/bbatsov/rubocop/issues/5357): Fix `Lint/InterpolationCheck` false positives on escaped interpolations. ([@pocke][])
 * [#5409](https://github.com/bbatsov/rubocop/issues/5409): Fix multiline indent for `Style/SymbolArray` and `Style/WordArray` autocorrect. ([@flyerhzm][])
-* [#5393](https://github.com/bbatsov/rubocop/issues/5393): Fix `Rails/Delegate`'s false positive with a method call with arguments. ([@pocke][]) 
+* [#5393](https://github.com/bbatsov/rubocop/issues/5393): Fix `Rails/Delegate`'s false positive with a method call with arguments. ([@pocke][])
 
 ### Changes
 


### PR DESCRIPTION
Follow up of #5410.

This PR fixes the following error on Travis CI.

```console
% bundle exec rspec ./spec/project_spec.rb
Run options: include {:focus=>true}

All examples were filtered out; ignoring {:focus=>true}

Randomized with seed 45488
..............F.F

Failures:

  1) RuboCop Project changelog entry body ends with a punctuation
     Failure/Error: expect(bodies).to all(match(/[\.\!]$/))

       expected ["Add new `` cop.", "Add new `` cop.", "Add new ``
       cop.", "Add new `` cop.", "Add new `` cop.", "Add ...nclosed in
       braces are not noticed.", "Received malformed format string
       ArgumentError from rubocop."] to all match /[\.\!]$/

          object at index 18 failed to match:
             expected "Fix ``'s false positive with a method
             call with arguments. ([@pocke][]) " to match /[\.\!]$/
     # ./spec/project_spec.rb:174:in `block (5 levels) in <top (required)>'

  2) RuboCop Project changelog entry after version 0.14.0 has a link to
  the contributors at the end
     Failure/Error: expect(entries).to all(match(/\(\[@\S+\]\[\](?:, \[@\S+\]\[\])*\)$/))

       expected ["* [#3666](https://github.com/bbatsov/rubocop/issues/3666): Add new
       `Naming/UncommunicativeBlockPara...552): `RaiseArgs` allows
       exception constructor calls with more than one 1
       argument. ([@bbatsov][])"] to all match /\(\[@\S+\]\[\](?:, \[@\S+\]\[\])*\)$/

          object at index 18 failed to match:
             expected "* [#5393](https://github.com/bbatsov/rubocop/issues/5393):
             Fix `Rails/Delegate`'s false positive with a
             method call with arguments. ([@pocke][]) " to
             match /\(\[@\S+\]\[\](?:, \[@\S+\]\[\])*\)$/
     # ./spec/project_spec.rb:123:in `block (5 levels) in <top (required)>'

Finished in 1.36 seconds (files took 1.07 seconds to load)
17 examples, 2 failures

Failed examples:

rspec ./spec/project_spec.rb:173 # RuboCop Project changelog entry body
ends with a punctuation
rspec ./spec/project_spec.rb:122 # RuboCop Project changelog entry after
version 0.14.0 has a link to the contributors at the end
```

https://travis-ci.org/bbatsov/rubocop/jobs/325980721#L1146-L1162

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
