### PR TITLE
[Fix #5515] Fix Style/EmptyElse autocorrect for nested if and case.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 * [#5524](https://github.com/bbatsov/rubocop/issues/5524): Return the instance based on the new type when calls `RuboCop::AST::Node#updated`. ([@wata727][])
 * [#5539](https://github.com/bbatsov/rubocop/pull/5539): Fix compilation error and ruby code generation when passing args to funcall and predicates. ([@Edouard-chin][])
 * [#4669](https://github.com/bbatsov/rubocop/issues/4669): Use binary file contents for cache key so changing EOL characters invalidates the cache. ([@jonas054][])
+* [#5515](https://github.com/bbatsov/rubocop/issues/5515): Fix `Style/EmptyElse` autocorrect for nested if and case statements. ([@asherkach][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/empty_else.rb
+++ b/lib/rubocop/cop/style/empty_else.rb
@@ -109,7 +109,7 @@ module RuboCop
           return false if comment_in_else?(node)
 
           lambda do |corrector|
-            end_pos = base_if_node(node).loc.end.begin_pos
+            end_pos = base_node(node).loc.end.begin_pos
             corrector.remove(range_between(node.loc.else.begin_pos, end_pos))
           end
         end
@@ -151,9 +151,12 @@ module RuboCop
           loc.else.first_line..loc.end.first_line
         end
 
-        def base_if_node(node)
-          return node unless node.case_type? || node.elsif?
-          node.each_ancestor(:if).find { |parent| parent.loc.end } || node
+        def base_node(node)
+          return node if node.case_type?
+          return node unless node.elsif?
+          node.each_ancestor(:if, :case, :when).find(-> { node }) do |parent|
+            parent.loc.end
+          end
         end
 
         def autocorrect_forbidden?(type)

--- a/spec/rubocop/cop/style/empty_else_spec.rb
+++ b/spec/rubocop/cop/style/empty_else_spec.rb
@@ -487,4 +487,45 @@ RSpec.describe RuboCop::Cop::Style::EmptyElse do
       end
     end
   end
+
+  context 'with nested if and case statement' do
+    let(:config) do
+      RuboCop::Config.new('Style/EmptyElse' => {
+                            'EnforcedStyle' => 'nil',
+                            'SupportedStyles' => %w[empty nil both]
+                          },
+                          'Style/MissingElse' => missing_else_config)
+    end
+
+    let(:source) do
+      ['def foo',
+       '  if @params',
+       '    case @params[:x]',
+       '    when :a',
+       '      :b',
+       '    else',
+       '      nil',
+       '    end',
+       '  else',
+       '    :c',
+       '  end',
+       'end'].join("\n")
+    end
+
+    let(:corrected_source) do
+      ['def foo',
+       '  if @params',
+       '    case @params[:x]',
+       '    when :a',
+       '      :b',
+       '    end',
+       '  else',
+       '    :c',
+       '  end',
+       'end'].join("\n")
+    end
+
+    it_behaves_like 'offense registration'
+    it_behaves_like 'auto-correct', 'case'
+  end
 end


### PR DESCRIPTION
In particular, fix the autocorrect to not delete any else statement associated with the outer if statement.

-----------------

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
