### PR TITLE
[Fix #5426] Make `Rails/InverseOf` accept `inverse_of: nil` to opt-out.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 * [#5348](https://github.com/bbatsov/rubocop/issues/5348): Fix false positive for `Style/SafeNavigation` when safe guarding more comparison methods. ([@rrosenblum][])
 * [#4889](https://github.com/bbatsov/rubocop/issues/4889): Auto-correcting `Style/SafeNavigation` will add safe navigation to all methods in a method chain. ([@rrosenblum][])
 * [#5287](https://github.com/bbatsov/rubocop/issues/5287): Do not register an offense in `Style/SafeNavigation` if there is an unsafe method used in a method chain. ([@rrosenblum][])
+* [#5426](https://github.com/bbatsov/rubocop/issues/5426): Make `Rails/InverseOf` accept `inverse_of: nil` to opt-out. ([@wata727][])
 
 ### Changes
 

--- a/lib/rubocop/cop/rails/inverse_of.rb
+++ b/lib/rubocop/cop/rails/inverse_of.rb
@@ -7,7 +7,8 @@ module RuboCop
       # ActiveRecord can't automatically determine the inverse association
       # because of a scope or the options used. This can result in unnecessary
       # queries in some circumstances. `:inverse_of` must be manually specified
-      # for associations to work in both ways, or set to `false` to opt-out.
+      # for associations to work in both ways, or set to `false` or `nil`
+      # to opt-out.
       #
       # @example
       #   # good
@@ -50,6 +51,24 @@ module RuboCop
       #
       #   class Post < ApplicationRecord
       #     belongs_to :blog
+      #   end
+      #
+      #   # good
+      #   # When you don't want to use the inverse association.
+      #   class Blog < ApplicationRecord
+      #     has_many(:posts,
+      #       -> { order(published_at: :desc) },
+      #       inverse_of: false
+      #     )
+      #   end
+      #
+      #   # good
+      #   # You can also opt-out with specifying `inverse_of: nil`.
+      #   class Blog < ApplicationRecord
+      #     has_many(:posts,
+      #       -> { order(published_at: :desc) },
+      #       inverse_of: nil
+      #     )
       #   end
       #
       # @example
@@ -155,7 +174,7 @@ module RuboCop
         PATTERN
 
         def_node_matcher :inverse_of_option?, <<-PATTERN
-          (pair (sym :inverse_of) !nil)
+          (pair (sym :inverse_of) _)
         PATTERN
 
         def on_send(node)

--- a/manual/cops_rails.md
+++ b/manual/cops_rails.md
@@ -684,7 +684,8 @@ This cop looks for has_(one|many) and belongs_to associations where
 ActiveRecord can't automatically determine the inverse association
 because of a scope or the options used. This can result in unnecessary
 queries in some circumstances. `:inverse_of` must be manually specified
-for associations to work in both ways, or set to `false` to opt-out.
+for associations to work in both ways, or set to `false` or `nil`
+to opt-out.
 
 ### Examples
 
@@ -729,6 +730,24 @@ end
 
 class Post < ApplicationRecord
   belongs_to :blog
+end
+
+# good
+# When you don't want to use the inverse association.
+class Blog < ApplicationRecord
+  has_many(:posts,
+    -> { order(published_at: :desc) },
+    inverse_of: false
+  )
+end
+
+# good
+# You can also opt-out with specifying `inverse_of: nil`.
+class Blog < ApplicationRecord
+  has_many(:posts,
+    -> { order(published_at: :desc) },
+    inverse_of: nil
+  )
 end
 ```
 ```ruby

--- a/spec/rubocop/cop/rails/inverse_of_spec.rb
+++ b/spec/rubocop/cop/rails/inverse_of_spec.rb
@@ -15,9 +15,15 @@ RSpec.describe RuboCop::Cop::Rails::InverseOf do
       RUBY
     end
 
-    it 'does not register an offense when specifying `:inverse_of`' do
+    it 'does not register an offense when specifying `inverse_of: false`' do
       expect_no_offenses(
         'has_many :foo, -> () { where(bar: true) }, inverse_of: false'
+      )
+    end
+
+    it 'does not register an offense when specifying `inverse_of: nil`' do
+      expect_no_offenses(
+        'has_many :foo, -> () { where(bar: true) }, inverse_of: nil'
       )
     end
   end


### PR DESCRIPTION
Fixes #5426

`inverse_of: nil` is a natural way to opt-out.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
