### PR TITLE
[Fix #5401] Fix Style/RedundantReturn to trigger when blocks present.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 * [#5348](https://github.com/bbatsov/rubocop/issues/5348): Fix false positive for `Style/SafeNavigation` when safe guarding more comparison methods. ([@rrosenblum][])
 * [#4889](https://github.com/bbatsov/rubocop/issues/4889): Auto-correcting `Style/SafeNavigation` will add safe navigation to all methods in a method chain. ([@rrosenblum][])
 * [#5287](https://github.com/bbatsov/rubocop/issues/5287): Do not register an offense in `Style/SafeNavigation` if there is an unsafe method used in a method chain. ([@rrosenblum][])
+* [#5401](https://github.com/bbatsov/rubocop/issues/5401): Fix `Style/RedundantReturn` to trigger when begin-end, rescue, and ensure blocks present. ([@asherkach][])
 
 ### Changes
 

--- a/lib/rubocop/cli.rb
+++ b/lib/rubocop/cli.rb
@@ -41,19 +41,19 @@ module RuboCop
       execute_runners(paths)
     rescue RuboCop::ConfigNotFoundError => e
       warn e.message
-      return e.status
+      e.status
     rescue RuboCop::Error => e
       warn Rainbow("Error: #{e.message}").red
-      return STATUS_ERROR
+      STATUS_ERROR
     rescue Finished
-      return STATUS_SUCCESS
+      STATUS_SUCCESS
     rescue IncorrectCopNameError => e
       warn e.message
-      return STATUS_ERROR
+      STATUS_ERROR
     rescue StandardError, SyntaxError, LoadError => e
       warn e.message
       warn e.backtrace
-      return STATUS_ERROR
+      STATUS_ERROR
     end
     # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
 

--- a/lib/rubocop/config_loader_resolver.rb
+++ b/lib/rubocop/config_loader_resolver.rb
@@ -155,7 +155,7 @@ module RuboCop
 
     def gem_config_path(gem_name, relative_config_path)
       spec = Gem::Specification.find_by_name(gem_name)
-      return File.join(spec.gem_dir, relative_config_path)
+      File.join(spec.gem_dir, relative_config_path)
     rescue Gem::LoadError => e
       raise Gem::LoadError,
             "Unable to find gem #{gem_name}; is the gem installed? #{e}"


### PR DESCRIPTION
Note that the new tests fail without these changes. Also note that these changes caused an existing redundant return within this codebase to be flagged.

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
