### PR TITLE
Improve Lint/DuplicateMethods document

### DIFF
--- a/lib/rubocop/cop/lint/duplicate_methods.rb
+++ b/lib/rubocop/cop/lint/duplicate_methods.rb
@@ -10,11 +10,11 @@ module RuboCop
       #
       #   # bad
       #
-      #   def duplicated
+      #   def foo
       #     1
       #   end
       #
-      #   def duplicated
+      #   def foo
       #     2
       #   end
       #
@@ -22,25 +22,33 @@ module RuboCop
       #
       #   # bad
       #
-      #   def duplicated
+      #   def foo
       #     1
       #   end
       #
-      #   alias duplicated other_duplicated
+      #   alias foo bar
       #
       # @example
       #
       #   # good
       #
-      #   def duplicated
+      #   def foo
       #     1
       #   end
       #
-      #   def other_duplicated
+      #   def bar
       #     2
       #   end
       #
-      #   alias other_duplicated_2 duplicated
+      # @example
+      #
+      #   # good
+      #
+      #   def foo
+      #     1
+      #   end
+      #
+      #   alias bar foo
       class DuplicateMethods < Cop
         MSG = 'Method `%<method>s` is defined at both %<defined>s and ' \
               '%<current>s.'.freeze

--- a/lib/rubocop/cop/lint/duplicate_methods.rb
+++ b/lib/rubocop/cop/lint/duplicate_methods.rb
@@ -39,6 +39,8 @@ module RuboCop
       #   def other_duplicated
       #     2
       #   end
+      #
+      #   alias other_duplicated_2 duplicated
       class DuplicateMethods < Cop
         MSG = 'Method `%<method>s` is defined at both %<defined>s and ' \
               '%<current>s.'.freeze

--- a/manual/cops_lint.md
+++ b/manual/cops_lint.md
@@ -349,6 +349,8 @@ end
 def other_duplicated
   2
 end
+
+alias other_duplicated_2 duplicated
 ```
 
 ## Lint/DuplicatedKey

--- a/manual/cops_lint.md
+++ b/manual/cops_lint.md
@@ -322,35 +322,42 @@ definitions.
 ```ruby
 # bad
 
-def duplicated
+def foo
   1
 end
 
-def duplicated
+def foo
   2
 end
 ```
 ```ruby
 # bad
 
-def duplicated
+def foo
   1
 end
 
-alias duplicated other_duplicated
+alias foo bar
 ```
 ```ruby
 # good
 
-def duplicated
+def foo
   1
 end
 
-def other_duplicated
+def bar
   2
 end
+```
+```ruby
+# good
 
-alias other_duplicated_2 duplicated
+def foo
+  1
+end
+
+alias bar foo
 ```
 
 ## Lint/DuplicatedKey


### PR DESCRIPTION
This is a small document improvement.

The example in Lint/DuplicateMethods document which defines duplicate method by using `alias` keyword is a little hard for me to understand what is wrong.

So I add a good example to help to understand this.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
