### PR TITLE
[#5069] Apply annotated string templates to collection of cops

### DIFF
--- a/lib/rubocop/cop/layout/block_alignment.rb
+++ b/lib/rubocop/cop/layout/block_alignment.rb
@@ -65,7 +65,7 @@ module RuboCop
         include ConfigurableEnforcedStyle
         include RangeHelp
 
-        MSG = '%s is not aligned with %s%s.'.freeze
+        MSG = '%<current>s is not aligned with %<prefer>s%<alt_prefer>s.'.freeze
 
         def_node_matcher :block_end_align_target?, <<-PATTERN
           {assignment?
@@ -170,9 +170,11 @@ module RuboCop
                            error_source_line_column)
           format(
             MSG,
-            format_source_line_column(loc_to_source_line_column(end_loc)),
-            format_source_line_column(error_source_line_column),
-            alt_start_msg(start_loc, do_source_line_column)
+            current: format_source_line_column(
+              loc_to_source_line_column(end_loc)
+            ),
+            prefer: format_source_line_column(error_source_line_column),
+            alt_prefer: alt_start_msg(start_loc, do_source_line_column)
           )
         end
 

--- a/lib/rubocop/cop/layout/space_inside_hash_literal_braces.rb
+++ b/lib/rubocop/cop/layout/space_inside_hash_literal_braces.rb
@@ -67,7 +67,7 @@ module RuboCop
         include ConfigurableEnforcedStyle
         include RangeHelp
 
-        MSG = 'Space inside %s.'.freeze
+        MSG = 'Space inside %<problem>s.'.freeze
 
         def on_hash(node)
           tokens = processed_source.tokens
@@ -174,7 +174,7 @@ module RuboCop
                           brace.source
                         end
           problem = expect_space ? 'missing' : 'detected'
-          format(MSG, "#{inside_what} #{problem}")
+          format(MSG, problem: "#{inside_what} #{problem}")
         end
 
         def space_range(token_range)

--- a/lib/rubocop/cop/layout/trailing_blank_lines.rb
+++ b/lib/rubocop/cop/layout/trailing_blank_lines.rb
@@ -109,8 +109,8 @@ module RuboCop
                          else
                            "instead of #{wanted_blank_lines} "
                          end
-            format('%d trailing blank lines %sdetected.', blank_lines,
-                   instead_of)
+            format('%<current>d trailing blank lines %<prefer>sdetected.',
+                   current: blank_lines, prefer: instead_of)
           end
         end
       end

--- a/lib/rubocop/cop/lint/ambiguous_block_association.rb
+++ b/lib/rubocop/cop/lint/ambiguous_block_association.rb
@@ -25,8 +25,9 @@ module RuboCop
       #   # Lambda arguments require no disambiguation
       #   foo = ->(bar) { bar.baz }
       class AmbiguousBlockAssociation < Cop
-        MSG = 'Parenthesize the param `%s` to make sure that the block will be'\
-              ' associated with the `%s` method call.'.freeze
+        MSG = 'Parenthesize the param `%<param>s` to make sure that the ' \
+              'block will be associated with the `%<method>s` method ' \
+              'call.'.freeze
 
         def on_send(node)
           return if !node.arguments? || node.parenthesized? ||
@@ -51,7 +52,8 @@ module RuboCop
         def message(send_node)
           block_param = send_node.last_argument
 
-          format(MSG, block_param.source, block_param.send_node.source)
+          format(MSG, param: block_param.source,
+                      method: block_param.send_node.source)
         end
       end
     end

--- a/lib/rubocop/cop/lint/boolean_symbol.rb
+++ b/lib/rubocop/cop/lint/boolean_symbol.rb
@@ -23,14 +23,14 @@ module RuboCop
       #   false
       class BooleanSymbol < Cop
         MSG = 'Symbol with a boolean name - ' \
-              'you probably meant to use `%s`.'.freeze
+              'you probably meant to use `%<boolean>s`.'.freeze
 
         def_node_matcher :boolean_symbol?, '(sym {:true :false})'
 
         def on_sym(node)
           return unless boolean_symbol?(node)
 
-          add_offense(node, message: format(MSG, node.value))
+          add_offense(node, message: format(MSG, boolean: node.value))
         end
       end
     end

--- a/lib/rubocop/cop/lint/circular_argument_reference.rb
+++ b/lib/rubocop/cop/lint/circular_argument_reference.rb
@@ -48,7 +48,7 @@ module RuboCop
       #     dry_ingredients.combine
       #   end
       class CircularArgumentReference < Cop
-        MSG = 'Circular argument reference - `%s`.'.freeze
+        MSG = 'Circular argument reference - `%<arg_name>s`.'.freeze
 
         def on_kwoptarg(node)
           check_for_circular_argument_references(*node)
@@ -64,7 +64,7 @@ module RuboCop
           return unless arg_value.lvar_type?
           return unless arg_value.to_a == [arg_name]
 
-          add_offense(arg_value, message: format(MSG, arg_name))
+          add_offense(arg_value, message: format(MSG, arg_name: arg_name))
         end
       end
     end

--- a/lib/rubocop/cop/lint/debugger.rb
+++ b/lib/rubocop/cop/lint/debugger.rb
@@ -33,7 +33,7 @@ module RuboCop
       #     do_something
       #   end
       class Debugger < Cop
-        MSG = 'Remove debugger entry point `%s`.'.freeze
+        MSG = 'Remove debugger entry point `%<source>s`.'.freeze
 
         def_node_matcher :kernel?, <<-PATTERN
           {
@@ -67,7 +67,7 @@ module RuboCop
         private
 
         def message(node)
-          format(MSG, node.source)
+          format(MSG, source: node.source)
         end
 
         def binding_irb?(node)

--- a/lib/rubocop/cop/lint/deprecated_class_methods.rb
+++ b/lib/rubocop/cop/lint/deprecated_class_methods.rb
@@ -39,7 +39,7 @@ module RuboCop
           end
         end
 
-        MSG = '`%s` is deprecated in favor of `%s`.'.freeze
+        MSG = '`%<current>s` is deprecated in favor of `%<prefer>s`.'.freeze
         DEPRECATED_METHODS_OBJECT = [
           DeprecatedClassMethod.new(:File, :exists?, :exist?),
           DeprecatedClassMethod.new(:Dir, :exists?, :exist?)
@@ -47,8 +47,8 @@ module RuboCop
 
         def on_send(node)
           check(node) do |data|
-            message = format(MSG, deprecated_method(data),
-                             replacement_method(data))
+            message = format(MSG, current: deprecated_method(data),
+                                  prefer: replacement_method(data))
 
             add_offense(node, location: :selector, message: message)
           end
@@ -82,7 +82,8 @@ module RuboCop
         end
 
         def method_call(class_constant, method)
-          format('%s.%s', class_constant, method)
+          format('%<constant>s.%<method>s', constant: class_constant,
+                                            method: method)
         end
       end
     end

--- a/lib/rubocop/cop/lint/duplicate_methods.rb
+++ b/lib/rubocop/cop/lint/duplicate_methods.rb
@@ -40,7 +40,8 @@ module RuboCop
       #     2
       #   end
       class DuplicateMethods < Cop
-        MSG = 'Method `%s` is defined at both %s and %s.'.freeze
+        MSG = 'Method `%<method>s` is defined at both %<defined>s and ' \
+              '%<current>s.'.freeze
 
         def initialize(config = nil, options = nil)
           super
@@ -121,8 +122,8 @@ module RuboCop
         end
 
         def message_for_dup(node, method_name)
-          format(MSG, method_name, @definitions[method_name],
-                 source_location(node))
+          format(MSG, method: method_name, defined: @definitions[method_name],
+                      current: source_location(node))
         end
 
         def found_instance_method(node, name)

--- a/lib/rubocop/cop/lint/format_parameter_mismatch.rb
+++ b/lib/rubocop/cop/lint/format_parameter_mismatch.rb
@@ -20,8 +20,8 @@ module RuboCop
       #   format('A value: %s and another: %i', a_value, another)
       class FormatParameterMismatch < Cop
         # http://rubular.com/r/CvpbxkcTzy
-        MSG = "Number of arguments (%i) to `%s` doesn't match the number of " \
-              'fields (%i).'.freeze
+        MSG = "Number of arguments (%<arg_num>i) to `%<method>s` doesn't " \
+              'match the number of fields (%<field_num>i).'.freeze
         FIELD_REGEX =
           /(%(([\s#+-0\*]*)(\d*)?(\.\d+)?[bBdiouxXeEfgGaAcps]|%))/
         NAMED_FIELD_REGEX = /%\{[_a-zA-Z][_a-zA-Z]+\}/
@@ -169,7 +169,8 @@ module RuboCop
 
           method_name = node.method?(:%) ? 'String#%' : node.method_name
 
-          format(MSG, num_args_for_format, method_name, num_expected_fields)
+          format(MSG, arg_num: num_args_for_format, method: method_name,
+                      field_num: num_expected_fields)
         end
       end
     end


### PR DESCRIPTION
This PR applies annotated string templates to all the remaining `Layout` cops, and in addition, `Lint` cops A - F .

-----------------

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
