### PR TITLE
Centralize `node_parts` method to node.rb

### DIFF
--- a/lib/rubocop/ast/node.rb
+++ b/lib/rubocop/ast/node.rb
@@ -111,6 +111,16 @@ module RuboCop
         parent.children.index { |sibling| sibling.equal?(self) }
       end
 
+      # Common destructuring method. This can be used to normalize
+      # destructuring for different variations of the node.
+      # Some node types override this with their own custom
+      # destructuring method.
+      #
+      # @return [Array<Node>] the different parts of the ndde
+      def node_parts
+        to_a
+      end
+
       # Calls the given block for each ancestor node from parent to root.
       # If no block is given, an `Enumerator` is returned.
       #

--- a/lib/rubocop/ast/node/and_node.rb
+++ b/lib/rubocop/ast/node/and_node.rb
@@ -24,14 +24,6 @@ module RuboCop
       def inverse_operator
         logical_operator? ? LOGICAL_OR : SEMANTIC_OR
       end
-
-      # Custom destructuring method. This can be used to normalize
-      # destructuring for different variations of the node.
-      #
-      # @return [Array<Node>] the different parts of the `and` predicate
-      def node_parts
-        to_a
-      end
     end
   end
 end

--- a/lib/rubocop/ast/node/block_node.rb
+++ b/lib/rubocop/ast/node/block_node.rb
@@ -103,14 +103,6 @@ module RuboCop
       def void_context?
         VOID_CONTEXT_METHODS.include?(send_node.method_name)
       end
-
-      # Custom destructuring method. This can be used to normalize
-      # destructuring for different variations of the node.
-      #
-      # @return [Array] the different parts of the `block` node
-      def node_parts
-        to_a
-      end
     end
   end
 end

--- a/lib/rubocop/ast/node/case_node.rb
+++ b/lib/rubocop/ast/node/case_node.rb
@@ -51,14 +51,6 @@ module RuboCop
       def else?
         loc.else
       end
-
-      # Custom destructuring method. This can be used to normalize
-      # destructuring for different variations of the node.
-      #
-      # @return [Array<Node>] the different parts of the `case` statement
-      def node_parts
-        to_a
-      end
     end
   end
 end

--- a/lib/rubocop/ast/node/ensure_node.rb
+++ b/lib/rubocop/ast/node/ensure_node.rb
@@ -12,14 +12,6 @@ module RuboCop
       def body
         node_parts[1]
       end
-
-      # Custom destructuring method. This can be used to normalize
-      # destructuring for different variations of the node.
-      #
-      # @return [Array<Node>] the different parts of the `ensure` statement
-      def node_parts
-        to_a
-      end
     end
   end
 end

--- a/lib/rubocop/ast/node/for_node.rb
+++ b/lib/rubocop/ast/node/for_node.rb
@@ -48,14 +48,6 @@ module RuboCop
       def body
         node_parts[2]
       end
-
-      # Custom destructuring method. This can be used to normalize
-      # destructuring for different variations of the node.
-      #
-      # @return [Array<Node>] the different parts of the `until` statement
-      def node_parts
-        to_a
-      end
     end
   end
 end

--- a/lib/rubocop/ast/node/or_node.rb
+++ b/lib/rubocop/ast/node/or_node.rb
@@ -24,14 +24,6 @@ module RuboCop
       def inverse_operator
         logical_operator? ? LOGICAL_AND : SEMANTIC_AND
       end
-
-      # Custom destructuring method. This can be used to normalize
-      # destructuring for different variations of the node.
-      #
-      # @return [Array<Node>] the different parts of the `or` predicate
-      def node_parts
-        to_a
-      end
     end
   end
 end

--- a/lib/rubocop/ast/node/pair_node.rb
+++ b/lib/rubocop/ast/node/pair_node.rb
@@ -51,14 +51,6 @@ module RuboCop
           hash_rocket? ? COLON : HASH_ROCKET
         end
       end
-
-      # Custom destructuring method. This is used to normalize the branches
-      # for `pair` and `kwsplat` nodes, to add duck typing to `hash` elements.
-      #
-      # @return [Array<Node>] the different parts of the `pair`
-      def node_parts
-        to_a
-      end
     end
   end
 end

--- a/lib/rubocop/ast/node/resbody_node.rb
+++ b/lib/rubocop/ast/node/resbody_node.rb
@@ -12,14 +12,6 @@ module RuboCop
       def body
         node_parts[2]
       end
-
-      # Custom destructuring method. This can be used to normalize
-      # destructuring for different variations of the node.
-      #
-      # @return [Array<Node>] the different parts of the `resbody` statement
-      def node_parts
-        to_a
-      end
     end
   end
 end

--- a/lib/rubocop/ast/node/send_node.rb
+++ b/lib/rubocop/ast/node/send_node.rb
@@ -10,14 +10,6 @@ module RuboCop
       include MethodDispatchNode
       ARROW = '->'.freeze
 
-      # Custom destructuring method. This can be used to normalize
-      # destructuring for different variations of the node.
-      #
-      # @return [Array] the different parts of the `send` node
-      def node_parts
-        to_a
-      end
-
       # Checks whether this is a negation method, i.e. `!` or keyword `not`.
       #
       # @return [Boolean] whether this method is a negation method

--- a/lib/rubocop/ast/node/symbol_node.rb
+++ b/lib/rubocop/ast/node/symbol_node.rb
@@ -7,14 +7,6 @@ module RuboCop
     # available to all `sym` nodes within RuboCop.
     class SymbolNode < Node
       include BasicLiteralNode
-
-      # Custom destructuring method. This can be used to normalize
-      # destructuring for different variations of the node.
-      #
-      # @return [Array] the different parts of the `sym` node
-      def node_parts
-        to_a
-      end
     end
   end
 end

--- a/lib/rubocop/ast/node/until_node.rb
+++ b/lib/rubocop/ast/node/until_node.rb
@@ -30,14 +30,6 @@ module RuboCop
       def do?
         loc.begin && loc.begin.is?('do')
       end
-
-      # Custom destructuring method. This can be used to normalize
-      # destructuring for different variations of the node.
-      #
-      # @return [Array<Node>] the different parts of the `until` statement
-      def node_parts
-        to_a
-      end
     end
   end
 end

--- a/lib/rubocop/ast/node/when_node.rb
+++ b/lib/rubocop/ast/node/when_node.rb
@@ -48,14 +48,6 @@ module RuboCop
       def body
         node_parts[-1]
       end
-
-      # Custom destructuring method. This can be used to normalize
-      # destructuring for different variations of the node.
-      #
-      # @return [Array<Node>] the different parts of the `until` statement
-      def node_parts
-        to_a
-      end
     end
   end
 end

--- a/lib/rubocop/ast/node/while_node.rb
+++ b/lib/rubocop/ast/node/while_node.rb
@@ -30,14 +30,6 @@ module RuboCop
       def do?
         loc.begin && loc.begin.is?('do')
       end
-
-      # Custom destructuring method. This can be used to normalize
-      # destructuring for different variations of the node.
-      #
-      # @return [Array<Node>] the different parts of the `while` statement
-      def node_parts
-        to_a
-      end
     end
   end
 end


### PR DESCRIPTION
This PR moves the standard implementation of `node_parts` directly into `node.rb`. There are a handful of nodes that define this method differently. These were all left intact.

There will be a follow up PR to centralize `body` in a similar fashion.  At that time, it will be possible for me to refactor a new `TrailingBody` mixin (where the `body` of a `class` and `module` are derived). I will also scan for other places where non-typed nodes craft `body` functionality in cops/mixins and refactor accordingly.

-----------------

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
