### PR TITLE
[Fix #4477] Add inherit_mode directive to support merging of arrays.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * [#5050](https://github.com/bbatsov/rubocop/issues/5050): Add auto-correction to `Style/ModuleFunction`. ([@garettarrowood][])
 * [#5358](https://github.com/bbatsov/rubocop/pull/5358):  `--no-auto-gen-timestamp` CLI option suppresses the inclusion of the date and time it was generated in auto-generated config. ([@dominicsayers][])
 * [#4274](https://github.com/bbatsov/rubocop/issues/4274): Add new `Layout/EmptyComment` cop. ([@koic][])
+* [#4477](https://github.com/bbatsov/rubocop/issues/4477): Add new configuration directive: `inherit_mode` for merging arrays. ([@leklund][])
 
 ### Bug fixes
 
@@ -3177,3 +3178,4 @@
 [@dominicsayers]: https://github.com/dominicsayers
 [@albertpaulp]: https://github.com/albertpaulp
 [@orgads]: https://github.com/orgads
+[@leklund]: https://github.com/leklund

--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -50,6 +50,7 @@ module RuboCop
         resolver.resolve_inheritance(path, hash, file)
 
         hash.delete('inherit_from')
+        hash.delete('inherit_mode')
 
         Config.create(hash, path)
       end

--- a/lib/rubocop/config_loader_resolver.rb
+++ b/lib/rubocop/config_loader_resolver.rb
@@ -23,13 +23,13 @@ module RuboCop
         .reverse.each_with_index do |base_config, index|
         base_config.each do |k, v|
           next unless v.is_a?(Hash)
-          hash[k] = if hash.key?(k)
-                      merge(v, hash[k],
-                            cop_name: k, file: file,
-                            inherited_file: inherited_files[index])
-                    else
-                      v
-                    end
+          if hash.key?(k)
+            v = merge(v, hash[k],
+                      cop_name: k, file: file,
+                      inherited_file: inherited_files[index],
+                      inherit_mode: determine_inherit_mode(hash, k))
+          end
+          hash[k] = v
         end
       end
     end
@@ -84,24 +84,13 @@ module RuboCop
       keys_appearing_in_both.each do |key|
         if base_hash[key].is_a?(Hash)
           result[key] = merge(base_hash[key], derived_hash[key])
+        elsif should_union?(base_hash, key, opts[:inherit_mode])
+          result[key] = base_hash[key] | derived_hash[key]
         else
           warn_on_duplicate_setting(base_hash, derived_hash, key, opts)
         end
       end
       result
-    end
-
-    def warn_on_duplicate_setting(base_hash, derived_hash, key, **opts)
-      return unless duplicate_setting?(base_hash, derived_hash,
-                                       key, opts[:inherited_file])
-
-      inherit_mode = opts.dig(:inherit_mode, 'merge')
-      return if base_hash[key].is_a?(Array) &&
-                inherit_mode && inherit_mode.include?(key)
-
-      warn("#{PathUtil.smart_path(opts[:file])}: " \
-           "#{opts[:cop_name]}:#{key} overrides " \
-           "the same parameter in #{opts[:inherited_file]}")
     end
 
     private
@@ -112,6 +101,33 @@ module RuboCop
       return false if base_hash[key] == derived_hash[key] # Same value
       return false if remote_file?(inherited_file) # Can't change
       Gem.path.none? { |dir| inherited_file.start_with?(dir) } # Can change?
+    end
+
+    def warn_on_duplicate_setting(base_hash, derived_hash, key, **opts)
+      return unless duplicate_setting?(base_hash, derived_hash,
+                                       key, opts[:inherited_file])
+
+      inherit_mode = opts[:inherit_mode]['merge'] ||
+                     opts[:inherit_mode]['override']
+      return if base_hash[key].is_a?(Array) &&
+                inherit_mode && inherit_mode.include?(key)
+
+      warn("#{PathUtil.smart_path(opts[:file])}: " \
+           "#{opts[:cop_name]}:#{key} overrides " \
+           "the same parameter in #{opts[:inherited_file]}")
+    end
+
+    def determine_inherit_mode(hash, key)
+      cop_cfg = hash[key]
+      local_inherit = cop_cfg.delete('inherit_mode') if cop_cfg.is_a?(Hash)
+      local_inherit || hash['inherit_mode'] || {}
+    end
+
+    def should_union?(base_hash, key, inherit_mode)
+      base_hash[key].is_a?(Array) &&
+        inherit_mode &&
+        inherit_mode['merge'] &&
+        inherit_mode['merge'].include?(key)
     end
 
     def base_configs(path, inherit_from, file)

--- a/manual/configuration.md
+++ b/manual/configuration.md
@@ -34,7 +34,8 @@ parameter that are hashes, for example `PreferredMethods` in
 configuration, while other parameter, such as `AllCops` / `Include`, are
 simply replaced by the local setting. If arrays were merged, there would
 be no way to remove elements through overriding them in local
-configuration.
+configuration. There is a way to have specific array settings merged using
+the `inherit_mode` setting.
 
 #### Inheriting from another configuration file in the project
 
@@ -120,6 +121,63 @@ dependency's installation path at runtime:
 ```
 $ bundle exec rubocop <options...>
 ```
+
+#### Merging arrays using inherit_mode
+
+The optional directive `inherit_mode` is used to specify which configuration
+keys that have array values should be merged together instead of overriding the
+inherited value.
+
+One caveat is that this directive only works with local and inherited
+configuration files, it is unable to merge with the default.yml config.
+
+Given the following config:
+```yaml
+# .rubocop.yml
+inherit_from:
+  - shared.yml
+
+inherit_mode:
+  merge:
+    - Exclude 
+
+Style/For:
+  Exclude:
+    - bar.rb
+```
+
+```yaml
+# .shared.yml
+Style/For:
+  Exclude:
+    - foo.rb
+```
+
+The list of `Exclude`s for the `Style/For` cop in this example will be
+`['foo.rb', 'bar.rb']`. 
+
+The directive can also be used on individual cop configurations to override
+the global setting.
+
+
+```yaml
+inherit_from:
+  - shared.yml
+
+inherit_mode:
+  merge:
+    - Exclude 
+
+Style/For:
+  inherit_mode:
+    override:
+      - Exclude
+  Exclude:
+    - bar.rb
+```
+
+In this example the `Exclude` would only include `bar.rb`.
+
 
 ### Defaults
 


### PR DESCRIPTION
### add `inherit_mode` directive

This PR is based on a suggestion in #4477. It adds support for a new directive that conditionally merges array values on a per key basis. This is incredibly useful when using a shared config file that has several excludes and project inheriting the shared repo would like to add a single file to the exclude list without duplicating the entire list.

The implementation requires that you specify which keys you would like to merge so that not all arrays are merged blindly.

Given the following configs:
```yaml
# .rubocop.yml
inherit_from:
  - shared.yml

inherit_mode:
  merge:
    - Exclude

Style/For:
  Exclude:
    - bar.rb
```

```yaml
# .shared.yml
Style/For:
  Exclude:
    - foo.rb
  Include:
    - zoot.rb
```

The `inherit_mode` directive will be used to determine that the values of the `Exclude` keys will be merged instead of overwritten. The result is that the exclude list for `Style/For` is `['foo.rb', 'bar.rb']`.

The directive can be used on a per cop basis to override the global setting:

```yaml
# .rubocop.yml
inherit_from:
  - shared.yml

inherit_mode:
  override:
    - Exclude
  merge:
    - Include

Style/For:
  Exclude:
    - bar.rb
  Include:
    - boot.rb
```

The exclude list would be just `bar.rb` and the Include list would be `['zoot.rb', 'boot.rb']`.

Related issues: #5480 

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/