### PR TITLE
[Fix #5436] Allow empty rest args in UncommunicativeName cops

### DIFF
--- a/lib/rubocop/cop/mixin/uncommunicative_name.rb
+++ b/lib/rubocop/cop/mixin/uncommunicative_name.rb
@@ -14,6 +14,7 @@ module RuboCop
       def check(node, args)
         args.each do |arg|
           name = arg.children.first.to_s
+          next if arg.restarg_type? && name.empty?
           next if allowed_names.include?(name)
           range = arg_range(arg, name.size)
           issue_offenses(node, range, name)

--- a/spec/rubocop/cop/naming/uncommunicative_method_param_name_spec.rb
+++ b/spec/rubocop/cop/naming/uncommunicative_method_param_name_spec.rb
@@ -50,6 +50,14 @@ RSpec.describe RuboCop::Cop::Naming::UncommunicativeMethodParamName, :config do
     RUBY
   end
 
+  it 'does not register offense for empty restarg' do
+    expect_no_offenses(<<-RUBY.strip_indent)
+      def qux(*)
+        stuff!
+      end
+    RUBY
+  end
+
   it 'registers offense when parameter ends in number' do
     expect_offense(<<-RUBY.strip_indent)
       def something(foo1, bar)


### PR DESCRIPTION
Allows empty rest args in UncommunicativeName cops. As @pocke pointed out [here](https://github.com/bbatsov/rubocop/pull/5442#discussion_r161149010), `*` rest arguments do not have names. So adding the symbol as a whitelisted name does not work.

Since this is a standard/valid way to pass args to `super`, I haven't added a config option for it. I've just internally always allowed it.

Since this cop is unreleased, I've not added a CHANGELOG entry.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
