### PR TITLE
Removes redundant sentence

### DIFF
--- a/manual/cops_lint.md
+++ b/manual/cops_lint.md
@@ -2078,9 +2078,6 @@ Enabled | No
 This cop identifies places where `URI.escape` can be replaced by
 `CGI.escape`, `URI.encode_www_form` or `URI.encode_www_form_component`
 depending on your specific use case.
-Also this cop identifies places where `URI.unescape` can be replaced by
-`CGI.unescape`, `URI.decode_www_form` or `URI.decode_www_form_component`
-depending on your specific use case.
 
 ### Examples
 


### PR DESCRIPTION
**Remove redundant sentence from Lint/UriEscapeUnescape documentation.**
-----------------

Noticed the redundancy when I was trying to get more information about this specific rule and decided to open a quick PR using the github web UI.

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
   * I am assuming this since I am using GitHub Web UI for this
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
