### PR TITLE
[Fix #5069] Finish all annotated templates in Cops

### DIFF
--- a/lib/rubocop/cop/lint/implicit_string_concatenation.rb
+++ b/lib/rubocop/cop/lint/implicit_string_concatenation.rb
@@ -23,8 +23,8 @@ module RuboCop
       #     'Item 2'
       #   ]
       class ImplicitStringConcatenation < Cop
-        MSG = 'Combine %s and %s into a single string literal, rather than ' \
-              'using implicit string concatenation.'.freeze
+        MSG = 'Combine %<string1>s and %<string2>s into a single string ' \
+              'literal, rather than using implicit string concatenation.'.freeze
         FOR_ARRAY = ' Or, if they were intended to be separate array ' \
                     'elements, separate them with a comma.'.freeze
         FOR_METHOD = ' Or, if they were intended to be separate method ' \
@@ -34,8 +34,8 @@ module RuboCop
           each_bad_cons(node) do |child_node1, child_node2|
             range   = child_node1.source_range.join(child_node2.source_range)
             message = format(MSG,
-                             display_str(child_node1),
-                             display_str(child_node2))
+                             string1: display_str(child_node1),
+                             string2: display_str(child_node2))
             if node.parent && node.parent.array_type?
               message << FOR_ARRAY
             elsif node.parent && node.parent.send_type?

--- a/lib/rubocop/cop/lint/ineffective_access_modifier.rb
+++ b/lib/rubocop/cop/lint/ineffective_access_modifier.rb
@@ -46,8 +46,8 @@ module RuboCop
       #     end
       #   end
       class IneffectiveAccessModifier < Cop
-        MSG = '`%s` (on line %d) does not make singleton methods %s. ' \
-              'Use %s instead.'.freeze
+        MSG = '`%<modifier>s` (on line %<line>d) does not make singleton ' \
+              'methods %<modifier>s. Use %<alternative>s instead.'.freeze
         ALTERNATIVE_PRIVATE = '`private_class_method` or `private` inside a ' \
                               '`class << self` block'.freeze
         ALTERNATIVE_PROTECTED = '`protected` inside a `class << self` ' \
@@ -91,8 +91,9 @@ module RuboCop
                         else
                           ALTERNATIVE_PROTECTED
                         end
-          format(MSG, visibility, modifier.location.expression.line, visibility,
-                 alternative)
+          format(MSG, modifier: visibility,
+                      line: modifier.location.expression.line,
+                      alternative: alternative)
         end
 
         def check_scope(node, cur_vis = :public)

--- a/lib/rubocop/cop/lint/inherit_exception.rb
+++ b/lib/rubocop/cop/lint/inherit_exception.rb
@@ -28,7 +28,7 @@ module RuboCop
       class InheritException < Cop
         include ConfigurableEnforcedStyle
 
