### PR TITLE
[Fix #5524] Return the instance based on the new type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 * [#5496](https://github.com/bbatsov/rubocop/pull/5496): Fix a false positive of `Style/FormatStringToken` with unrelated `format` call. ([@pocke][])
 * [#5503](https://github.com/bbatsov/rubocop/issues/5503): Fix `Rails/CreateTableWithTimestamps` false positive when using `to_proc` syntax. ([@wata727][])
 * [#5520](https://github.com/bbatsov/rubocop/issues/5520): Fix `Style/RedundantException` auto-correction does not keep parenthesization. ([@dpostorivo][])
+* [#5524](https://github.com/bbatsov/rubocop/issues/5524): Return the instance based on the new type when calls `RuboCop::AST::Node#updated`. ([@wata727][])
 
 ### Changes
 

--- a/lib/rubocop/ast/builder.rb
+++ b/lib/rubocop/ast/builder.rb
@@ -2,41 +2,49 @@
 
 module RuboCop
   module AST
-    # `RuboCop::Builder` is an AST builder that is utilized to let `Parser`
+    # `RuboCop::AST::Builder` is an AST builder that is utilized to let `Parser`
     # generate ASTs with {RuboCop::AST::Node}.
     #
     # @example
     #   buffer = Parser::Source::Buffer.new('(string)')
     #   buffer.source = 'puts :foo'
     #
-    #   builder = RuboCop::Builder.new
-    #   parser = Parser::CurrentRuby.new(builder)
+    #   builder = RuboCop::AST::Builder.new
+    #   require 'parser/ruby25'
+    #   parser = Parser::Ruby25.new(builder)
     #   root_node = parser.parse(buffer)
     class Builder < Parser::Builders::Default
       NODE_MAP = {
-        AndNode          => [:and],
-        ArgsNode         => [:args],
-        ArrayNode        => [:array],
-        BlockNode        => [:block],
-        CaseNode         => [:case],
-        DefNode          => %i[def defs],
-        EnsureNode       => [:ensure],
-        ForNode          => [:for],
-        HashNode         => [:hash],
-        IfNode           => [:if],
-        KeywordSplatNode => [:kwsplat],
-        OrNode           => [:or],
-        PairNode         => [:pair],
-        RegexpNode       => [:regexp],
-        ResbodyNode      => [:resbody],
-        SendNode         => %i[csend send],
-        StrNode          => %i[str dstr xstr],
-        SuperNode        => %i[super zsuper],
-        SymbolNode       => [:sym],
-        UntilNode        => %i[until until_post],
-        WhenNode         => [:when],
-        WhileNode        => %i[while while_post],
-        YieldNode        => [:yield]
+        and:        AndNode,
+        args:       ArgsNode,
+        array:      ArrayNode,
+        block:      BlockNode,
+        case:       CaseNode,
+        def:        DefNode,
+        defs:       DefNode,
+        ensure:     EnsureNode,
+        for:        ForNode,
+        hash:       HashNode,
+        if:         IfNode,
+        kwsplat:    KeywordSplatNode,
+        or:         OrNode,
+        pair:       PairNode,
+        regexp:     RegexpNode,
+        resbody:    ResbodyNode,
+        csend:      SendNode,
+        send:       SendNode,
+        str:        StrNode,
+        dstr:       StrNode,
+        xstr:       StrNode,
+        super:      SuperNode,
+        zsuper:     SuperNode,
+        sym:        SymbolNode,
+        until:      UntilNode,
+        until_post: UntilNode,
+        when:       WhenNode,
+        while:      WhileNode,
+        while_post: WhileNode,
+        yield:      YieldNode
       }.freeze
 
       # Generates {Node} from the given information.
@@ -55,17 +63,7 @@ module RuboCop
       private
 
       def node_klass(type)
-        node_map[type] || Node
-      end
-
-      # Take the human readable constant and generate a hash map where each
-      # (mapped) node type is a key with its constant as the value.
-      def node_map
-        @node_map ||= begin
-          NODE_MAP.each_pair.each_with_object({}) do |(klass, types), map|
-            types.each { |type| map[type] = klass }
-          end
-        end
+        NODE_MAP[type] || Node
       end
     end
   end

--- a/lib/rubocop/ast/node.rb
+++ b/lib/rubocop/ast/node.rb
@@ -100,7 +100,8 @@ module RuboCop
       # part of it is changed.
       def updated(type = nil, children = nil, properties = {})
         properties[:location] ||= @location
-        self.class.new(type || @type, children || @children, properties)
+        klass = RuboCop::AST::Builder::NODE_MAP[type || @type] || Node
+        klass.new(type || @type, children || @children, properties)
       end
 
       # Returns the index of the receiver node in its siblings. (Sibling index

--- a/spec/rubocop/cop/rails/lexically_scoped_action_filter_spec.rb
+++ b/spec/rubocop/cop/rails/lexically_scoped_action_filter_spec.rb
@@ -144,4 +144,18 @@ RSpec.describe RuboCop::Cop::Rails::LexicallyScopedActionFilter do
       end
     RUBY
   end
+
+  it "doesn't register an offense when using %I literal" do
+    expect_no_offenses <<-RUBY
+      class FooController < ApplicationController
+        before_action :foo, except: %I[index show]
+
+        def index
+        end
+
+        def show
+        end
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
Fixes #5524

When parsing the following, we get `StrNode` instead of `SymbolNode`.

```ruby
%I[index]
```

```
$ pry -rparser -rparser/ruby24 -rrubocop
[1] pry(main)> buffer = Parser::Source::Buffer.new('(string)')
[2] pry(main)> buffer.source = "%I[index]"
[3] pry(main)> builder = RuboCop::AST::Builder.new
[4] pry(main)> parser = Parser::Ruby24.new(builder)
[5] pry(main)> node = parser.parse(buffer)
=> s(:array,
  s(;sym, :index))
[6] pry(main)> node.children.first.type
=> :sym
[7] pry(main)> node.children.first.class
=> RuboCop::AST::StrNode # Why?
```

This is because the parser gem updates the node itself in `Parser::AST::Node#symbols_compose` when processing `tSYMBOLS_BEG`.

See also:
https://github.com/whitequark/parser/blob/v2.4.0.2/lib/parser/ruby24.y#L1738
https://github.com/whitequark/parser/blob/v2.4.0.2/lib/parser/builders/default.rb#L298

However, since RuboCop overrides `Parser::AST::Node#updated`, even if the type is updated, it will use the current class as it is.

In order to prevent this, it creates an instance based on type instead of `self` class.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
