### PR TITLE
Restyle examples formatting for `Layout/IndentHeredoc` cop

### DIFF
--- a/lib/rubocop/cop/layout/indent_heredoc.rb
+++ b/lib/rubocop/cop/layout/indent_heredoc.rb
@@ -12,13 +12,31 @@ module RuboCop
       #       this cop does not add any offenses for long here documents to
       #       avoid `Metrics/LineLength`'s offenses.
       #
-      # @example
-      #
+      # @example EnforcedStyle: auto_detection (default)
       #   # bad
       #   <<-RUBY
       #   something
       #   RUBY
       #
+      #   # good
+      #   # When using Ruby 2.3 or higher.
+      #   <<~RUBY
+      #     something
+      #   RUBY
+      #
+      #   # good
+      #   # When using Ruby 2.2 or lower and enabled Rails department.
+      #   # The following is possible to enable Rails department by
+      #   # adding for example:
+      #   #
+      #   # Rails:
+      #   #   Enabled: true
+      #   #
+      #   <<-RUBY.strip_heredoc
+      #     something
+      #   RUBY
+      #
+      # @example EnforcedStyle: squiggly
       #   # good
       #   # When EnforcedStyle is squiggly, bad code is auto-corrected to the
       #   # following code.
@@ -26,12 +44,30 @@ module RuboCop
       #     something
       #   RUBY
       #
+      # @example EnforcedStyle: active_support
       #   # good
       #   # When EnforcedStyle is active_support, bad code is auto-corrected to
       #   # the following code.
       #   <<-RUBY.strip_heredoc
       #     something
       #   RUBY
+      #
+      # @example EnforcedStyle: powerpack
+      #   # good
+      #   # When EnforcedStyle is powerpack, bad code is auto-corrected to
+      #   # the following code.
+      #   <<-RUBY.strip_indent
+      #     something
+      #   RUBY
+      #
+      # @example EnforcedStyle: unindent
+      #   # good
+      #   # When EnforcedStyle is unindent, bad code is auto-corrected to
+      #   # the following code.
+      #   <<-RUBY.unindent
+      #     something
+      #   RUBY
+      #
       class IndentHeredoc < Cop
         include Heredoc
         include ConfigurableEnforcedStyle

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -1952,6 +1952,8 @@ Note: When `Metrics/LineLength`'s `AllowHeredoc` is false(not default),
 
 ### Examples
 
+#### EnforcedStyle: auto_detection (default)
+
 ```ruby
 # bad
 <<-RUBY
@@ -1959,16 +1961,60 @@ something
 RUBY
 
 # good
-# When EnforcedStyle is squiggly, bad code is auto-corrected to the
-# following code.
+# When using Ruby 2.3 or higher.
 <<~RUBY
   something
 RUBY
 
 # good
+# When using Ruby 2.2 or lower and enabled Rails department.
+# The following is possible to enable Rails department by
+# adding for example:
+#
+# Rails:
+#   Enabled: true
+#
+<<-RUBY.strip_heredoc
+  something
+RUBY
+```
+#### EnforcedStyle: squiggly
+
+```ruby
+# good
+# When EnforcedStyle is squiggly, bad code is auto-corrected to the
+# following code.
+<<~RUBY
+  something
+RUBY
+```
+#### EnforcedStyle: active_support
+
+```ruby
+# good
 # When EnforcedStyle is active_support, bad code is auto-corrected to
 # the following code.
 <<-RUBY.strip_heredoc
+  something
+RUBY
+```
+#### EnforcedStyle: powerpack
+
+```ruby
+# good
+# When EnforcedStyle is powerpack, bad code is auto-corrected to
+# the following code.
+<<-RUBY.strip_indent
+  something
+RUBY
+```
+#### EnforcedStyle: unindent
+
+```ruby
+# good
+# When EnforcedStyle is unindent, bad code is auto-corrected to
+# the following code.
+<<-RUBY.unindent
   something
 RUBY
 ```


### PR DESCRIPTION
Follow up of https://github.com/bbatsov/rubocop/pull/4880#issuecomment-338499947.

This is only document change.

This commit adds an example of `EnforcedStyle` to `Layout/IndentHeredoc` cop.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
