### PR TITLE
Rubocop Dependency update

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,14 +8,14 @@ gem 'bump', require: false
 gem 'pry'
 gem 'rake', '~> 12.0'
 gem 'rspec', '~> 3.7'
-gem 'rubocop-rspec', '~> 1.20.0'
+gem 'rubocop-rspec', '~> 1.22.0'
 gem 'simplecov', '~> 0.10'
 gem 'test-queue'
 gem 'yard', '~> 0.9'
 
 group :test do
   gem 'codeclimate-test-reporter', '~> 1.0', require: false
-  gem 'public_suffix', '~> 2.0', require: false
+  gem 'public_suffix', '~> 3.0', require: false
   gem 'safe_yaml', require: false
   gem 'webmock', require: false
 end

--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,6 @@ gem 'yard', '~> 0.9'
 
 group :test do
   gem 'codeclimate-test-reporter', '~> 1.0', require: false
-  gem 'public_suffix', '~> 3.0', require: false
   gem 'safe_yaml', require: false
   gem 'webmock', require: false
 end

--- a/spec/rubocop/formatter/disabled_lines_formatter_spec.rb
+++ b/spec/rubocop/formatter/disabled_lines_formatter_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe RuboCop::Formatter::DisabledLinesFormatter do
 
       it 'does not add to cop_disabled_line_ranges' do
         expect { file_started }.not_to(
-          change { formatter.cop_disabled_line_ranges }
+          change(formatter, :cop_disabled_line_ranges)
         )
       end
     end
@@ -35,7 +35,7 @@ RSpec.describe RuboCop::Formatter::DisabledLinesFormatter do
 
       it 'merges the changes into cop_disabled_line_ranges' do
         expect { file_started }.to(
-          change { formatter.cop_disabled_line_ranges }
+          change(formatter, :cop_disabled_line_ranges)
         )
       end
     end

--- a/spec/rubocop/formatter/offense_count_formatter_spec.rb
+++ b/spec/rubocop/formatter/offense_count_formatter_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe RuboCop::Formatter::OffenseCountFormatter do
       let(:offenses) { [] }
 
       it 'does not add to offense_counts' do
-        expect { finish }.not_to change { formatter.offense_counts }
+        expect { finish }.not_to change(formatter, :offense_counts)
       end
     end
 
@@ -28,7 +28,7 @@ RSpec.describe RuboCop::Formatter::OffenseCountFormatter do
       let(:offenses) { [double('offense', cop_name: 'OffendedCop')] }
 
       it 'increments the count for the cop in offense_counts' do
-        expect { finish }.to change { formatter.offense_counts }
+        expect { finish }.to change(formatter, :offense_counts)
       end
     end
   end


### PR DESCRIPTION
Inspired by:  

<img width="319" alt="screen shot 2018-01-27 at 4 08 52 pm" src="https://user-images.githubusercontent.com/12770108/35476345-74bf6b92-037c-11e8-8f4f-a6cd056e7a53.png">

Investigation revealed:

<img width="1015" alt="screen shot 2018-01-27 at 4 01 31 pm" src="https://user-images.githubusercontent.com/12770108/35476348-847dbbb0-037c-11e8-853f-e4c3ed6a713d.png">

and

<img width="1053" alt="screen shot 2018-01-27 at 4 01 20 pm" src="https://user-images.githubusercontent.com/12770108/35476350-8a7108ba-037c-11e8-9ada-10665721453a.png">

Upgrading `rubocop-rspec` resulted in 4 `RSpec/ExpectChange` offenses. This cop seems to have been added recently, and the default is `method_call`.  Makes sense to me :) .

PR that added new cop:  https://github.com/backus/rubocop-rspec/pull/520

-----------------

* [x] Wrote [good commit messages][1].
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
