### PR TITLE
Ignore .ruby-version file in git management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ doc
 Gemfile.lock
 Gemfile.local
 
+# rbenv
+.ruby-version
+
 # rspec
 /spec/examples.txt
 /.test_queue_stats


### PR DESCRIPTION
In development of RuboCop that supports multiple Ruby versions, I think that it is better to ignore .ruby-version in git management.
