### PR TITLE
Remove last blank line of generated .rubocop.yml if there is no content

### DIFF
--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -146,8 +146,8 @@ module RuboCop
 
       def write_dotfile(file_string, rubocop_yml_contents)
         File.open(DOTFILE, 'w') do |f|
-          f.write "inherit_from:#{file_string}\n\n"
-          f.write rubocop_yml_contents if rubocop_yml_contents
+          f.write "inherit_from:#{file_string}\n"
+          f.write "\n#{rubocop_yml_contents}" if rubocop_yml_contents
         end
       end
 


### PR DESCRIPTION
`rubocop --auto-gen-config` generartes following `.rubocop.yml`

```diff
+inherit_from: .rubocop_todo.yml
+
```

this patch fixes generated `.rubocop.yml` to

```diff
+inherit_from: .rubocop_todo.yml
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
