### PR TITLE
Update an examples for `Layout/TrailingBlankLines`

### DIFF
--- a/lib/rubocop/cop/layout/trailing_blank_lines.rb
+++ b/lib/rubocop/cop/layout/trailing_blank_lines.rb
@@ -12,16 +12,13 @@ module RuboCop
       #
       #   # bad
       #   class Foo; end
-      #
       #   # EOF
       #
       #   # bad
-      #   class Foo; end
-      #   # EOF
+      #   class Foo; end # EOF
       #
       #   # good
       #   class Foo; end
-      #   # a blank line
       #
       #   # EOF
       #
@@ -30,17 +27,14 @@ module RuboCop
       #
       #   # bad
       #   class Foo; end
-      #   # a blank line
       #
       #   # EOF
       #
       #   # bad
-      #   class Foo; end
-      #   # EOF
+      #   class Foo; end # EOF
       #
       #   # good
       #   class Foo; end
-      #
       #   # EOF
       #
       class TrailingBlankLines < Cop

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -3782,16 +3782,13 @@ source code.
 
 # bad
 class Foo; end
-
 # EOF
 
 # bad
-class Foo; end
-# EOF
+class Foo; end # EOF
 
 # good
 class Foo; end
-# a blank line
 
 # EOF
 ```
@@ -3802,17 +3799,14 @@ class Foo; end
 
 # bad
 class Foo; end
-# a blank line
 
 # EOF
 
 # bad
-class Foo; end
-# EOF
+class Foo; end # EOF
 
 # good
 class Foo; end
-
 # EOF
 ```
 


### PR DESCRIPTION
Follow up of #5416.

This commit is a change of document for `Layout/TrailingBlankLines` cop.
It changed the line feed position of EOF.

Take the default `EnforcedStyle: final_newline (default)` as an example. The following is the result of executing the rubocop command after adjusting the line feed position.

## bad

```console
% echo "class Foo; end\n" > /tmp/example.rb && rubocop --only Layout/TrailingBlankLines /tmp/example.rb
Inspecting 1 file
C

Offenses:

/tmp/example.rb:2:1: C: Layout/TrailingBlankLines: 1 trailing blank
lines detected.

1 file inspected, 1 offense detected
```

The example of this bad case is as follows.

```ruby
class Foo; end

# EOF
```

## bad

```console
% echo "class Foo; end" | tr -d "\n" > /tmp/example.rb && rubocop --only Layout/TrailingBlankLines /tmp/example.rb
Inspecting 1 file
C

Offenses:

/tmp/example.rb:1:15: C: Layout/TrailingBlankLines: Final newline
missing.
class Foo; end

1 file inspected, 1 offense detected
```

The example of this bad case is as follows.

```ruby
class Foo; end # EOF
```

## good

```console
% echo "class Foo; end" > /tmp/example.rb && rubocop --only Layout/TrailingBlankLines /tmp/example.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
```

The example of this good case is as follows.

```ruby
class Foo; end
# EOF
```

---

I thought that such a document is good as a representation of visual EOF position.

@garettarrowood What do you think?

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
