### PR TITLE
[Fix #5512] Make Kernel#tap a void-context-method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 * [#5427](https://github.com/bbatsov/rubocop/pull/5427): Fix exception when executing from a different drive on Windows. ([@orgads][])
 * [#5429](https://github.com/bbatsov/rubocop/issues/5429): Detect tabs other than indentation by `Layout/Tab`. ([@pocke][])
 * [#5496](https://github.com/bbatsov/rubocop/pull/5496): Fix a false positive of `Style/FormatStringToken` with unrelated `format` call. ([@pocke][])
+* [#5512](https://github.com/bbatsov/rubocop/issues/5512): Improve `Lint/Void` to detect `Kernel#tap` as method that ignores the block's value. ([@untitaker][])
 
 ### Changes
 
@@ -3177,3 +3178,4 @@
 [@dominicsayers]: https://github.com/dominicsayers
 [@albertpaulp]: https://github.com/albertpaulp
 [@orgads]: https://github.com/orgads
+[@untitaker]: https://github.com/untitaker

--- a/lib/rubocop/ast/node/block_node.rb
+++ b/lib/rubocop/ast/node/block_node.rb
@@ -9,7 +9,7 @@ module RuboCop
     # A `block` node is essentially a method send with a block. Parser nests
     # the `send` node inside the `block` node.
     class BlockNode < Node
-      VOID_CONTEXT_METHODS = %i[each].freeze
+      VOID_CONTEXT_METHODS = %i[each tap].freeze
 
       # The `send` node associated with this block.
       #

--- a/spec/rubocop/ast/block_node_spec.rb
+++ b/spec/rubocop/ast/block_node_spec.rb
@@ -214,6 +214,12 @@ RSpec.describe RuboCop::AST::BlockNode do
       it { expect(block_node.void_context?).to be_truthy }
     end
 
+    context 'when block method is tap' do
+      let(:source) { 'tap { bar }' }
+
+      it { expect(block_node.void_context?).to be_truthy }
+    end
+
     context 'when block method is not each' do
       let(:source) { 'map { bar }' }
 

--- a/spec/rubocop/cop/lint/void_spec.rb
+++ b/spec/rubocop/cop/lint/void_spec.rb
@@ -176,6 +176,17 @@ RSpec.describe RuboCop::Cop::Lint::Void do
     RUBY
   end
 
+  it 'registers two offenses for void literals in `#tap` method' do
+    expect_offense(<<-RUBY.strip_indent)
+      foo.tap do |x|
+        42
+        ^^ Literal `42` used in void context.
+        42
+        ^^ Literal `42` used in void context.
+      end
+    RUBY
+  end
+
   it 'registers two offenses for void literals in a `for`' do
     expect_offense(<<-RUBY.strip_indent)
       for _item in array do


### PR DESCRIPTION
Not sure about two things:

- Error message is not pretty. You might not understand what's happening if you
  are misunderstanding/misremembering the behavior of `tap`. But adding a
  specialized error message is probably too much effort.

- Amount of tests