-        MSG = 'Inherit from `%s` instead of `%s`.'.freeze
+        MSG = 'Inherit from `%<prefer>s` instead of `%<current>s`.'.freeze
         PREFERRED_BASE_CLASS = {
           runtime_error: 'RuntimeError',
           standard_error: 'StandardError'
@@ -64,7 +64,7 @@ module RuboCop
         private
 
         def message(node)
-          format(MSG, preferred_base_class, node.const_name)
+          format(MSG, prefer: preferred_base_class, current: node.const_name)
         end
 
         def illegal_class_name?(class_node)

--- a/lib/rubocop/cop/lint/literal_as_condition.rb
+++ b/lib/rubocop/cop/lint/literal_as_condition.rb
@@ -31,7 +31,7 @@ module RuboCop
       #     do_something
       #   end
       class LiteralAsCondition < Cop
-        MSG = 'Literal `%s` appeared as a condition.'.freeze
+        MSG = 'Literal `%<literal>s` appeared as a condition.'.freeze
 
         def on_if(node)
           check_for_literal(node)
@@ -71,7 +71,7 @@ module RuboCop
         end
 
         def message(node)
-          format(MSG, node.source)
+          format(MSG, literal: node.source)
         end
 
         private

--- a/lib/rubocop/cop/lint/rand_one.rb
+++ b/lib/rubocop/cop/lint/rand_one.rb
@@ -21,7 +21,7 @@ module RuboCop
       #
       #   0 # just use 0 instead
       class RandOne < Cop
-        MSG = '`%s` always returns `0`. ' \
+        MSG = '`%<method>s` always returns `0`. ' \
               'Perhaps you meant `rand(2)` or `rand`?'.freeze
 
         def_node_matcher :rand_one?, <<-PATTERN
@@ -37,7 +37,7 @@ module RuboCop
         private
 
         def message(node)
-          format(MSG, node.source)
+          format(MSG, method: node.source)
         end
       end
     end

--- a/lib/rubocop/cop/lint/rescue_type.rb
+++ b/lib/rubocop/cop/lint/rescue_type.rb
@@ -37,8 +37,8 @@ module RuboCop
       class RescueType < Cop
         include RescueNode
 
-        MSG = 'Rescuing from `%s` will raise a `TypeError` instead of ' \
-              'catching the actual exception.'.freeze
+        MSG = 'Rescuing from `%<invalid_exceptions>s` will raise a ' \
+              '`TypeError` instead of catching the actual exception.'.freeze
         INVALID_TYPES = %i[array dstr float hash nil int str sym].freeze
 
         def on_resbody(node)
@@ -51,7 +51,10 @@ module RuboCop
           add_offense(
             node,
             location: node.loc.keyword.join(rescued.loc.expression),
-            message: format(MSG, invalid_exceptions.map(&:source).join(', '))
+            message: format(
+              MSG, invalid_exceptions: invalid_exceptions.map(&:source)
+                                                         .join(', ')
+            )
           )
         end
 

--- a/lib/rubocop/cop/lint/return_in_void_context.rb
+++ b/lib/rubocop/cop/lint/return_in_void_context.rb
@@ -32,7 +32,7 @@ module RuboCop
       #     return
       #   end
       class ReturnInVoidContext < Cop
-        MSG = 'Do not return a value in `%s`.'.freeze
+        MSG = 'Do not return a value in `%<method>s`.'.freeze
 
         def on_return(return_node)
           return unless return_node.descendants.any?
@@ -47,7 +47,7 @@ module RuboCop
 
           add_offense(return_node,
                       location: :keyword,
-                      message: format(message, method_name))
+                      message: format(message, method: method_name))
         end
 
         private

--- a/lib/rubocop/cop/lint/script_permission.rb
+++ b/lib/rubocop/cop/lint/script_permission.rb
@@ -6,7 +6,7 @@ module RuboCop
       # This cop checks if a file which has a shebang line as
       # its first line is granted execute permission.
       class ScriptPermission < Cop
-        MSG = "Script file %s doesn't have execute permission.".freeze
+        MSG = "Script file %<file>s doesn't have execute permission.".freeze
         SHEBANG = '#!'.freeze
 
         def investigate(processed_source)
@@ -36,7 +36,7 @@ module RuboCop
 
         def format_message_from(processed_source)
           basename = File.basename(processed_source.file_path)
-          format(MSG, basename)
+          format(MSG, file: basename)
         end
       end
     end

--- a/lib/rubocop/cop/lint/shadowed_argument.rb
+++ b/lib/rubocop/cop/lint/shadowed_argument.rb
@@ -37,8 +37,8 @@ module RuboCop
       #     puts foo
       #   end
       class ShadowedArgument < Cop
-        MSG = 'Argument `%s` was shadowed by a local variable before it was ' \
-              'used.'.freeze
+        MSG = 'Argument `%<argument>s` was shadowed by a local variable ' \
+              'before it was used.'.freeze
 
         def_node_search :uses_var?, '(lvar %)'
 
@@ -58,7 +58,7 @@ module RuboCop
           return unless argument.method_argument? || argument.block_argument?
 
           shadowing_assignment(argument) do |node|
-            message = format(MSG, argument.name)
+            message = format(MSG, argument: argument.name)
 
             add_offense(node, message: message)
           end

--- a/lib/rubocop/cop/lint/shadowing_outer_local_variable.rb
+++ b/lib/rubocop/cop/lint/shadowing_outer_local_variable.rb
@@ -32,7 +32,7 @@ module RuboCop
       #     end
       #   end
       class ShadowingOuterLocalVariable < Cop
-        MSG = 'Shadowing outer local variable - `%s`.'.freeze
+        MSG = 'Shadowing outer local variable - `%<variable>s`.'.freeze
 
         def join_force?(force_class)
           force_class == VariableForce
@@ -44,7 +44,7 @@ module RuboCop
           outer_local_variable = variable_table.find_variable(variable.name)
           return unless outer_local_variable
 
