### PR TITLE
Revert "Workaround for `bundle conflict` in AppVeyor"

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ version: "{build}"
 install:
   - set PATH=C:\Ruby%ruby_version%\bin;%PATH%
   - gem update --system 2.6.14 --no-document
-  - gem install bundler --no-document --force
+  - gem install bundler --no-document
   - bundle install --jobs 3 --retry 3
 
 build: off


### PR DESCRIPTION
This reverts commit ae8a37dd19a0f9d74baf697c2564c7455de25436.

appveyor/ci#1944 has been resolved. This PR will revert the workaround.
