### PR TITLE
#4812 Add style for extra space at beginning of class to Layout/EmptyLinesAroundClassBody cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * [#5532](https://github.com/bbatsov/rubocop/pull/5532): Include `.axlsx` file by default. ([@georf][])
 * [#5490](https://github.com/bbatsov/rubocop/issues/5490): Add new `Lint/OrderedMagicComments` cop. ([@koic][])
 * [#4008](https://github.com/bbatsov/rubocop/issues/4008): Add new `Style/ExpandPathArguments` cop. ([@koic][])
+* [#4812](https://github.com/bbatsov/rubocop/issues/4812): Add `beginning_only` and `ending_only` style options to `Layout/EmptyLinesAroundClassBody` cop. ([@jmks][])
 
 ### Bug fixes
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -295,6 +295,8 @@ Layout/EmptyLinesAroundClassBody:
     - empty_lines_except_namespace
     - empty_lines_special
     - no_empty_lines
+    - beginning_only
+    - ending_only
 
 Layout/EmptyLinesAroundModuleBody:
   EnforcedStyle: no_empty_lines

--- a/lib/rubocop/cop/layout/empty_lines_around_class_body.rb
+++ b/lib/rubocop/cop/layout/empty_lines_around_class_body.rb
@@ -36,6 +36,26 @@ module RuboCop
       #
       #   end
       #
+      # @example Enforcedstyle: beginning_only
+      #   # good
+      #
+      #   class Foo
+      #
+      #     def bar
+      #       # ...
+      #     end
+      #   end
+      #
+      # @example Enforcedstyle: ending_only
+      #   # good
+      #
+      #   class Foo
+      #     def bar
+      #       # ...
+      #     end
+      #
+      #   end
+      #
       # @example EnforcedStyle: no_empty_lines (default)
       #   # good
       #

--- a/lib/rubocop/cop/mixin/empty_lines_around_body.rb
+++ b/lib/rubocop/cop/mixin/empty_lines_around_body.rb
@@ -65,8 +65,17 @@ module RuboCop
         end
 
         def check_both(style, first_line, last_line)
-          check_beginning(style, first_line)
-          check_ending(style, last_line)
+          case style
+          when :beginning_only
+            check_beginning(:empty_lines, first_line)
+            check_ending(:no_empty_lines, last_line)
+          when :ending_only
+            check_beginning(:no_empty_lines, first_line)
+            check_ending(:empty_lines, last_line)
+          else
+            check_beginning(style, first_line)
+            check_ending(style, last_line)
+          end
         end
 
         def check_beginning(style, first_line)

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -1265,6 +1265,30 @@ class Foo
 
 end
 ```
+#### Enforcedstyle: beginning_only
+
+```ruby
+# good
+
+class Foo
+
+  def bar
+    # ...
+  end
+end
+```
+#### Enforcedstyle: ending_only
+
+```ruby
+# good
+
+class Foo
+  def bar
+    # ...
+  end
+
+end
+```
 #### EnforcedStyle: no_empty_lines (default)
 
 ```ruby
@@ -1281,7 +1305,7 @@ end
 
 Name | Default value | Configurable values
 --- | --- | ---
-EnforcedStyle | `no_empty_lines` | `empty_lines`, `empty_lines_except_namespace`, `empty_lines_special`, `no_empty_lines`
+EnforcedStyle | `no_empty_lines` | `empty_lines`, `empty_lines_except_namespace`, `empty_lines_special`, `no_empty_lines`, `beginning_only`, `ending_only`
 
 ### References
 

--- a/spec/rubocop/cop/layout/empty_lines_around_class_body_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_class_body_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundClassBody, :config do
         end
       RUBY
       expect(cop.messages)
-        .to eq(['Extra empty line detected at class body beginning.'])
+        .to eq([extra_begin])
     end
 
     it 'autocorrects class body containing only a blank' do
@@ -44,7 +44,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundClassBody, :config do
         end
       RUBY
       expect(cop.messages)
-        .to eq(['Extra empty line detected at class body end.'])
+        .to eq([extra_end])
     end
 
     it 'registers an offense for singleton class body starting with a blank' do
@@ -55,7 +55,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundClassBody, :config do
         end
       RUBY
       expect(cop.messages)
-        .to eq(['Extra empty line detected at class body beginning.'])
+        .to eq([extra_begin])
     end
 
     it 'autocorrects singleton class body containing only a blank' do
@@ -78,7 +78,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundClassBody, :config do
         end
       RUBY
       expect(cop.messages)
-        .to eq(['Extra empty line detected at class body end.'])
+        .to eq([extra_end])
     end
   end
 
@@ -92,8 +92,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundClassBody, :config do
           do_something
         end
       RUBY
-      expect(cop.messages).to eq(['Empty line missing at class body beginning.',
-                                  'Empty line missing at class body end.'])
+      expect(cop.messages).to eq([missing_begin, missing_end])
     end
 
     it 'ignores classes with an empty body' do
@@ -124,8 +123,7 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundClassBody, :config do
           do_something
         end
       RUBY
-      expect(cop.messages).to eq(['Empty line missing at class body beginning.',
-                                  'Empty line missing at class body end.'])
+      expect(cop.messages).to eq([missing_begin, missing_end])
     end
 
     it 'ignores singleton classes with an empty body' do

--- a/spec/rubocop/cop/layout/empty_lines_around_class_body_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_class_body_spec.rb
@@ -313,5 +313,89 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundClassBody, :config do
     end
   end
 
+  context 'when EnforcedStyle is beginning_only' do
+    let(:cop_config) { { 'EnforcedStyle' => 'beginning_only' } }
+
+    it 'ignores empty lines at the beginning of a class' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        class SomeClass
+
+          do_something
+        end
+      RUBY
+    end
+
+    it 'registers an offense for an empty line at the end of a class' do
+      inspect_source(<<-RUBY.strip_indent)
+        class SomeClass
+
+          do_something
+
+        end
+      RUBY
+
+      expect(cop.messages).to eq([extra_end])
+    end
+
+    it 'autocorrects end' do
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
+        class SomeClass
+
+          do_something
+
+        end
+      RUBY
+
+      expect(new_source).to eq(<<-RUBY.strip_indent)
+        class SomeClass
+
+          do_something
+        end
+      RUBY
+    end
+  end
+
+  context 'when EnforcedStyle is ending_only' do
+    let(:cop_config) { { 'EnforcedStyle' => 'ending_only' } }
+
+    it 'ignores empty lines at the beginning of a class' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        class SomeClass
+          do_something
+
+        end
+      RUBY
+    end
+
+    it 'registers an offense for an empty line at the end of a class' do
+      inspect_source(<<-RUBY.strip_indent)
+        class SomeClass
+
+          do_something
+
+        end
+      RUBY
+
+      expect(cop.messages).to eq([extra_begin])
+    end
+
+    it 'autocorrects end' do
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
+        class SomeClass
+
+          do_something
+
+        end
+      RUBY
+
+      expect(new_source).to eq(<<-RUBY.strip_indent)
+        class SomeClass
+          do_something
+
+        end
+      RUBY
+    end
+  end
+
   include_examples 'empty_lines_around_class_or_module_body', 'class'
 end


### PR DESCRIPTION
Add more options to `SupportedStyle` of the `Layout/EmptyLinesAroundClassBody` cop.

`beginning_only` allows an empty line only after the class definition:

```ruby
# bad
class Foo

  def bar
    # ...
  end

end

# bad
class Foo
  def bar
    # ...
  end

end

# good
class Foo

  def bar
    # ...
  end
end
```

`ending_only` allows an empty line before the closing `end` of the class definition:

```ruby
# bad
class Foo
  def bar
    # ...
  end
end

# bad
class Foo

  def bar
    # ...
  end

end

# good
class Foo
  def bar
    # ...
  end

end
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
