### PR TITLE
[Fix #5431] Refine message for `Gemspec::RequiredRubyVersion` cop

### DIFF
--- a/lib/rubocop/cop/gemspec/required_ruby_version.rb
+++ b/lib/rubocop/cop/gemspec/required_ruby_version.rb
@@ -38,8 +38,8 @@ module RuboCop
       class RequiredRubyVersion < Cop
         MSG = '`required_ruby_version` (%<required_ruby_version>s, ' \
               'declared in %<gemspec_filename>s) and `TargetRubyVersion` ' \
-              '(%<target_ruby_version>s, declared in .rubocop.yml) ' \
-              'should be equal.'.freeze
+              '(%<target_ruby_version>s, which may be specified in ' \
+              '.rubocop.yml) should be equal.'.freeze
 
         def_node_search :required_ruby_version, <<-PATTERN
           (send _ :required_ruby_version= ${(str _) (array (str _))})

--- a/spec/rubocop/cop/gemspec/required_ruby_version_spec.rb
+++ b/spec/rubocop/cop/gemspec/required_ruby_version_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe RuboCop::Cop::Gemspec::RequiredRubyVersion, :config do
       expect_offense(<<-RUBY.strip_indent, '/path/to/foo.gemspec')
         Gem::Specification.new do |spec|
           spec.required_ruby_version = '>= 2.3.0'
-                                       ^^^^^^^^^^ `required_ruby_version` (2.3, declared in foo.gemspec) and `TargetRubyVersion` (2.4, declared in .rubocop.yml) should be equal.
+                                       ^^^^^^^^^^ `required_ruby_version` (2.3, declared in foo.gemspec) and `TargetRubyVersion` (2.4, which may be specified in .rubocop.yml) should be equal.
         end
       RUBY
     end
@@ -44,7 +44,7 @@ RSpec.describe RuboCop::Cop::Gemspec::RequiredRubyVersion, :config do
       expect_offense(<<-RUBY.strip_indent, '/path/to/bar.gemspec')
         Gem::Specification.new do |spec|
           spec.required_ruby_version = '>= 2.3.0'
-                                       ^^^^^^^^^^ `required_ruby_version` (2.3, declared in bar.gemspec) and `TargetRubyVersion` (2.2, declared in .rubocop.yml) should be equal.
+                                       ^^^^^^^^^^ `required_ruby_version` (2.3, declared in bar.gemspec) and `TargetRubyVersion` (2.2, which may be specified in .rubocop.yml) should be equal.
         end
       RUBY
     end


### PR DESCRIPTION
Fixes #5431.
Based on #5431 feedback, This commit refined not to misleading message.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
