### PR TITLE
[Fix #5435] Whitelist common names for UncommunicativeMethodArgName

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -743,7 +743,9 @@ Naming/UncommunicativeMethodArgName:
   MinNameLength: 3
   AllowNamesEndingInNumbers: true
   # Whitelisted names that will not register an offense
-  AllowedNames: []
+  AllowedNames:
+    - io
+    - id
   # Blacklisted names that will register an offense
   ForbiddenNames: []
 

--- a/manual/cops_naming.md
+++ b/manual/cops_naming.md
@@ -470,7 +470,7 @@ Name | Default value | Configurable values
 --- | --- | ---
 MinNameLength | `3` | Integer
 AllowNamesEndingInNumbers | `true` | Boolean
-AllowedNames | `[]` | Array
+AllowedNames | `io`, `id` | Array
 ForbiddenNames | `[]` | Array
 
 ## Naming/VariableName


### PR DESCRIPTION
Adds requested common names to new cop, `Naming/UncommunicativeMethodArgName`.

Since this functionality is already tested, I've not added anything new. Also, this is unreleased, so there is no need for a CHANGELOG entry.

-----------------

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
