### PR TITLE
[Fix #5050] Add auto-correction to Style/ModuleFunction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * [#3394](https://github.com/bbatsov/rubocop/issues/3394): Add new `Style/TrailingCommmaInHashLiteral` cop. ([@garettarrowood][])
 * [#5319](https://github.com/bbatsov/rubocop/pull/5319): Add new `Security/Open` cop. ([@mame][])
 * Add `EnforcedStyleForEmptyBrackets` configuration to `Layout/SpaceInsideReferenceBrackets`.([@garettarrowood][])
+* [#5050](https://github.com/bbatsov/rubocop/issues/5050): Add auto-correction to `Style/ModuleFunction`. ([@garettarrowood][])
 * [#5358](https://github.com/bbatsov/rubocop/pull/5358):  `--no-auto-gen-timestamp` CLI option suppresses the inclusion of the date and time it was generated in auto-generated config. ([@dominicsayers][])
 
 ### Bug fixes

--- a/lib/rubocop/cop/style/module_function.rb
+++ b/lib/rubocop/cop/style/module_function.rb
@@ -56,6 +56,16 @@ module RuboCop
           end
         end
 
+        def autocorrect(node)
+          lambda do |corrector|
+            if extend_self_node?(node)
+              corrector.replace(node.source_range, 'module_function')
+            else
+              corrector.replace(node.source_range, 'extend self')
+            end
+          end
+        end
+
         private
 
         def each_wrong_style(nodes)

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -3037,7 +3037,7 @@ end
 
 Enabled by default | Supports autocorrection
 --- | ---
-Enabled | No
+Enabled | Yes
 
 This cops checks for use of `extend self` or `module_function` in a
 module.

--- a/spec/rubocop/cop/style/module_function_spec.rb
+++ b/spec/rubocop/cop/style/module_function_spec.rb
@@ -23,6 +23,22 @@ RSpec.describe RuboCop::Cop::Style::ModuleFunction, :config do
         end
       RUBY
     end
+
+    it 'auto-corrects `extend self` to `module_function`' do
+      source = <<-RUBY.strip_indent
+        module Foo
+          extend self
+          def test; end
+        end
+      RUBY
+      corrected = autocorrect_source(source)
+      expect(corrected).to eq <<-RUBY.strip_indent
+        module Foo
+          module_function
+          def test; end
+        end
+      RUBY
+    end
   end
 
   context 'when enforced style is `extend_self`' do
@@ -43,6 +59,22 @@ RSpec.describe RuboCop::Cop::Style::ModuleFunction, :config do
         module Test
           def test; end
           module_function :test
+        end
+      RUBY
+    end
+
+    it 'auto-corrects `module_function` to `extend self`' do
+      source = <<-RUBY.strip_indent
+        module Foo
+          module_function
+          def test; end
+        end
+      RUBY
+      corrected = autocorrect_source(source)
+      expect(corrected).to eq <<-RUBY.strip_indent
+        module Foo
+          extend self
+          def test; end
         end
       RUBY
     end


### PR DESCRIPTION
Adds auto-correction to `Style/ModuleFunction` as final 'fix' to issue #5050 .

-----------------

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
