### PR TITLE
Add an example of `EnforcedStyle` for `Layout/MultilineOperationIndentation`

### DIFF
--- a/lib/rubocop/cop/layout/multiline_operation_indentation.rb
+++ b/lib/rubocop/cop/layout/multiline_operation_indentation.rb
@@ -6,10 +6,10 @@ module RuboCop
       # This cop checks the indentation of the right hand side operand in
       # binary operations that span more than one line.
       #
-      # @example
+      # @example EnforcedStyle: aligned (default)
       #   # bad
       #   if a +
-      #   b
+      #       b
       #     something
       #   end
       #
@@ -18,6 +18,20 @@ module RuboCop
       #      b
       #     something
       #   end
+      #
+      # @example EnforcedStyle: indented
+      #   # bad
+      #   if a +
+      #      b
+      #     something
+      #   end
+      #
+      #   # good
+      #   if a +
+      #       b
+      #     something
+      #   end
+      #
       class MultilineOperationIndentation < Cop
         include ConfigurableEnforcedStyle
         include Alignment

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -2315,16 +2315,33 @@ binary operations that span more than one line.
 
 ### Examples
 
+#### EnforcedStyle: aligned (default)
+
 ```ruby
 # bad
 if a +
-b
+    b
   something
 end
 
 # good
 if a +
    b
+  something
+end
+```
+#### EnforcedStyle: indented
+
+```ruby
+# bad
+if a +
+   b
+  something
+end
+
+# good
+if a +
+    b
   something
 end
 ```


### PR DESCRIPTION
Follow up of https://github.com/bbatsov/rubocop/pull/4880#issuecomment-338499947.

This is only document change.

This commit adds an example of `EnforcedStyle` to `Layout/MultilineOperationIndentation`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