-          message = format(MSG, variable.name)
+          message = format(MSG, variable: variable.name)
           add_offense(variable.declaration_node, message: message)
         end
       end

--- a/lib/rubocop/cop/lint/unified_integer.rb
+++ b/lib/rubocop/cop/lint/unified_integer.rb
@@ -18,7 +18,7 @@ module RuboCop
       #
       #   1.is_a?(Integer)
       class UnifiedInteger < Cop
-        MSG = 'Use `Integer` instead of `%s`.'.freeze
+        MSG = 'Use `Integer` instead of `%<klass>s`.'.freeze
 
         def_node_matcher :fixnum_or_bignum_const, <<-PATTERN
           (:const {nil? (:cbase)} ${:Fixnum :Bignum})
@@ -29,7 +29,7 @@ module RuboCop
 
           return unless klass
 
-          add_offense(node, message: format(MSG, klass))
+          add_offense(node, message: format(MSG, klass: klass))
         end
 
         def autocorrect(node)

--- a/lib/rubocop/cop/lint/uri_escape_unescape.rb
+++ b/lib/rubocop/cop/lint/uri_escape_unescape.rb
@@ -41,8 +41,9 @@ module RuboCop
           URI.decode_www_form_component
         ].freeze
 
-        MSG = '`%s` method is obsolete and should not be used. Instead, use ' \
-              '`%s`, `%s` or `%s` depending on your specific use case.'.freeze
+        MSG = '`%<uri_method>s` method is obsolete and should not be used. ' \
+              'Instead, use %<replacements>s depending on your specific use ' \
+              'case.'.freeze
 
         def_node_matcher :uri_escape_unescape?, <<-PATTERN
           (send
@@ -52,18 +53,18 @@ module RuboCop
 
         def on_send(node)
           uri_escape_unescape?(node) do |top_level, obsolete_method|
-            replacement_methods = if %i[escape encode].include?(obsolete_method)
-                                    ALTERNATE_METHODS_OF_URI_ESCAPE
-                                  else
-                                    ALTERNATE_METHODS_OF_URI_UNESCAPE
-                                  end
+            replacements = if %i[escape encode].include?(obsolete_method)
+                             ALTERNATE_METHODS_OF_URI_ESCAPE
+                           else
+                             ALTERNATE_METHODS_OF_URI_UNESCAPE
+                           end
 
             double_colon = top_level ? '::' : ''
 
             message = format(
-              MSG,
-              "#{double_colon}URI.#{obsolete_method}",
-              *replacement_methods
+              MSG, uri_method: "#{double_colon}URI.#{obsolete_method}",
+                   replacements: "`#{replacements[0]}`, `#{replacements[1]}` " \
+                                 "or `#{replacements[2]}`"
             )
 
             add_offense(node, message: message)

--- a/lib/rubocop/cop/lint/useless_access_modifier.rb
+++ b/lib/rubocop/cop/lint/useless_access_modifier.rb
@@ -91,7 +91,7 @@ module RuboCop
       #     delegate :method_a, to: :method_b
       #   end
       class UselessAccessModifier < Cop
-        MSG = 'Useless `%s` access modifier.'.freeze
+        MSG = 'Useless `%<current>s` access modifier.'.freeze
 
         def on_class(node)
           check_node(node.children[2]) # class body
@@ -135,14 +135,14 @@ module RuboCop
           if node.begin_type?
             check_scope(node)
           elsif node.send_type? && node.access_modifier?
-            add_offense(node, message: format(MSG, node.method_name))
+            add_offense(node, message: format(MSG, current: node.method_name))
           end
         end
 
         def check_scope(node)
           cur_vis, unused = check_child_nodes(node, nil, :public)
 
-          add_offense(unused, message: format(MSG, cur_vis)) if unused
+          add_offense(unused, message: format(MSG, current: cur_vis)) if unused
         end
 
         def check_child_nodes(node, unused, cur_vis)
@@ -165,10 +165,12 @@ module RuboCop
         def check_new_visibility(node, unused, new_vis, cur_vis)
           # does this modifier just repeat the existing visibility?
           if new_vis == cur_vis
-            add_offense(node, message: format(MSG, cur_vis))
+            add_offense(node, message: format(MSG, current: cur_vis))
           else
             # was the previous modifier never applied to any defs?
-            add_offense(unused, message: format(MSG, cur_vis)) if unused
+            if unused
+              add_offense(unused, message: format(MSG, current: cur_vis))
+            end
             # once we have already warned about a certain modifier, don't
             # warn again even if it is never applied to any method defs
             unused = node

--- a/lib/rubocop/cop/lint/useless_assignment.rb
+++ b/lib/rubocop/cop/lint/useless_assignment.rb
@@ -32,7 +32,7 @@ module RuboCop
       #   end
       class UselessAssignment < Cop
         include NameSimilarity
-        MSG = 'Useless assignment to variable - `%s`.'.freeze
+        MSG = 'Useless assignment to variable - `%<variable>s`.'.freeze
 
         def join_force?(force_class)
           force_class == VariableForce
@@ -65,7 +65,7 @@ module RuboCop
         def message_for_useless_assignment(assignment)
           variable = assignment.variable
 
-          format(MSG, variable.name) +
+          format(MSG, variable: variable.name) +
             message_specification(assignment, variable).to_s
         end
 

--- a/lib/rubocop/cop/lint/useless_setter_call.rb
+++ b/lib/rubocop/cop/lint/useless_setter_call.rb
@@ -25,7 +25,7 @@ module RuboCop
       #     x
       #   end
       class UselessSetterCall < Cop
-        MSG = 'Useless setter call to local variable `%s`.'.freeze
+        MSG = 'Useless setter call to local variable `%<variable>s`.'.freeze
         ASSIGNMENT_TYPES = %i[lvasgn ivasgn cvasgn gvasgn].freeze
 
         def on_def(node)
@@ -42,7 +42,7 @@ module RuboCop
           add_offense(
             receiver,
             location: :name,
-            message: format(MSG, receiver.loc.name.source)
+            message: format(MSG, variable: receiver.loc.name.source)
           )
         end
         alias on_defs on_def

--- a/lib/rubocop/cop/lint/void.rb
+++ b/lib/rubocop/cop/lint/void.rb
@@ -42,11 +42,11 @@ module RuboCop
       #     some_var
       #   end
       class Void < Cop
-        OP_MSG = 'Operator `%s` used in void context.'.freeze
-        VAR_MSG = 'Variable `%s` used in void context.'.freeze
-        LIT_MSG = 'Literal `%s` used in void context.'.freeze
+        OP_MSG = 'Operator `%<op>s` used in void context.'.freeze
+        VAR_MSG = 'Variable `%<var>s` used in void context.'.freeze
+        LIT_MSG = 'Literal `%<lit>s` used in void context.'.freeze
         SELF_MSG = '`self` used in void context.'.freeze
-        DEFINED_MSG = '`%s` used in void context.'.freeze
+        DEFINED_MSG = '`%<defined>s` used in void context.'.freeze
 
         BINARY_OPERATORS = %i[* / % + - == === != < > <= >= <=>].freeze
         UNARY_OPERATORS = %i[+@ -@ ~ !].freeze
@@ -77,7 +77,7 @@ module RuboCop
 
           add_offense(node,
                       location: :selector,
-                      message: format(OP_MSG, node.method_name))
+                      message: format(OP_MSG, op: node.method_name))
         end
 
         def check_var(node)
