### PR TITLE
[Fix #5448] Improve Rails/LexicallyScopedActionFilter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 * [#5287](https://github.com/bbatsov/rubocop/issues/5287): Do not register an offense in `Style/SafeNavigation` if there is an unsafe method used in a method chain. ([@rrosenblum][])
 * [#5401](https://github.com/bbatsov/rubocop/issues/5401): Fix `Style/RedundantReturn` to trigger when begin-end, rescue, and ensure blocks present. ([@asherkach][])
 * [#5426](https://github.com/bbatsov/rubocop/issues/5426): Make `Rails/InverseOf` accept `inverse_of: nil` to opt-out. ([@wata727][])
+* [#5448](https://github.com/bbatsov/rubocop/issues/5448): Improve `Rails/LexicallyScopedActionFilter`. ([@wata727][])
 
 ### Changes
 

--- a/manual/cops_rails.md
+++ b/manual/cops_rails.md
@@ -825,12 +825,12 @@ Enabled by default | Supports autocorrection
 Enabled | No
 
 This cop checks that methods specified in the filter's `only`
-or `except` options are explicitly defined in the controller.
+or `except` options are explicitly defined in the class or module.
 
 You can specify methods of superclass or methods added by mixins
 on the filter, but these confuse developers. If you specify methods
-where are defined on another controller, you should define the filter
-in that controller.
+where are defined on another classes or modules, you should define
+the filter in that class or module.
 
 ### Examples
 
@@ -854,6 +854,29 @@ class LoginController < ApplicationController
   end
 
   def logout
+  end
+end
+```
+```ruby
+# bad
+module FooMixin
+  extend ActiveSupport::Concern
+
+  included do
+    before_action proc { authenticate }, only: :foo
+  end
+end
+
+# good
+module FooMixin
+  extend ActiveSupport::Concern
+
+  included do
+    before_action proc { authenticate }, only: :foo
+  end
+
+  def foo
+    # something
   end
 end
 ```


### PR DESCRIPTION
Fixes #5448

In addition, I also made it possible to inspect modules like mixin.
See also https://github.com/bbatsov/rubocop/issues/5448#issuecomment-357245739

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
