### PR TITLE
Fix a false positive of `Style/FormatStringToken` with unrelated `format` method call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 * [#5479](https://github.com/bbatsov/rubocop/issues/5479): Fix false positives for `Rails/Presence` when using with `elsif`. ([@wata727][])
 * [#5427](https://github.com/bbatsov/rubocop/pull/5427): Fix exception when executing from a different drive on Windows. ([@orgads][])
 * [#5429](https://github.com/bbatsov/rubocop/issues/5429): Detect tabs other than indentation by `Layout/Tab`. ([@pocke][])
+* [#5496](https://github.com/bbatsov/rubocop/pull/5496): Fix a false positive of `Style/FormatStringToken` with unrelated `format` call. ([@pocke][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/format_string_token.rb
+++ b/lib/rubocop/cop/style/format_string_token.rb
@@ -68,11 +68,8 @@ module RuboCop
         private
 
         def includes_format_methods?(node)
-          root_node = node.ancestors.last
-          return unless root_node
-
-          root_node.descendants.any? do |desc_node|
-            FORMAT_STRING_METHODS.include?(desc_node.method_name)
+          node.each_ancestor.any? do |ancestor|
+            FORMAT_STRING_METHODS.include?(ancestor.method_name)
           end
         end
 

--- a/spec/rubocop/cop/style/format_string_token_spec.rb
+++ b/spec/rubocop/cop/style/format_string_token_spec.rb
@@ -108,6 +108,13 @@ RSpec.describe RuboCop::Cop::Style::FormatStringToken, :config do
     RUBY
   end
 
+  it 'ignores time format and unrelated `format` method using' do
+    expect_no_offenses(<<-RUBY.strip_indent)
+      Time.now.strftime('%Y-%m-%d-%H-%M-%S')
+      format
+    RUBY
+  end
+
   it 'handles dstrs' do
     inspect_source('"c#{b}%{template}"')
     expect(cop.highlights).to eql(['%{template}'])


### PR DESCRIPTION
Ref: https://github.com/bbatsov/rubocop/issues/5483

Problem
===

Currently `Style/FormatStringToken` cop adds a falsy offense.

```ruby
Time.now.strftime('%Y-%m-%d-%H-%M-%S')
format
```

```bash
$ rubocop
Inspecting 1 file
C

Offenses:

test.rb:1:26: C: Style/FormatStringToken: Prefer annotated tokens (like %<foo>s) over unannotated tokens (like %s).
Time.now.strftime('%Y-%m-%d-%H-%M-%S')
                         ^^

1 file inspected, 1 offense detected
```

But the cop does not add any offenses to the following code.

```ruby
Time.now.strftime('%Y-%m-%d-%H-%M-%S')
```

```
$ rubocop
Inspecting 1 file
.

1 file inspected, no offenses detected
```

Cause
===

The cause is here.
https://github.com/bbatsov/rubocop/blob/86476f13e8e12e370f84911d82bef8638f3fdf96/lib/rubocop/cop/style/format_string_token.rb#L70-L77



The `node.ancestors.last` is a root node of ast. In other words, it equals `processed_source.ast`. So the code checks `format` method existence from whole a file.

Solution
====

Check `format` method existence only from ancestors of the string node.

**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
