### PR TITLE
Catch exception in relative path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 * [#5426](https://github.com/bbatsov/rubocop/issues/5426): Make `Rails/InverseOf` accept `inverse_of: nil` to opt-out. ([@wata727][])
 * [#5448](https://github.com/bbatsov/rubocop/issues/5448): Improve `Rails/LexicallyScopedActionFilter`. ([@wata727][])
 * [#3947](https://github.com/bbatsov/rubocop/issues/3947): Fix false positive for `Rails/FilePath` when using `Rails.root.join` in string interpolation of argument. ([@koic][])
+* [#5427](https://github.com/bbatsov/rubocop/pull/5427): Fix exception when executing from a different drive on Windows. ([@orgads][])
 
 ### Changes
 
@@ -3167,3 +3168,4 @@
 [@mame]: https://github.com/mame
 [@dominicsayers]: https://github.com/dominicsayers
 [@albertpaulp]: https://github.com/albertpaulp
+[@orgads]: https://github.com/orgads

--- a/lib/rubocop/path_util.rb
+++ b/lib/rubocop/path_util.rb
@@ -15,7 +15,11 @@ module RuboCop
       end
 
       path_name = Pathname.new(File.expand_path(path))
-      path_name.relative_path_from(Pathname.new(base_dir)).to_s
+      begin
+        path_name.relative_path_from(Pathname.new(base_dir)).to_s
+      rescue ArgumentError
+        path
+      end
     end
 
     def smart_path(path)

--- a/spec/rubocop/path_util_spec.rb
+++ b/spec/rubocop/path_util_spec.rb
@@ -10,6 +10,17 @@ RSpec.describe RuboCop::PathUtil do
     it 'supports custom base paths' do
       expect(described_class.relative_path('/foo/bar', '/foo')).to eq('bar')
     end
+
+    if RuboCop::Platform.windows?
+      it 'works for different drives' do
+        expect(described_class.relative_path('D:/foo/bar', 'C:/foo'))
+          .to eq('D:/foo/bar')
+      end
+      it 'works for the same drive' do
+        expect(described_class.relative_path('D:/foo/bar', 'D:/foo'))
+          .to eq('bar')
+      end
+    end
   end
 
   describe '#match_path?', :isolated_environment do


### PR DESCRIPTION
```console
F:/Ruby/lib/ruby/2.4.0/pathname.rb:520:in `relative_path_from': different prefix: "D:/" and "C:/Directory" (ArgumentError)
	from path_util.rb:19:in `relative_path'
	from config.rb:363:in `path_relative_to_config'
	from cop/cop.rb:209:in `block in file_name_matches_any?'
	from cop/cop.rb:204:in `any?'
	from cop/cop.rb:204:in `file_name_matches_any?'
	from cop/cop.rb:184:in `relevant_file?'
	from cop/cop.rb:189:in `excluded_file?'
	from cop/commissioner.rb:71:in `block in remove_irrelevant_cops'
	from cop/commissioner.rb:71:in `reject!'
	from cop/commissioner.rb:71:in `remove_irrelevant_cops'
	from cop/commissioner.rb:55:in `investigate'
	from cop/team.rb:114:in `investigate'
	from cop/team.rb:102:in `offenses'
	from cop/team.rb:44:in `inspect_file'
	from runner.rb:258:in `inspect_file'
	from script.rb:16:in `_inspect_code'
	from script.rb:38:in `parse'
	from script.rb:57:in `main'
	from script.rb:61:in `<main>'```