### PR TITLE
[Fix #5479] Fix false positives for `Rails/Presence`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 * [#5426](https://github.com/bbatsov/rubocop/issues/5426): Make `Rails/InverseOf` accept `inverse_of: nil` to opt-out. ([@wata727][])
 * [#5448](https://github.com/bbatsov/rubocop/issues/5448): Improve `Rails/LexicallyScopedActionFilter`. ([@wata727][])
 * [#3947](https://github.com/bbatsov/rubocop/issues/3947): Fix false positive for `Rails/FilePath` when using `Rails.root.join` in string interpolation of argument. ([@koic][])
+* [#5479](https://github.com/bbatsov/rubocop/issues/5479): Fix false positives for `Rails/Presence` when using with `elsif`. ([@wata727][])
 
 ### Changes
 

--- a/lib/rubocop/cop/rails/presence.rb
+++ b/lib/rubocop/cop/rails/presence.rb
@@ -71,6 +71,8 @@ module RuboCop
         PATTERN
 
         def on_if(node)
+          return if ignore_if_node?(node)
+
           redundant_receiver_and_other(node) do |receiver, other|
             unless ignore_other_node?(other) || receiver.nil?
               add_offense(node, message: message(node, receiver, other))
@@ -97,6 +99,10 @@ module RuboCop
         end
 
         private
+
+        def ignore_if_node?(node)
+          node.elsif?
+        end
 
         def ignore_other_node?(node)
           node && (node.if_type? || node.rescue_type? || node.while_type?)

--- a/spec/rubocop/cop/rails/presence_spec.rb
+++ b/spec/rubocop/cop/rails/presence_spec.rb
@@ -50,6 +50,14 @@ RSpec.describe RuboCop::Cop::Rails::Presence do
     end
   RUBY
 
+  it_behaves_like :offense, <<-RUBY.strip_indent.chomp, 'a.presence', 1, 5
+    unless a.present?
+      nil
+    else
+      a
+    end
+  RUBY
+
   it_behaves_like :offense, 'a if a.present?', 'a.presence', 1, 1
   it_behaves_like :offense, 'a unless a.blank?', 'a.presence', 1, 1
   it_behaves_like :offense, <<-RUBY.strip_indent.chomp, <<-FIXED.strip_indent.chomp, 1, 7 # rubocop:disable Metrics/LineLength
@@ -161,6 +169,16 @@ RSpec.describe RuboCop::Cop::Rails::Presence do
         a
       else
         fetch_state while waiting?
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when using #present? with elsif block' do
+    expect_no_offenses(<<-RUBY.strip_indent)
+      if something?
+        a
+      elsif b.present?
+        b
       end
     RUBY
   end


### PR DESCRIPTION
Fixes #5479

`elsif` and` unless` are treated as `if` node. However, if using `present?` with `elsif`, this cop corrupts code by auto-correction.

So change it to ignore the `elsif` node.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
