### PR TITLE
Move the `include` of RSpec helper modules

### DIFF
--- a/lib/rubocop/rspec/cop_helper.rb
+++ b/lib/rubocop/rspec/cop_helper.rb
@@ -92,7 +92,3 @@ module RuboCop
     end
   end
 end
-
-RSpec.configure do |config|
-  config.include CopHelper
-end

--- a/lib/rubocop/rspec/host_environment_simulation_helper.rb
+++ b/lib/rubocop/rspec/host_environment_simulation_helper.rb
@@ -26,7 +26,3 @@ module HostEnvironmentSimulatorHelper
     end
   end
 end
-
-RSpec.configure do |config|
-  config.include HostEnvironmentSimulatorHelper
-end

--- a/lib/rubocop/rspec/support.rb
+++ b/lib/rubocop/rspec/support.rb
@@ -7,3 +7,8 @@ require_relative 'host_environment_simulation_helper'
 require_relative 'shared_contexts'
 require_relative 'shared_examples'
 require_relative 'expect_offense'
+
+RSpec.configure do |config|
+  config.include CopHelper
+  config.include HostEnvironmentSimulatorHelper
+end


### PR DESCRIPTION
Move the including of RSpec helper modules out of the file *defining* said module, and into the file *requiring* it.

When testing a custom Rubocop Cop, you do not necessarily want to include `CopHelper` and `HostEnvironmentSimulatorHelper` into *all* example groups. With this change, you can require `CopHelper` and `HostEnvironmentSimulatorHelper` and yourself choose whether to include it in all example groups, a tagged subset of example groups, or just a single example group.

See documentation of RSpec module inclusion at https://relishapp.com/rspec/rspec-core/v/3-7/docs/helper-methods/define-helper-methods-in-a-module

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
