### PR TITLE
[#5473] Infer TargetRailsVersion from bundler lock files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * [#4008](https://github.com/bbatsov/rubocop/issues/4008): Add new `Style/ExpandPathArguments` cop. ([@koic][])
 * [#4812](https://github.com/bbatsov/rubocop/issues/4812): Add `beginning_only` and `ending_only` style options to `Layout/EmptyLinesAroundClassBody` cop. ([@jmks][])
 * [#5591](https://github.com/bbatsov/rubocop/pull/5591): Include `.arb` file by default. ([@deivid-rodriguez][])
+* [#5473](https://github.com/bbatsov/rubocop/issues/5473): Use `gems.locked` or `Gemfile.lock` to determine the best `TargetRailsVersion` when it is not specified in the config. ([@roberts1000][])
 
 ### Bug fixes
 
@@ -3203,3 +3204,4 @@
 [@georf]: https://github.com/georf
 [@Edouard-chin]: https://github.com/Edouard-chin
 [@eostrom]: https://github.com/eostrom
+[@roberts1000]: https://github.com/roberts1000

--- a/config/default.yml
+++ b/config/default.yml
@@ -119,7 +119,14 @@ AllCops:
   # Else if .ruby-version exists and it contains an MRI version it is used.
   # Otherwise we fallback to the oldest officially supported Ruby version (2.1).
   TargetRubyVersion: ~
-  TargetRailsVersion: 5.0
+  # What version of Rails is the inspected code using?  If a value is specified
+  # for TargetRailsVersion then it is used.  Acceptable values are specificed
+  # as a float (i.e. 5.1); the patch version of Rails should not be included.
+  # If TargetRailsVersion is not set, RuboCop will parse the Gemfile.lock or
+  # gems.locked file to find the version of Rails that has been bound to the
+  # application.  If neither of those files exist, RuboCop will use Rails 5.0
+  # as the default.
+  TargetRailsVersion: ~
 
 #################### Layout ###########################
 


### PR DESCRIPTION
Closes #5473.

Change the config init process slightly for `TargetRailsVersion` to look in `gems.locked` or `Gemfile.lock` for the best value.  Either of those files will lock Rails to a specific version and we can use that information to dynamically pick the best value for `TargetRailsVersion`.

If `TargetRailsVersion` is set in the config file, it still takes precedence and is always used.  If Rails is not in `gems.locked` or `Gemfile.lock`, and the user hasn't specified a version in the config, the default version is still used as the fallback.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
