### PR TITLE
[Fix #3947] Fix a false positive for `Rails/FilePath`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 * [#5401](https://github.com/bbatsov/rubocop/issues/5401): Fix `Style/RedundantReturn` to trigger when begin-end, rescue, and ensure blocks present. ([@asherkach][])
 * [#5426](https://github.com/bbatsov/rubocop/issues/5426): Make `Rails/InverseOf` accept `inverse_of: nil` to opt-out. ([@wata727][])
 * [#5448](https://github.com/bbatsov/rubocop/issues/5448): Improve `Rails/LexicallyScopedActionFilter`. ([@wata727][])
+* [#3947](https://github.com/bbatsov/rubocop/issues/3947): Fix false positive for `Rails/FilePath` when using `Rails.root.join` in string interpolation of argument. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/rails/file_path.rb
+++ b/lib/rubocop/cop/rails/file_path.rb
@@ -32,7 +32,11 @@ module RuboCop
         PATTERN
 
         def on_dstr(node)
-          return unless rails_root_nodes?(node)
+          unless node.children.last.source.start_with?('.')
+            return if rails_root_nodes?(node) &&
+                      !node.children.last.source.include?(File::SEPARATOR)
+          end
+
           register_offense(node)
         end
 

--- a/spec/rubocop/cop/rails/file_path_spec.rb
+++ b/spec/rubocop/cop/rails/file_path_spec.rb
@@ -9,6 +9,12 @@ RSpec.describe RuboCop::Cop::Rails::FilePath do
     end
   end
 
+  context 'when using Rails.root.join in string interpolation of argument' do
+    it 'does not registers an offense' do
+      expect_no_offenses('system "rm -rf #{Rails.root.join(\'a\', \'b.png\')}"')
+    end
+  end
+
   context 'when using File.join with Rails.root' do
     it 'registers an offense' do
       expect_offense(<<-RUBY.strip_indent)
@@ -32,6 +38,26 @@ RSpec.describe RuboCop::Cop::Rails::FilePath do
       expect_offense(<<-'RUBY'.strip_indent)
         "#{Rails.root}/app/models/goober"
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Please use `Rails.root.join('path', 'to')` instead.
+      RUBY
+    end
+  end
+
+  context 'when concat Rails.root and file separator ' \
+          'using string interpolation' do
+    it 'registers an offense' do
+      expect_offense(<<-'RUBY'.strip_indent)
+        system "rm -rf #{Rails.root}/foo/bar"
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Please use `Rails.root.join('path', 'to')` instead.
+      RUBY
+    end
+  end
+
+  context 'when concat Rails.root.join and extension ' \
+          'using string interpolation' do
+    it 'registers an offense' do
+      expect_offense(<<-'RUBY'.strip_indent)
+        "#{Rails.root.join('tmp', user.id, 'icon')}.png"
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Please use `Rails.root.join('path', 'to')` instead.
       RUBY
     end
   end


### PR DESCRIPTION
Fixes #3947 and Fixes #3974.

This PR is the takeover of #4178. It fixes a false positive for `Rails/FilePath` when using `Rails.root.join` in string interpolation of argument.

In addition, the following review comments are reflected in the test cases.

- https://github.com/bbatsov/rubocop/pull/4178#issuecomment-290312263
- https://github.com/bbatsov/rubocop/pull/4178#issuecomment-290398109

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
