### PR TITLE
Fix `Lint/IndentationWidth` when `Lint/EndAlignment` is configured with `start_of_line`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### Bug fixes
 
+* [#4105](https://github.com/bbatsov/rubocop/issues/4105): Fix `Lint/IndentationWidth` when `Lint/EndAlignment` is configured with `start_of_line`. ([@brandonweiss][])
 * [#5343](https://github.com/bbatsov/rubocop/issues/5343): Fix offense detection in `Style/TrailingMethodEndStatement`. ([@garettarrowood][])
 * [#5334](https://github.com/bbatsov/rubocop/issues/5334): Fix semicolon removal for `Style/TrailingBodyOnMethodDefinition` autocorrection. ([@garettarrowood][])
 * [#5350](https://github.com/bbatsov/rubocop/issues/5350): Fix `Metric/LineLength` false offenses for URLs in double quotes. ([@garettarrowood][])

--- a/lib/rubocop/cop/mixin/end_keyword_alignment.rb
+++ b/lib/rubocop/cop/mixin/end_keyword_alignment.rb
@@ -55,8 +55,12 @@ module RuboCop
       end
 
       def variable_alignment?(whole_expression, rhs, end_alignment_style)
-        end_alignment_style == :variable &&
+        case end_alignment_style
+        when :variable
           !line_break_before_keyword?(whole_expression, rhs)
+        when :start_of_line
+          true
+        end
       end
 
       def line_break_before_keyword?(whole_expression, rhs)

--- a/spec/rubocop/cop/layout/indentation_width_spec.rb
+++ b/spec/rubocop/cop/layout/indentation_width_spec.rb
@@ -385,7 +385,7 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth do
       end
 
       context 'with assignment' do
-        context 'when alignment style is variable' do
+        shared_examples 'assignment with if statement' do
           context 'and end is aligned with variable' do
             it 'accepts an if with end aligned with setter' do
               expect_no_offenses(<<-RUBY.strip_indent)
@@ -537,7 +537,27 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth do
           end
         end
 
-        shared_examples 'assignment and if with keyword alignment' do
+        context 'when alignment style is variable' do
+          let(:end_alignment_config) do
+            { 'Enabled' => true, 'EnforcedStyleAlignWith' => 'variable' }
+          end
+
+          include_examples 'assignment with if statement'
+        end
+
+        context 'when alignment style is start_of_line' do
+          let(:end_alignment_config) do
+            { 'Enabled' => true, 'EnforcedStyleAlignWith' => 'start_of_line' }
+          end
+
+          include_examples 'assignment with if statement'
+        end
+
+        context 'when alignment style is keyword' do
+          let(:end_alignment_config) do
+            { 'Enabled' => true, 'EnforcedStyleAlignWith' => 'keyword' }
+          end
+
           context 'and end is aligned with variable' do
             it 'registers an offense for an if' do
               inspect_source(<<-RUBY.strip_indent)
@@ -628,14 +648,6 @@ RSpec.describe RuboCop::Cop::Layout::IndentationWidth do
               RUBY
             end
           end
-        end
-
-        context 'when alignment style is keyword by choice' do
-          let(:end_alignment_config) do
-            { 'Enabled' => true, 'EnforcedStyleAlignWith' => 'keyword' }
-          end
-
-          include_examples 'assignment and if with keyword alignment'
         end
       end
 


### PR DESCRIPTION
Fix #4105 and continue the closed PR #4652

I added the tests and @satyap figured out the fix!

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/