### PR TITLE
[#5436] Change UncommunicativeMethodArg to UncommunicativeMethodParam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### New features
 
 * [#3666](https://github.com/bbatsov/rubocop/issues/3666): Add new `Naming/UncommunicativeBlockParamName` cop. ([@garettarrowood][])
-* [#3666](https://github.com/bbatsov/rubocop/issues/3666): Add new `Naming/UncommunicativeMethodArgName` cop. ([@garettarrowood][])
+* [#3666](https://github.com/bbatsov/rubocop/issues/3666): Add new `Naming/UncommunicativeMethodParamName` cop. ([@garettarrowood][])
 * [#5356](https://github.com/bbatsov/rubocop/issues/5356): Add new `Lint/UnneededCopEnableDirective` cop. ([@garettarrowood][])
 * [#5248](https://github.com/bbatsov/rubocop/pull/5248): Add new `Lint/BigDecimalNew` cop. ([@koic][])
 * [#3394](https://github.com/bbatsov/rubocop/issues/3394): Add new `Style/TrailingCommmaInArrayLiteral` cop. ([@garettarrowood][])
@@ -30,7 +30,7 @@
 * [#4889](https://github.com/bbatsov/rubocop/issues/4889): Auto-correcting `Style/SafeNavigation` will add safe navigation to all methods in a method chain. ([@rrosenblum][])
 * [#5287](https://github.com/bbatsov/rubocop/issues/5287): Do not register an offense in `Style/SafeNavigation` if there is an unsafe method used in a method chain. ([@rrosenblum][])
 * [#5401](https://github.com/bbatsov/rubocop/issues/5401): Fix `Style/RedundantReturn` to trigger when begin-end, rescue, and ensure blocks present. ([@asherkach][])
-* [#5426](https://github.com/bbatsov/rubocop/issues/5426): Make `Rails/InverseOf` accept `inverse_of: nil` to opt-out. ([@wata727][]) 
+* [#5426](https://github.com/bbatsov/rubocop/issues/5426): Make `Rails/InverseOf` accept `inverse_of: nil` to opt-out. ([@wata727][])
 
 ### Changes
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -738,8 +738,8 @@ Naming/UncommunicativeBlockParamName:
   # Blacklisted names that will register an offense
   ForbiddenNames: []
 
-Naming/UncommunicativeMethodArgName:
-  # Argrument names may be equal to or greater than this value
+Naming/UncommunicativeMethodParamName:
+  # Parameter names may be equal to or greater than this value
   MinNameLength: 3
   AllowNamesEndingInNumbers: true
   # Whitelisted names that will not register an offense

--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -869,9 +869,9 @@ Naming/UncommunicativeBlockParamName:
                 end in numbers, or do not meet a minimal length.
   Enabled: true
 
-Naming/UncommunicativeMethodArgName:
+Naming/UncommunicativeMethodParamName:
   Description: >-
-                Checks for method argument names that contain capital letters,
+                Checks for method parameter names that contain capital letters,
                 end in numbers, or do not meet a minimal length.
   Enabled: true
 

--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -336,7 +336,7 @@ require_relative 'rubocop/cop/naming/method_name'
 require_relative 'rubocop/cop/naming/binary_operator_parameter_name'
 require_relative 'rubocop/cop/naming/predicate_name'
 require_relative 'rubocop/cop/naming/uncommunicative_block_param_name'
-require_relative 'rubocop/cop/naming/uncommunicative_method_arg_name'
+require_relative 'rubocop/cop/naming/uncommunicative_method_param_name'
 require_relative 'rubocop/cop/naming/variable_name'
 require_relative 'rubocop/cop/naming/variable_number'
 

--- a/lib/rubocop/cop/mixin/uncommunicative_name.rb
+++ b/lib/rubocop/cop/mixin/uncommunicative_name.rb
@@ -43,7 +43,7 @@ module RuboCop
         @name_type ||= begin
           case node.type
           when :block then 'block parameter'
-          when :def, :defs then 'method argument'
+          when :def, :defs then 'method parameter'
           end
         end
       end

--- a/lib/rubocop/cop/naming/uncommunicative_method_param_name.rb
+++ b/lib/rubocop/cop/naming/uncommunicative_method_param_name.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Naming
-      # This cop checks method argument names for how descriptive they
+      # This cop checks method parameter names for how descriptive they
       # are. It is highly configurable.
       #
       # The `MinNameLength` config option takes an integer. It represents
@@ -43,7 +43,7 @@ module RuboCop
       #   def baz(age_a, height_b, gender_c)
       #     do_stuff(age_a, height_b, gender_c)
       #   end
-      class UncommunicativeMethodArgName < Cop
+      class UncommunicativeMethodParamName < Cop
         include UncommunicativeName
 
         def on_def(node)

--- a/manual/cops.md
+++ b/manual/cops.md
@@ -283,7 +283,7 @@ In the following section you find all available cops:
 * [Naming/MethodName](cops_naming.md#namingmethodname)
 * [Naming/PredicateName](cops_naming.md#namingpredicatename)
 * [Naming/UncommunicativeBlockParamName](cops_naming.md#naminguncommunicativeblockparamname)
-* [Naming/UncommunicativeMethodArgName](cops_naming.md#naminguncommunicativemethodargname)
+* [Naming/UncommunicativeMethodParamName](cops_naming.md#naminguncommunicativemethodparamname)
 * [Naming/VariableName](cops_naming.md#namingvariablename)
 * [Naming/VariableNumber](cops_naming.md#namingvariablenumber)
 

--- a/manual/cops_naming.md
+++ b/manual/cops_naming.md
@@ -414,13 +414,13 @@ AllowNamesEndingInNumbers | `true` | Boolean
 AllowedNames | `[]` | Array
 ForbiddenNames | `[]` | Array
 
-## Naming/UncommunicativeMethodArgName
+## Naming/UncommunicativeMethodParamName
 
 Enabled by default | Supports autocorrection
 --- | ---
 Enabled | No
 
-This cop checks method argument names for how descriptive they
+This cop checks method parameter names for how descriptive they
 are. It is highly configurable.
 
 The `MinNameLength` config option takes an integer. It represents

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -1518,7 +1518,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
         expect($stdout.string).to eq(<<-RESULT.strip_indent)
             == example/example1.rb ==
             C:  1: 11: Metrics/ParameterLists: Avoid parameter lists longer than 5 parameters. [6/5]
-            C:  1: 39: Naming/UncommunicativeMethodArgName: Method argument must be longer than 3 characters.
+            C:  1: 39: Naming/UncommunicativeMethodParamName: Method parameter must be longer than 3 characters.
             C:  1: 46: Style/CommentedKeyword: Do not place comments on the same line as the def keyword.
             E:  1: 81: Metrics/LineLength: Line is too long. [90/80]
 

--- a/spec/rubocop/cop/naming/uncommunicative_method_param_name_spec.rb
+++ b/spec/rubocop/cop/naming/uncommunicative_method_param_name_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::Naming::UncommunicativeMethodArgName, :config do
+RSpec.describe RuboCop::Cop::Naming::UncommunicativeMethodParamName, :config do
   subject(:cop) { described_class.new(config) }
 
   let(:cop_config) do
@@ -10,7 +10,7 @@ RSpec.describe RuboCop::Cop::Naming::UncommunicativeMethodArgName, :config do
     }
   end
 
-  it 'does not register for method without arguments' do
+  it 'does not register for method without parameters' do
     expect_no_offenses(<<-RUBY.strip_indent)
       def something
         do_stuff
@@ -18,7 +18,7 @@ RSpec.describe RuboCop::Cop::Naming::UncommunicativeMethodArgName, :config do
     RUBY
   end
 
-  it 'does not register offense for valid argument names' do
+  it 'does not register offense for valid parameter names' do
     expect_no_offenses(<<-RUBY.strip_indent)
       def something(foo, bar)
         do_stuff
@@ -26,7 +26,7 @@ RSpec.describe RuboCop::Cop::Naming::UncommunicativeMethodArgName, :config do
     RUBY
   end
 
-  it 'does not register offense for valid argument names on self.method' do
+  it 'does not register offense for valid parameter names on self.method' do
     expect_no_offenses(<<-RUBY.strip_indent)
       def self.something(foo, bar)
         do_stuff
@@ -34,7 +34,7 @@ RSpec.describe RuboCop::Cop::Naming::UncommunicativeMethodArgName, :config do
     RUBY
   end
 
-  it 'does not register offense for valid default arguments' do
+  it 'does not register offense for valid default parameters' do
     expect_no_offenses(<<-RUBY.strip_indent)
       def self.something(foo = Pwd.dir, bar = 1)
         do_stuff
@@ -42,7 +42,7 @@ RSpec.describe RuboCop::Cop::Naming::UncommunicativeMethodArgName, :config do
     RUBY
   end
 
-  it 'does not register offense for valid keyword arguments' do
+  it 'does not register offense for valid keyword parameters' do
     expect_no_offenses(<<-RUBY.strip_indent)
       def self.something(foo: Pwd.dir, bar: 1)
         do_stuff
@@ -50,55 +50,55 @@ RSpec.describe RuboCop::Cop::Naming::UncommunicativeMethodArgName, :config do
     RUBY
   end
 
-  it 'registers offense when argument ends in number' do
+  it 'registers offense when parameter ends in number' do
     expect_offense(<<-RUBY.strip_indent)
       def something(foo1, bar)
-                    ^^^^ Do not end method argument with a number.
+                    ^^^^ Do not end method parameter with a number.
         do_stuff
        end
     RUBY
   end
 
-  it 'registers offense when argument ends in number on class method' do
+  it 'registers offense when parameter ends in number on class method' do
     expect_offense(<<-RUBY.strip_indent)
       def self.something(foo, bar1)
-                              ^^^^ Do not end method argument with a number.
+                              ^^^^ Do not end method parameter with a number.
         do_stuff
        end
     RUBY
   end
 
-  it 'registers offense when argument is less than minimum length' do
+  it 'registers offense when parameter is less than minimum length' do
     expect_offense(<<-RUBY.strip_indent)
       def something(ab)
-                    ^^ Method argument must be longer than 3 characters.
+                    ^^ Method parameter must be longer than 3 characters.
         do_stuff
       end
     RUBY
   end
 
-  it 'registers offense when argument contains uppercase characters' do
+  it 'registers offense when parameter contains uppercase characters' do
     expect_offense(<<-RUBY.strip_indent)
       def something(number_One)
-                    ^^^^^^^^^^ Only use lowercase characters for method argument.
+                    ^^^^^^^^^^ Only use lowercase characters for method parameter.
         do_stuff
       end
     RUBY
   end
 
-  it 'registers offense for offensive default argument' do
+  it 'registers offense for offensive default parameter' do
     expect_offense(<<-RUBY.strip_indent)
       def self.something(foo1 = Pwd.dir)
-                         ^^^^ Do not end method argument with a number.
+                         ^^^^ Do not end method parameter with a number.
         do_stuff
       end
     RUBY
   end
 
-  it 'registers offense for offensive keyword arguments' do
+  it 'registers offense for offensive keyword parameters' do
     expect_offense(<<-RUBY.strip_indent)
       def something(fooBar:)
-                    ^^^^^^ Only use lowercase characters for method argument.
+                    ^^^^^^ Only use lowercase characters for method parameter.
         do_stuff
       end
     RUBY
@@ -112,9 +112,9 @@ RSpec.describe RuboCop::Cop::Naming::UncommunicativeMethodArgName, :config do
     RUBY
     expect(cop.offenses.size).to eq(3)
     expect(cop.messages).to eq [
-      'Method argument must be longer than 3 characters.',
-      'Do not end method argument with a number.',
-      'Only use lowercase characters for method argument.'
+      'Method parameter must be longer than 3 characters.',
+      'Do not end method parameter with a number.',
+      'Only use lowercase characters for method parameter.'
     ]
   end
 
@@ -137,7 +137,7 @@ RSpec.describe RuboCop::Cop::Naming::UncommunicativeMethodArgName, :config do
     it 'registers unlisted offensive names' do
       expect_offense(<<-RUBY.strip_indent)
         def quux(bar, bar1)
-                      ^^^^ Do not end method argument with a number.
+                      ^^^^ Do not end method parameter with a number.
           do_stuff
         end
       RUBY
@@ -151,19 +151,19 @@ RSpec.describe RuboCop::Cop::Naming::UncommunicativeMethodArgName, :config do
       }
     end
 
-    it 'registers offense for argument listed as forbidden' do
+    it 'registers offense for parameter listed as forbidden' do
       expect_offense(<<-RUBY.strip_indent)
         def baz(arg)
-                ^^^ Do not use arg as a name for a method argument.
+                ^^^ Do not use arg as a name for a method parameter.
           arg.do_things
         end
       RUBY
     end
 
-    it "accepts argument that uses a forbidden name's letters" do
+    it "accepts parameter that uses a forbidden name's letters" do
       expect_no_offenses(<<-RUBY.strip_indent)
-        def baz(foo_argument)
-          foo_argument.do_things
+        def baz(foo_parameter)
+          foo_parameter.do_things
         end
       RUBY
     end
@@ -176,7 +176,7 @@ RSpec.describe RuboCop::Cop::Naming::UncommunicativeMethodArgName, :config do
       }
     end
 
-    it 'accept arguments that end in numbers' do
+    it 'accept parameters that end in numbers' do
       expect_no_offenses(<<-RUBY.strip_indent)
         def something(foo1, bar2, qux3)
           do_stuff


### PR DESCRIPTION
As discussed in #5436 , this cop should be named `Naming/UncommunicativeMethodParamName` instead of `Naming/UncommunicativeMethodArgName`.  This topic is a byproduct of the discussion around the issue and does not warrant a `"[Fix]"`. Also, since it is unreleased, the CHANGELOG entry that announces the new cop is adjusted, vs adding a new entry.

-----------------

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
