### PR TITLE
Fix example for `Layout/IndentationConsistency` cop

### DIFF
--- a/lib/rubocop/cop/layout/indentation_consistency.rb
+++ b/lib/rubocop/cop/layout/indentation_consistency.rb
@@ -51,7 +51,7 @@ module RuboCop
       #   class A
       #     def test
       #       puts 'hello'
-      #        puts 'world'
+      #       puts 'world'
       #     end
       #
       #     protected
@@ -78,7 +78,7 @@ module RuboCop
       #   class A
       #     def test
       #       puts 'hello'
-      #        puts 'world'
+      #       puts 'world'
       #     end
       #
       #     protected

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -1960,7 +1960,7 @@ end
 class A
   def test
     puts 'hello'
-     puts 'world'
+    puts 'world'
   end
 
   protected
@@ -1989,7 +1989,7 @@ end
 class A
   def test
     puts 'hello'
-     puts 'world'
+    puts 'world'
   end
 
   protected


### PR DESCRIPTION
Follow up of https://github.com/bbatsov/rubocop/pull/5439#discussion_r161088752.
There was a typo in the good case of `EnforcedStyle: normal (default)`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
