### PR TITLE
Correct indentation on Documentation example

### DIFF
--- a/manual/development.md
+++ b/manual/development.md
@@ -302,48 +302,48 @@ module Department
   # configs with these value types.
   #
   # @example EnforcedStyle: bar
-  #    # Description about this particular option
+  #   # Description about this particular option
   #
-  #    # bad
-  #    bad_example1
-  #    bad_example2
+  #   # bad
+  #   bad_example1
+  #   bad_example2
   #
-  #    # good
-  #    good_example1
-  #    good_example2
+  #   # good
+  #   good_example1
+  #   good_example2
   #
   # @example EnforcedStyle: foo (default)
-  #    # Description about this particular option
+  #   # Description about this particular option
   #
-  #    # bad
-  #    bad_example1
-  #    bad_example2
+  #   # bad
+  #   bad_example1
+  #   bad_example2
   #
-  #    # good
-  #    good_example1
-  #    good_example2
+  #   # good
+  #   good_example1
+  #   good_example2
   #
   # @example AnyUniqueConfigKeyThatIsAString: qux (default)
-  #    # Description about this particular option
+  #   # Description about this particular option
   #
-  #    # bad
-  #    bad_example1
-  #    bad_example2
+  #   # bad
+  #   bad_example1
+  #   bad_example2
   #
-  #    # good
-  #    good_example1
-  #    good_example2
+  #   # good
+  #   good_example1
+  #   good_example2
   #
   # @example AnyUniqueConfigKeyThatIsAString: thud
-  #    # Description about this particular option
+  #   # Description about this particular option
   #
-  #    # bad
-  #    bad_example1
-  #    bad_example2
+  #   # bad
+  #   bad_example1
+  #   bad_example2
   #
-  #    # good
-  #    good_example1
-  #    good_example2
+  #   # good
+  #   good_example1
+  #   good_example2
   #
   class YourCop
     # ...


### PR DESCRIPTION
I'm not sure how I overlooked this when creating the `Documentation` example. But it appears the indentation is off by one char.  This PR corrects it.

-----------------

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