@@ -85,13 +85,13 @@ module RuboCop
 
           add_offense(node,
                       location: :name,
-                      message: format(VAR_MSG, node.loc.name.source))
+                      message: format(VAR_MSG, var: node.loc.name.source))
         end
 
         def check_literal(node)
           return if !node.literal? || node.xstr_type?
 
-          add_offense(node, message: format(LIT_MSG, node.source))
+          add_offense(node, message: format(LIT_MSG, lit: node.source))
         end
 
         def check_self(node)
@@ -103,7 +103,7 @@ module RuboCop
         def check_defined(node)
           return unless node.defined_type?
 
-          add_offense(node, message: format(DEFINED_MSG, node.source))
+          add_offense(node, message: format(DEFINED_MSG, defined: node.source))
         end
 
         def in_void_context?(node)


### PR DESCRIPTION
This commit specifically adds annotated string templates for Lint Cops I-V

When regenerating our `rubocop_todo.yml` file, the `Offense count` for `Style/FormatStringToken` goes down to `36` offenses. These offenses are made up of missed spots in our cops, templates used outside of cops, but many may also be bugs in offense detection. There are some open issues outlining some scenarios - #5398 & #5242 seem relevant.  

Happy to submit a regeneration of our `rubocop_todo.yml`.  But seems better for a separate PR, after this is merged.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
