### PR TITLE
Style/SafeNavigation will register an offense for methods that nil responds to

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@
 * [#5402](https://github.com/bbatsov/rubocop/pull/5402): Remove undefined `ActiveSupport::TimeZone#strftime` method from defined dangerous methods of `Rails/TimeZone` cop. ([@koic][])
 * [#4704](https://github.com/bbatsov/rubocop/issues/4704): Move `Lint/EndAlignment`, `Lint/DefEndAlignment`, `Lint/BlockAlignment`, and `Lint/ConditionPosition` to the `Layout` namespace. ([@bquorning][])
 * [#5283](https://github.com/bbatsov/rubocop/issues/5283): Change file path output by `Formatter::JSONFormatter` from relative path to smart path. ([@koic][])
+* `Style/SafeNavigation` will now register an offense for methods that `nil` responds to. ([@rrosenblum][])
 
 ## 0.52.1 (2017-12-27)
 

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -4710,10 +4710,6 @@ foo.nil? || foo.bar
 foo.baz = bar if foo
 foo.baz + bar if foo
 foo.bar > 2 if foo
-
-# Methods that `nil` will `respond_to?` should not be converted to
-# use safe navigation
-foo.to_i if foo
 ```
 
 ### Configurable attributes

--- a/spec/rubocop/cop/style/safe_navigation_spec.rb
+++ b/spec/rubocop/cop/style/safe_navigation_spec.rb
@@ -23,15 +23,6 @@ RSpec.describe RuboCop::Cop::Style::SafeNavigation, :config do
       expect_no_offenses('nil&.bar')
     end
 
-    it 'allows method calls that nil responds to safe guarded by ' \
-      'an object check' do
-      expect_no_offenses('foo.to_i if foo')
-    end
-
-    it 'allows an object check before a method calls that nil responds to ' do
-      expect_no_offenses('foo && foo.to_i')
-    end
-
     it 'allows an object check before hash access' do
       expect_no_offenses('foo && foo[:bar]')
     end
@@ -127,6 +118,13 @@ RSpec.describe RuboCop::Cop::Style::SafeNavigation, :config do
 
     shared_examples 'all variable types' do |variable|
       context 'modifier if' do
+        it 'registers an offense for a method call that nil responds to ' \
+        'safe guarded by an object check' do
+          inspect_source("#{variable}.to_i if #{variable}")
+
+          expect(cop.messages).to eq([message])
+        end
+
         it 'registers an offense for a method call on an accessor ' \
           'safeguarded by a check for the accessed variable' do
           inspect_source("#{variable}[1].bar if #{variable}[1]")
@@ -453,6 +451,13 @@ RSpec.describe RuboCop::Cop::Style::SafeNavigation, :config do
             expect_no_offenses(<<-RUBY.strip_indent)
               !#{variable}.nil? && #{variable}.bar(baz) { |e| e.qux }
             RUBY
+          end
+
+          it 'registers an offense for an object check followed by ' \
+            'a method calls that nil responds to ' do
+            inspect_source("#{variable} && #{variable}.to_i")
+
+            expect(cop.messages).to eq([message])
           end
 
           it 'registers an offense for an object check followed by ' \


### PR DESCRIPTION
`Lint/SafeNavigationChain` will still allow `nil` methods. I was torn on if I should modify `SafeNavigationChain`. The issue is that we need to convert `nil` methods to use safe navigation if we are changing the rest of the method chain to use safe navigation. If a `nil` method is chained to safe navigation, the code is exploiting side effects, and we are not able to tell if this is intended or not. I am leaning towards we should register an offense in `SafeNavigationChain` because it is better to not write code that relies on side effects.

```ruby
foo && foo.bar.nil?

 foo | bar | return
 nil |     | nil
 any | nil | true
 any | any | false

foo&.bar.nil?
 foo | bar | return
 nil |     | true
 any | nil | true
 any | any | false

foo&.bar&.nil?
 foo | bar | return
 nil |     | nil
 any | nil | true
 any | any | false

foo && foo.bar.to_i
 foo | bar | return
 nil |     | nil
 any | nil | 0
 any |  1  | 1

foo&.bar.to_i
 foo | bar | return
 nil |     | 0
 any | nil | 0
 any |  1  | 1

foo&.bar&.to_i
 foo | bar | return
 nil |     | nil
 any | nil | 0
 any |  1  | 1
```