### PR TITLE
[Fix #4889, #5287, and #5348] - SafeNavigation fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * [#5357](https://github.com/bbatsov/rubocop/issues/5357): Fix `Lint/InterpolationCheck` false positives on escaped interpolations. ([@pocke][])
 * [#5409](https://github.com/bbatsov/rubocop/issues/5409): Fix multiline indent for `Style/SymbolArray` and `Style/WordArray` autocorrect. ([@flyerhzm][])
 * [#5393](https://github.com/bbatsov/rubocop/issues/5393): Fix `Rails/Delegate`'s false positive with a method call with arguments. ([@pocke][])
+* [#5348](https://github.com/bbatsov/rubocop/issues/5348): Fix false positive for `Style/SafeNavigation` when safe guarding more comparison methods. ([@rrosenblum][])
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * [#5393](https://github.com/bbatsov/rubocop/issues/5393): Fix `Rails/Delegate`'s false positive with a method call with arguments. ([@pocke][])
 * [#5348](https://github.com/bbatsov/rubocop/issues/5348): Fix false positive for `Style/SafeNavigation` when safe guarding more comparison methods. ([@rrosenblum][])
 * [#4889](https://github.com/bbatsov/rubocop/issues/4889): Auto-correcting `Style/SafeNavigation` will add safe navigation to all methods in a method chain. ([@rrosenblum][])
+* [#5287](https://github.com/bbatsov/rubocop/issues/5287): Do not register an offense in `Style/SafeNavigation` if there is an unsafe method used in a method chain. ([@rrosenblum][])
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * [#5409](https://github.com/bbatsov/rubocop/issues/5409): Fix multiline indent for `Style/SymbolArray` and `Style/WordArray` autocorrect. ([@flyerhzm][])
 * [#5393](https://github.com/bbatsov/rubocop/issues/5393): Fix `Rails/Delegate`'s false positive with a method call with arguments. ([@pocke][])
 * [#5348](https://github.com/bbatsov/rubocop/issues/5348): Fix false positive for `Style/SafeNavigation` when safe guarding more comparison methods. ([@rrosenblum][])
+* [#4889](https://github.com/bbatsov/rubocop/issues/4889): Auto-correcting `Style/SafeNavigation` will add safe navigation to all methods in a method chain. ([@rrosenblum][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/safe_navigation.rb
+++ b/lib/rubocop/cop/style/safe_navigation.rb
@@ -50,6 +50,7 @@ module RuboCop
         MSG = 'Use safe navigation (`&.`) instead of checking if an object ' \
               'exists before calling the method.'.freeze
         NIL_METHODS = nil.methods.freeze
+        ADDITIONAL_COMPARISON_METHODS = %i[<=> =~ !~].freeze
 
         minimum_target_ruby_version 2.3
 
@@ -167,7 +168,9 @@ module RuboCop
         end
 
         def comparison_node?(parent)
-          parent.send_type? && parent.comparison_method?
+          parent.send_type? &&
+            (parent.comparison_method? ||
+             ADDITIONAL_COMPARISON_METHODS.include?(parent.method_name))
         end
 
         def unsafe_method?(send_node)

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -4635,7 +4635,9 @@ Enabled | Yes
 
 This cop transforms usages of a method call safeguarded by a non `nil`
 check for the variable whose method is being called to
-safe navigation (`&.`).
+safe navigation (`&.`). If there is a method chain, all of the methods
+in the chain need to be checked for safety, and all of the methods will
+need to be changed to use safe navigation.
 
 Configuration option: ConvertCodeThatCanStartToReturnNil
 The default for this is `false`. When configured to `true`, this will
@@ -4650,6 +4652,7 @@ returns.
 ```ruby
 # bad
 foo.bar if foo
+foo.bar.baz if foo
 foo.bar(param1, param2) if foo
 foo.bar { |e| e.something } if foo
 foo.bar(param) { |e| e.something } if foo
@@ -4659,16 +4662,23 @@ foo.bar unless !foo
 foo.bar unless foo.nil?
 
 foo && foo.bar
+foo && foo.bar.baz
 foo && foo.bar(param1, param2)
 foo && foo.bar { |e| e.something }
 foo && foo.bar(param) { |e| e.something }
 
 # good
 foo&.bar
+foo&.bar&.baz
 foo&.bar(param1, param2)
 foo&.bar { |e| e.something }
 foo&.bar(param) { |e| e.something }
 
+# Method calls that do not use `.`
+foo && foo < bar
+foo < bar if foo
+
+# This could start returning `nil` as well as the return of the method
 foo.nil? || foo.bar
 !foo || foo.bar
 

--- a/spec/rubocop/cop/style/safe_navigation_spec.rb
+++ b/spec/rubocop/cop/style/safe_navigation_spec.rb
@@ -84,6 +84,16 @@ RSpec.describe RuboCop::Cop::Style::SafeNavigation, :config do
       expect_no_offenses('foo && foo.bar <=> baz')
     end
 
+    it 'allows an object check before a method chain that is used in ' \
+      'a comparison' do
+      expect_no_offenses('foo && foo.bar.baz > 2')
+    end
+
+    it 'allows a method chain that is used in a comparison ' \
+      'safe guarded by an object check' do
+      expect_no_offenses('foo.bar.baz > 2 if foo')
+    end
+
     it 'allows method calls that do not get called using . safe guarded by ' \
       'an object check' do
       expect_no_offenses('foo + bar if foo')

--- a/spec/rubocop/cop/style/safe_navigation_spec.rb
+++ b/spec/rubocop/cop/style/safe_navigation_spec.rb
@@ -724,7 +724,7 @@ RSpec.describe RuboCop::Cop::Style::SafeNavigation, :config do
             RUBY
 
             expect(new_source).to eq(<<-RUBY.strip_indent)
-              #{variable}&.one.two(baz) { |e| e.qux }
+              #{variable}&.one&.two(baz) { |e| e.qux }
             RUBY
           end
 
@@ -735,7 +735,7 @@ RSpec.describe RuboCop::Cop::Style::SafeNavigation, :config do
             RUBY
 
             expect(new_source).to eq(<<-RUBY.strip_indent)
-              #{variable}&.one.two(baz) { |e| e.qux }
+              #{variable}&.one&.two(baz) { |e| e.qux }
             RUBY
           end
 
@@ -746,7 +746,7 @@ RSpec.describe RuboCop::Cop::Style::SafeNavigation, :config do
             RUBY
 
             expect(new_source).to eq(<<-RUBY.strip_indent)
-              #{variable}&.one.two(baz) { |e| e.qux }
+              #{variable}&.one&.two(baz) { |e| e.qux }
             RUBY
           end
         end
@@ -1021,7 +1021,7 @@ RSpec.describe RuboCop::Cop::Style::SafeNavigation, :config do
               RUBY
 
               expect(new_source).to eq(<<-RUBY.strip_indent)
-                #{variable}&.one.two(baz) { |e| e.qux }
+                #{variable}&.one&.two(baz) { |e| e.qux }
               RUBY
             end
 
@@ -1032,7 +1032,7 @@ RSpec.describe RuboCop::Cop::Style::SafeNavigation, :config do
               RUBY
 
               expect(new_source).to eq(<<-RUBY.strip_indent)
-                #{variable}&.one.two.three(baz) { |e| e.qux }
+                #{variable}&.one&.two&.three(baz) { |e| e.qux }
               RUBY
             end
 
@@ -1043,7 +1043,7 @@ RSpec.describe RuboCop::Cop::Style::SafeNavigation, :config do
               RUBY
 
               expect(new_source).to eq(<<-RUBY.strip_indent)
-                #{variable}&.one { |a| b}.two(baz) { |e| e.qux }
+                #{variable}&.one { |a| b}&.two(baz) { |e| e.qux }
               RUBY
             end
           end

--- a/spec/rubocop/cop/style/safe_navigation_spec.rb
+++ b/spec/rubocop/cop/style/safe_navigation_spec.rb
@@ -44,14 +44,44 @@ RSpec.describe RuboCop::Cop::Style::SafeNavigation, :config do
       expect_no_offenses('foo && !foo.bar.baz?')
     end
 
-    it 'allows method call that are used in a comparison safe guarded by ' \
+    it 'allows method call that is used in a comparison safe guarded by ' \
       'an object check' do
       expect_no_offenses('foo.bar > 2 if foo')
     end
 
-    it 'allows an object check before a method call that are used in ' \
+    it 'allows method call that is used in a regex comparison ' \
+      'safe guarded by an object check' do
+      expect_no_offenses('foo.bar =~ /baz/ if foo')
+    end
+
+    it 'allows method call that is used in a negated regex comparison ' \
+      'safe guarded by an object check' do
+      expect_no_offenses('foo.bar !~ /baz/ if foo')
+    end
+
+    it 'allows method call that is used in a spaceship comparison ' \
+      'safe guarded by an object check' do
+      expect_no_offenses('foo.bar <=> baz if foo')
+    end
+
+    it 'allows an object check before a method call that is used in ' \
       'a comparison' do
       expect_no_offenses('foo && foo.bar > 2')
+    end
+
+    it 'allows an object check before a method call that is used in ' \
+      'a regex comparison' do
+      expect_no_offenses('foo && foo.bar =~ /baz/')
+    end
+
+    it 'allows an object check before a method call that is used in ' \
+      'a negated regex comparison' do
+      expect_no_offenses('foo && foo.bar !~ /baz/')
+    end
+
+    it 'allows an object check before a method call that is used in ' \
+      'a spaceship comparison' do
+      expect_no_offenses('foo && foo.bar <=> baz')
     end
 
     it 'allows method calls that do not get called using . safe guarded by ' \


### PR DESCRIPTION
This fixes #4889, #5287, and #5348.

* Do not register an offense for `foo && foo.bar !~ /baz/`
`=~`, `!~`, and `<=>` are not in the list of comparable methods.
* Auto-correct all methods in a method chain to use safe navigation
This is needed for safety. Example: `foo && foo.bar.baz` if this is corrected to `foo&.bar.baz` and `foo = nil`, then `baz` would be run on `nil`.
* Do not register an offense when an unsafe method is used in a method chain
This is the same reasoning as why all methods in a chain need safe navigation.