### PR TITLE
[Fix #5520] Fix `Style/RedundantException` auto-correction does not keep parenthesization.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 * [#5429](https://github.com/bbatsov/rubocop/issues/5429): Detect tabs other than indentation by `Layout/Tab`. ([@pocke][])
 * [#5496](https://github.com/bbatsov/rubocop/pull/5496): Fix a false positive of `Style/FormatStringToken` with unrelated `format` call. ([@pocke][])
 * [#5503](https://github.com/bbatsov/rubocop/issues/5503): Fix `Rails/CreateTableWithTimestamps` false positive when using `to_proc` syntax. ([@wata727][])
+* [#5520](https://github.com/bbatsov/rubocop/issues/5520): Fix `Style/RedundantException` auto-correction does not keep parenthesization. ([@dpostorivo][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/redundant_exception.rb
+++ b/lib/rubocop/cop/style/redundant_exception.rb
@@ -28,11 +28,16 @@ module RuboCop
 
         # Switch `raise RuntimeError, 'message'` to `raise 'message'`, and
         # `raise RuntimeError.new('message')` to `raise 'message'`.
-        def autocorrect(node)
+        def autocorrect(node) # rubocop:disable Metrics/MethodLength
           exploded?(node) do |command, message|
             return lambda do |corrector|
-              corrector.replace(node.source_range,
-                                "#{command} #{message.source}")
+              if node.parenthesized?
+                corrector.replace(node.source_range,
+                                  "#{command}(#{message.source})")
+              else
+                corrector.replace(node.source_range,
+                                  "#{command} #{message.source}")
+              end
             end
           end
           compact?(node) do |new_call, message|

--- a/spec/rubocop/cop/style/redundant_exception_spec.rb
+++ b/spec/rubocop/cop/style/redundant_exception_spec.rb
@@ -33,6 +33,13 @@ RSpec.describe RuboCop::Cop::Style::RedundantException do
       expect(new_src).to eq(result_src)
     end
 
+    it "auto-corrects a #{keyword} RuntimeError and leaves parentheses" do
+      src = "#{keyword}(RuntimeError, msg)"
+      result_src = "#{keyword}(msg)"
+      new_src = autocorrect_source(src)
+      expect(new_src).to eq(result_src)
+    end
+
     it "auto-corrects a #{keyword} RuntimeError.new with parentheses by " \
        'removing RuntimeError.new' do
       src = "#{keyword} RuntimeError.new(msg)"


### PR DESCRIPTION
This PR fixes #5520 and checks for parentheses when autocorrecting `Style/RedundantException` offences.

One thing to note in this PR is that the additional auto correct logic caused a new Metrics/MethodLength so if there's a better way to write the logic I'm prepared to change it.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
