### PR TITLE
Add an example of `EnforcedStyle` for `Layout/IndentationConsistency`

### DIFF
--- a/lib/rubocop/cop/layout/indentation_consistency.rb
+++ b/lib/rubocop/cop/layout/indentation_consistency.rb
@@ -5,13 +5,117 @@ module RuboCop
     module Layout
       # This cops checks for inconsistent indentation.
       #
-      # @example
+      # The difference between `rails` and `normal` is that the `rails` style
+      # prescribes that in classes and modules the `protected` and `private`
+      # modifier keywords shall be indented the same as public methods and that
+      # protected and private members shall be indented one step more than the
+      # modifiers. Other than that, both styles mean that entities on the same
+      # logical depth shall have the same indentation.
       #
+      # @example EnforcedStyle: normal (default)
+      #   # bad
       #   class A
       #     def test
       #       puts 'hello'
       #        puts 'world'
       #     end
+      #   end
+      #
+      #   # bad
+      #   class A
+      #     def test
+      #       puts 'hello'
+      #       puts 'world'
+      #     end
+      #
+      #     protected
+      #
+      #       def foo
+      #       end
+      #
+      #     private
+      #
+      #       def bar
+      #       end
+      #   end
+      #
+      #   # good
+      #   class A
+      #     def test
+      #       puts 'hello'
+      #       puts 'world'
+      #     end
+      #   end
+      #
+      #   # good
+      #   class A
+      #     def test
+      #       puts 'hello'
+      #        puts 'world'
+      #     end
+      #
+      #     protected
+      #
+      #     def foo
+      #     end
+      #
+      #     private
+      #
+      #     def bar
+      #     end
+      #   end
+      #
+      # @example EnforcedStyle: rails
+      #   # bad
+      #   class A
+      #     def test
+      #       puts 'hello'
+      #        puts 'world'
+      #     end
+      #   end
+      #
+      #   # bad
+      #   class A
+      #     def test
+      #       puts 'hello'
+      #        puts 'world'
+      #     end
+      #
+      #     protected
+      #
+      #     def foo
+      #     end
+      #
+      #     private
+      #
+      #     def bar
+      #     end
+      #   end
+      #
+      #   # good
+      #   class A
+      #     def test
+      #       puts 'hello'
+      #       puts 'world'
+      #     end
+      #   end
+      #
+      #   # good
+      #   class A
+      #     def test
+      #       puts 'hello'
+      #       puts 'world'
+      #     end
+      #
+      #     protected
+      #
+      #       def foo
+      #       end
+      #
+      #     private
+      #
+      #       def bar
+      #       end
       #   end
       class IndentationConsistency < Cop
         include Alignment

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -1910,14 +1910,123 @@ Enabled | Yes
 
 This cops checks for inconsistent indentation.
 
+The difference between `rails` and `normal` is that the `rails` style
+prescribes that in classes and modules the `protected` and `private`
+modifier keywords shall be indented the same as public methods and that
+protected and private members shall be indented one step more than the
+modifiers. Other than that, both styles mean that entities on the same
+logical depth shall have the same indentation.
+
 ### Examples
 
+#### EnforcedStyle: normal (default)
+
 ```ruby
+# bad
 class A
   def test
     puts 'hello'
      puts 'world'
   end
+end
+
+# bad
+class A
+  def test
+    puts 'hello'
+    puts 'world'
+  end
+
+  protected
+
+    def foo
+    end
+
+  private
+
+    def bar
+    end
+end
+
+# good
+class A
+  def test
+    puts 'hello'
+    puts 'world'
+  end
+end
+
+# good
+class A
+  def test
+    puts 'hello'
+     puts 'world'
+  end
+
+  protected
+
+  def foo
+  end
+
+  private
+
+  def bar
+  end
+end
+```
+#### EnforcedStyle: rails
+
+```ruby
+# bad
+class A
+  def test
+    puts 'hello'
+     puts 'world'
+  end
+end
+
+# bad
+class A
+  def test
+    puts 'hello'
+     puts 'world'
+  end
+
+  protected
+
+  def foo
+  end
+
+  private
+
+  def bar
+  end
+end
+
+# good
+class A
+  def test
+    puts 'hello'
+    puts 'world'
+  end
+end
+
+# good
+class A
+  def test
+    puts 'hello'
+    puts 'world'
+  end
+
+  protected
+
+    def foo
+    end
+
+  private
+
+    def bar
+    end
 end
 ```
 


### PR DESCRIPTION
Follow up of https://github.com/bbatsov/rubocop/pull/4880#issuecomment-338499947.

This is only document change.

This commit adds an example of `EnforcedStyle` to `Layout/IndentationConsistency`.

Also this commit adds information on how to use by adding a description of `Layout/IndentationConsistency` cop written in config/default.yml.
https://github.com/bbatsov/rubocop/blob/v0.52.1/config/default.yml#L312-L317

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
