### PR TITLE
[Fix #5503] Fix `Rails/CreateTableWithTimestamps` false positive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 * [#5427](https://github.com/bbatsov/rubocop/pull/5427): Fix exception when executing from a different drive on Windows. ([@orgads][])
 * [#5429](https://github.com/bbatsov/rubocop/issues/5429): Detect tabs other than indentation by `Layout/Tab`. ([@pocke][])
 * [#5496](https://github.com/bbatsov/rubocop/pull/5496): Fix a false positive of `Style/FormatStringToken` with unrelated `format` call. ([@pocke][])
+* [#5503](https://github.com/bbatsov/rubocop/issues/5503): Fix `Rails/CreateTableWithTimestamps` false positive when using `to_proc` syntax. ([@wata727][])
 
 ### Changes
 

--- a/lib/rubocop/cop/rails/create_table_with_timestamps.rb
+++ b/lib/rubocop/cop/rails/create_table_with_timestamps.rb
@@ -50,6 +50,10 @@ module RuboCop
             _)
         PATTERN
 
+        def_node_matcher :create_table_with_timestamps_proc?, <<-PATTERN
+          (send nil? :create_table (sym _) (block-pass (sym :timestamps)))
+        PATTERN
+
         def_node_search :timestamps_included?, <<-PATTERN
           (send _var :timestamps ...)
         PATTERN
@@ -66,6 +70,8 @@ module RuboCop
             if parent.body.nil? || !time_columns_included?(parent.body)
               add_offense(parent)
             end
+          elsif create_table_with_timestamps_proc?(node)
+            # nothing to do
           else
             add_offense(node)
           end

--- a/spec/rubocop/cop/rails/create_table_with_timestamps_spec.rb
+++ b/spec/rubocop/cop/rails/create_table_with_timestamps_spec.rb
@@ -39,6 +39,14 @@ RSpec.describe RuboCop::Cop::Rails::CreateTableWithTimestamps do
     RUBY
   end
 
+  it 'registers an offense when not including timestamps' \
+     'with `to_proc` syntax' do
+    expect_offense <<-RUBY
+      create_table :users, &:extension_columns
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Add timestamps when creating a new table.
+    RUBY
+  end
+
   it 'does not register an offense when including timestamps in block' do
     expect_no_offenses <<-RUBY
       create_table :users do |t|
@@ -47,6 +55,13 @@ RSpec.describe RuboCop::Cop::Rails::CreateTableWithTimestamps do
 
         t.timestamps
       end
+    RUBY
+  end
+
+  it 'does not register an offense when including timestamps' \
+     'with `to_proc` syntax' do
+    expect_no_offenses <<-RUBY
+      create_table :users, &:timestamps
     RUBY
   end
 


### PR DESCRIPTION
Fixes #5503

When using `to_proc` syntax, `Rails/CreateTableWithTimestamps` cop doesn't report offenses even if specifying timestamps.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
