### PR TITLE
Include `.axlsx` file by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * [#5358](https://github.com/bbatsov/rubocop/pull/5358):  `--no-auto-gen-timestamp` CLI option suppresses the inclusion of the date and time it was generated in auto-generated config. ([@dominicsayers][])
 * [#4274](https://github.com/bbatsov/rubocop/issues/4274): Add new `Layout/EmptyComment` cop. ([@koic][])
 * [#4477](https://github.com/bbatsov/rubocop/issues/4477): Add new configuration directive: `inherit_mode` for merging arrays. ([@leklund][])
+* [#5532](https://github.com/bbatsov/rubocop/pull/5532): Include `.axlsx` file by default. ([@georf][])
 
 ### Bug fixes
 
@@ -3186,3 +3187,4 @@
 [@orgads]: https://github.com/orgads
 [@leklund]: https://github.com/leklund
 [@walinga]: https://github.com/walinga
+[@georf]: https://github.com/georf

--- a/config/default.yml
+++ b/config/default.yml
@@ -9,6 +9,7 @@ inherit_from:
 AllCops:
   # Include common Ruby source files.
   Include:
+    - '**/*.axlsx'
     - '**/*.builder'
     - '**/*.fcgi'
     - '**/*.gemfile'

--- a/lib/rubocop/target_finder.rb
+++ b/lib/rubocop/target_finder.rb
@@ -4,6 +4,7 @@ require 'set'
 
 module RuboCop
   RUBY_EXTENSIONS = %w[.rb
+                       .axlsx
                        .builder
                        .fcgi
                        .gemfile


### PR DESCRIPTION
axlsx_rails gem uses `.axlsx` extension.
https://github.com/straydogstudio/axlsx_rails

For example:

```ruby

wb = xlsx_package.workbook
wb.add_worksheet(name: "Buttons") do |sheet|
  @buttons.each do |button|
      sheet.add_row [button.name, button.category, button.price]
  end
end

```

I've added .axlsx to TargetFinder and default.yml

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/