### PR TITLE
Add `AllowMarginComment` option to `Layout/EmptyComment` cop

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -270,6 +270,7 @@ Layout/DotPosition:
 
 Layout/EmptyComment:
   AllowBorderComment: true
+  AllowMarginComment: true
 
 # Use empty lines between defs.
 Layout/EmptyLineBetweenDefs:

--- a/lib/rubocop/cop/layout/empty_comment.rb
+++ b/lib/rubocop/cop/layout/empty_comment.rb
@@ -42,19 +42,45 @@ module RuboCop
       #   def bar
       #   end
       #
+      # @example AllowMarginComment: true (default)
+      #   # good
+      #
+      #   #
+      #   # Description of `Foo` class.
+      #   #
+      #   class Foo
+      #   end
+      #
+      # @example AllowMarginComment: false
+      #   # bad
+      #
+      #   #
+      #   # Description of `Foo` class.
+      #   #
+      #   class Foo
+      #   end
+      #
       class EmptyComment < Cop
         include RangeHelp
 
         MSG = 'Source code comment is empty.'.freeze
 
         def investigate(processed_source)
-          comments = concat_consecutive_comments(processed_source.comments)
+          if allow_margin_comment?
+            comments = concat_consecutive_comments(processed_source.comments)
 
-          comments.each do |comment|
-            next unless empty_comment_only?(comment[0])
+            comments.each do |comment|
+              next unless empty_comment_only?(comment[0])
 
-            comment[1].each do |offense_comment|
-              add_offense(offense_comment)
+              comment[1].each do |offense_comment|
+                add_offense(offense_comment)
+              end
+            end
+          else
+            processed_source.comments.each do |comment|
+              next unless empty_comment_only?(comment_text(comment))
+
+              add_offense(comment)
             end
           end
         end
@@ -103,6 +129,10 @@ module RuboCop
 
         def allow_border_comment?
           cop_config['AllowBorderComment']
+        end
+
+        def allow_margin_comment?
+          cop_config['AllowMarginComment']
         end
       end
     end

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -936,12 +936,35 @@ end
 def bar
 end
 ```
+#### AllowMarginComment: true (default)
+
+```ruby
+# good
+
+#
+# Description of `Foo` class.
+#
+class Foo
+end
+```
+#### AllowMarginComment: false
+
+```ruby
+# bad
+
+#
+# Description of `Foo` class.
+#
+class Foo
+end
+```
 
 ### Configurable attributes
 
 Name | Default value | Configurable values
 --- | --- | ---
 AllowBorderComment | `true` | Boolean
+AllowMarginComment | `true` | Boolean
 
 ## Layout/EmptyLineAfterMagicComment
 

--- a/spec/rubocop/cop/layout/empty_comment_spec.rb
+++ b/spec/rubocop/cop/layout/empty_comment_spec.rb
@@ -3,7 +3,9 @@
 RSpec.describe RuboCop::Cop::Layout::EmptyComment, :config do
   subject(:cop) { described_class.new(config) }
 
-  let(:cop_config) { { 'AllowBorderComment' => true } }
+  let(:cop_config) do
+    { 'AllowBorderComment' => true, 'AllowMarginComment' => true }
+  end
 
   it 'registers an offense when using single line empty comment' do
     expect_offense(<<-RUBY.strip_indent)
@@ -70,6 +72,34 @@ RSpec.describe RuboCop::Cop::Layout::EmptyComment, :config do
       expect_offense(<<-RUBY.strip_indent)
         #################################
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Source code comment is empty.
+      RUBY
+    end
+  end
+
+  context 'allow margin comment (default)' do
+    it 'does not register an offense when using margin comment' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        #
+        # Description of `hello` method.
+        #
+        def hello
+        end
+      RUBY
+    end
+  end
+
+  context 'disallow margin comment' do
+    let(:cop_config) { { 'AllowMarginComment' => false } }
+
+    it 'registers an offense when using margin comment' do
+      expect_offense(<<-RUBY.strip_indent)
+        #
+        ^ Source code comment is empty.
+        # Description of `hello` method.
+        #
+        ^ Source code comment is empty.
+        def hello
+        end
       RUBY
     end
   end


### PR DESCRIPTION
Related to #5495.

This PR adds option and document for the following margin comment.

```ruby
#
# Description of `hello` method.
#
def hello
end
```

By default margin comment is allowed.

If the user does not like the margin comment, it can be set as follows.

```yaml
Layout/EmptyComment:
  AllowMarginComment: false
```

It will be warned as follows.

```ruby
% cat /tmp/example.rb
#
# Description of `hello` method.
#
def hello
end

% rubocop --only Layout/EmptyComment /tmp/example.rb
Inspecting 1 file
C

Offenses:

/tmp/example.rb:1:1: C: Layout/EmptyComment: Source code comment is empty.
#
/tmp/example.rb:3:1: C: Layout/EmptyComment: Source code comment is empty.
#

1 file inspected, 2 offenses detected
```

The addition of option to `Layout/EmptyComment` cop I planned is over with this change.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
