### PR TITLE
Add examples of `EnforcedLastArgumentHashStyle` to `Layout/AlignHash`

### DIFF
--- a/lib/rubocop/cop/layout/align_hash.rb
+++ b/lib/rubocop/cop/layout/align_hash.rb
@@ -101,6 +101,70 @@ module RuboCop
       #     ba:  baz
       #   }
       #
+      # @example EnforcedLastArgumentHashStyle: always_inspect (default)
+      #   # Inspect both implicit and explicit hashes.
+      #
+      #   # bad
+      #   do_something(foo: 1,
+      #     bar: 2)
+      #
+      #   # bad
+      #   do_something({foo: 1,
+      #     bar: 2})
+      #
+      #   # good
+      #   do_something(foo: 1,
+      #                bar: 2)
+      #
+      #   # good
+      #   do_something(
+      #     foo: 1,
+      #     bar: 2
+      #   )
+      #
+      #   # good
+      #   do_something({foo: 1,
+      #                 bar: 2})
+      #
+      #   # good
+      #   do_something({
+      #     foo: 1,
+      #     bar: 2
+      #   })
+      #
+      # @example EnforcedLastArgumentHashStyle: always_ignore
+      #   # Ignore both implicit and explicit hashes.
+      #
+      #   # good
+      #   do_something(foo: 1,
+      #     bar: 2)
+      #
+      #   # good
+      #   do_something({foo: 1,
+      #     bar: 2})
+      #
+      # @example EnforcedLastArgumentHashStyle: ignore_implicit
+      #   # Ignore only implicit hashes.
+      #
+      #   # bad
+      #   do_something({foo: 1,
+      #     bar: 2})
+      #
+      #   # good
+      #   do_something(foo: 1,
+      #     bar: 2)
+      #
+      # @example EnforcedLastArgumentHashStyle: ignore_explicit
+      #   # Ignore only explicit hashes.
+      #
+      #   # bad
+      #   do_something(foo: 1,
+      #     bar: 2)
+      #
+      #   # good
+      #   do_something({foo: 1,
+      #     bar: 2})
+      #
       class AlignHash < Cop
         include HashAlignment
         include RangeHelp

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -202,6 +202,78 @@ can also be configured. The options are:
   ba:  baz
 }
 ```
+#### EnforcedLastArgumentHashStyle: always_inspect (default)
+
+```ruby
+# Inspect both implicit and explicit hashes.
+
+# bad
+do_something(foo: 1,
+  bar: 2)
+
+# bad
+do_something({foo: 1,
+  bar: 2})
+
+# good
+do_something(foo: 1,
+             bar: 2)
+
+# good
+do_something(
+  foo: 1,
+  bar: 2
+)
+
+# good
+do_something({foo: 1,
+              bar: 2})
+
+# good
+do_something({
+  foo: 1,
+  bar: 2
+})
+```
+#### EnforcedLastArgumentHashStyle: always_ignore
+
+```ruby
+# Ignore both implicit and explicit hashes.
+
+# good
+do_something(foo: 1,
+  bar: 2)
+
+# good
+do_something({foo: 1,
+  bar: 2})
+```
+#### EnforcedLastArgumentHashStyle: ignore_implicit
+
+```ruby
+# Ignore only implicit hashes.
+
+# bad
+do_something({foo: 1,
+  bar: 2})
+
+# good
+do_something(foo: 1,
+  bar: 2)
+```
+#### EnforcedLastArgumentHashStyle: ignore_explicit
+
+```ruby
+# Ignore only explicit hashes.
+
+# bad
+do_something(foo: 1,
+  bar: 2)
+
+# good
+do_something({foo: 1,
+  bar: 2})
+```
 
 ### Configurable attributes
 


### PR DESCRIPTION
Follow up of #5412.

This commit is a change of document format for Layout/AlignHash cop.

This commit adds an examples of `EnforcedLastArgumentHashStyle` to `Layout/AlignHash` cop.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
