### PR TITLE
Bump license year for 2018

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2012-17 Bozhidar Batsov
+Copyright (c) 2012-18 Bozhidar Batsov
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the


### PR DESCRIPTION
Follow up of #5413.
This commit unifies the copyright year to 2018.
