### PR TITLE
Add `AllowBorderComment` option to `Layout/EmptyComment` cop

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -268,6 +268,9 @@ Layout/DotPosition:
     - leading
     - trailing
 
+Layout/EmptyComment:
+  AllowBorderComment: true
+
 # Use empty lines between defs.
 Layout/EmptyLineBetweenDefs:
   # If `true`, this parameter means that single line method definitions don't

--- a/lib/rubocop/cop/layout/empty_comment.rb
+++ b/lib/rubocop/cop/layout/empty_comment.rb
@@ -20,6 +20,28 @@ module RuboCop
       #   class Foo
       #   end
       #
+      # @example AllowBorderComment: true (default)
+      #   # good
+      #
+      #   def foo
+      #   end
+      #
+      #   #################
+      #
+      #   def bar
+      #   end
+      #
+      # @example AllowBorderComment: false
+      #   # bad
+      #
+      #   def foo
+      #   end
+      #
+      #   #################
+      #
+      #   def bar
+      #   end
+      #
       class EmptyComment < Cop
         include RangeHelp
 
@@ -66,11 +88,21 @@ module RuboCop
         end
 
         def empty_comment_only?(comment_text)
-          comment_text =~ /\A(#\n)+\z/ ? true : false
+          empty_comment_pattern = if allow_border_comment?
+                                    /\A(#\n)+\z/
+                                  else
+                                    /\A(#+\n)+\z/
+                                  end
+
+          !(comment_text =~ empty_comment_pattern).nil?
         end
 
         def comment_text(comment)
           "#{comment.text.strip}\n"
+        end
+
+        def allow_border_comment?
+          cop_config['AllowBorderComment']
         end
       end
     end

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -910,6 +910,38 @@ end
 class Foo
 end
 ```
+#### AllowBorderComment: true (default)
+
+```ruby
+# good
+
+def foo
+end
+
+#################
+
+def bar
+end
+```
+#### AllowBorderComment: false
+
+```ruby
+# bad
+
+def foo
+end
+
+#################
+
+def bar
+end
+```
+
+### Configurable attributes
+
+Name | Default value | Configurable values
+--- | --- | ---
+AllowBorderComment | `true` | Boolean
 
 ## Layout/EmptyLineAfterMagicComment
 

--- a/spec/rubocop/cop/layout/empty_comment_spec.rb
+++ b/spec/rubocop/cop/layout/empty_comment_spec.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::Layout::EmptyComment do
+RSpec.describe RuboCop::Cop::Layout::EmptyComment, :config do
   subject(:cop) { described_class.new(config) }
 
-  let(:config) { RuboCop::Config.new }
+  let(:cop_config) { { 'AllowBorderComment' => true } }
 
   it 'registers an offense when using single line empty comment' do
     expect_offense(<<-RUBY.strip_indent)
@@ -48,10 +48,30 @@ RSpec.describe RuboCop::Cop::Layout::EmptyComment do
     RUBY
   end
 
-  it 'does not register an offense when using border comment' do
-    expect_no_offenses(<<-RUBY.strip_indent)
-      #################################
-    RUBY
+  context 'allow border comment (default)' do
+    it 'does not register an offense when using border comment' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        #################################
+      RUBY
+    end
+  end
+
+  context 'disallow border comment' do
+    let(:cop_config) { { 'AllowBorderComment' => false } }
+
+    it 'registers an offense when using single line empty comment' do
+      expect_offense(<<-RUBY.strip_indent)
+        #
+        ^ Source code comment is empty.
+      RUBY
+    end
+
+    it 'registers an offense when using border comment' do
+      expect_offense(<<-RUBY.strip_indent)
+        #################################
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Source code comment is empty.
+      RUBY
+    end
   end
 
   it 'autocorrects empty comment' do


### PR DESCRIPTION
Follow up of https://github.com/bbatsov/rubocop/pull/5495#issuecomment-359302649.

## Summary

This PR adds options and documents for the following border comment.

```ruby
def foo
end

#################

def bar
end
```

By default border comment is allowed for the following reasons.

- Social impact is unclear
- It is strict not to allow border comment by default, it can be done later
- Test codes of RuboCop depends on border comment

If the user does not like the border comment, it can be set as follows.

```yaml
Layout/EmptyComment:
  AllowBorderComment: false
```

## Other Information

As a future plan to extend `Layout/EmptyComment` cop, there is an option to "Allow leading and trailing blank lines".

https://github.com/bbatsov/rubocop/pull/4288#issuecomment-296359224

This isn't described in CHANGELOG.md because it is extended to `Layout/EmptyComment` cop which has not yet been released.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
