### PR TITLE
[Fix #5453] Remove erroneous downcases during casecmp auto-correct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 ### Bug fixes
 
 * [#4105](https://github.com/bbatsov/rubocop/issues/4105): Fix `Lint/IndentationWidth` when `Lint/EndAlignment` is configured with `start_of_line`. ([@brandonweiss][])
+* [#5453](https://github.com/bbatsov/rubocop/issues/5453): Fix erroneous downcase in `Performance/Casecmp` auto-correction. ([@walinga][])
 * [#5343](https://github.com/bbatsov/rubocop/issues/5343): Fix offense detection in `Style/TrailingMethodEndStatement`. ([@garettarrowood][])
 * [#5334](https://github.com/bbatsov/rubocop/issues/5334): Fix semicolon removal for `Style/TrailingBodyOnMethodDefinition` autocorrection. ([@garettarrowood][])
 * [#5350](https://github.com/bbatsov/rubocop/issues/5350): Fix `Metric/LineLength` false offenses for URLs in double quotes. ([@garettarrowood][])
@@ -3181,3 +3182,4 @@
 [@albertpaulp]: https://github.com/albertpaulp
 [@orgads]: https://github.com/orgads
 [@leklund]: https://github.com/leklund
+[@walinga]: https://github.com/walinga

--- a/spec/rubocop/cop/performance/casecmp_spec.rb
+++ b/spec/rubocop/cop/performance/casecmp_spec.rb
@@ -72,12 +72,12 @@ RSpec.describe RuboCop::Cop::Performance::Casecmp do
 
     it "autocorrects obj.#{selector} == str.#{selector}" do
       new_source = autocorrect_source("obj.#{selector} == str.#{selector}")
-      expect(new_source).to eq "obj.casecmp(str.#{selector}).zero?"
+      expect(new_source).to eq 'obj.casecmp(str).zero?'
     end
 
     it "autocorrects obj.#{selector} eql? str.#{selector}" do
       new_source = autocorrect_source("obj.#{selector}.eql? str.#{selector}")
-      expect(new_source).to eq "obj.casecmp(str.#{selector}).zero?"
+      expect(new_source).to eq 'obj.casecmp(str).zero?'
     end
 
     it "formats the error message correctly for str.#{selector} ==" do


### PR DESCRIPTION
Fixes #5453 by checking if the strings on both sides of the comparison operator have `#downcase` called on them. This allows us to grab both individual strings before we pass it on to the corrector method.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
