### PR TITLE
Remove `final_blank_line` style from `Layout/TrailingBlankLines`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@
 * [#4704](https://github.com/bbatsov/rubocop/issues/4704): Move `Lint/EndAlignment`, `Lint/DefEndAlignment`, `Lint/BlockAlignment`, and `Lint/ConditionPosition` to the `Layout` namespace. ([@bquorning][])
 * [#5283](https://github.com/bbatsov/rubocop/issues/5283): Change file path output by `Formatter::JSONFormatter` from relative path to smart path. ([@koic][])
 * `Style/SafeNavigation` will now register an offense for methods that `nil` responds to. ([@rrosenblum][])
+* [#5533](https://github.com/bbatsov/rubocop/pull/5533): Remove support `final_blank_line` style from `Layout/TrailingBlankLines` cop. ([@koic][])
 
 ## 0.52.1 (2017-12-27)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -624,12 +624,6 @@ Layout/Tab:
   # replace each tab.
   IndentationWidth: ~
 
-Layout/TrailingBlankLines:
-  EnforcedStyle: final_newline
-  SupportedStyles:
-    - final_newline
-    - final_blank_line
-
 #################### Naming ##########################
 
 Naming/FileName:

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -3915,29 +3915,7 @@ source code.
 
 ### Examples
 
-#### EnforcedStyle: final_blank_line
-
 ```ruby
-# `final_blank_line` looks for one blank line followed by a new line
-# at the end of files.
-
-# bad
-class Foo; end
-# EOF
-
-# bad
-class Foo; end # EOF
-
-# good
-class Foo; end
-
-# EOF
-```
-#### EnforcedStyle: final_newline (default)
-
-```ruby
-# `final_newline` looks for one newline at the end of files.
-
 # bad
 class Foo; end
 
@@ -3950,12 +3928,6 @@ class Foo; end # EOF
 class Foo; end
 # EOF
 ```
-
-### Configurable attributes
-
-Name | Default value | Configurable values
---- | --- | ---
-EnforcedStyle | `final_newline` | `final_newline`, `final_blank_line`
 
 ### References
 

--- a/spec/rubocop/cop/layout/trailing_blank_lines_spec.rb
+++ b/spec/rubocop/cop/layout/trailing_blank_lines_spec.rb
@@ -3,124 +3,68 @@
 RSpec.describe RuboCop::Cop::Layout::TrailingBlankLines, :config do
   subject(:cop) { described_class.new(config) }
 
-  context 'when EnforcedStyle is final_newline' do
-    let(:cop_config) { { 'EnforcedStyle' => 'final_newline' } }
+  it 'accepts final newline' do
+    expect_no_offenses("x = 0\n")
+  end
 
-    it 'accepts final newline' do
-      expect_no_offenses("x = 0\n")
-    end
+  it 'accepts an empty file' do
+    expect_no_offenses('')
+  end
 
-    it 'accepts an empty file' do
-      expect_no_offenses('')
-    end
-
-    it 'accepts final blank lines if they come after __END__' do
-      expect_no_offenses(<<-RUBY.strip_indent)
+  it 'accepts final blank lines if they come after __END__' do
+    expect_no_offenses(<<-RUBY.strip_indent)
         x = 0
 
         __END__
 
       RUBY
-    end
+  end
 
-    it 'accepts final blank lines if they come after __END__ in empty file' do
-      expect_no_offenses(<<-RUBY.strip_indent)
+  it 'accepts final blank lines if they come after __END__ in empty file' do
+    expect_no_offenses(<<-RUBY.strip_indent)
         __END__
 
 
       RUBY
-    end
-
-    it 'registers an offense for multiple trailing blank lines' do
-      inspect_source(['x = 0', '', '', '', ''])
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages).to eq(['3 trailing blank lines detected.'])
-    end
-
-    it 'registers an offense for multiple blank lines in an empty file' do
-      inspect_source(['', '', '', '', ''])
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages).to eq(['3 trailing blank lines detected.'])
-    end
-
-    it 'registers an offense for no final newline after assignment' do
-      inspect_source('x = 0')
-      expect(cop.messages).to eq(['Final newline missing.'])
-    end
-
-    it 'registers an offense for no final newline after block comment' do
-      inspect_source("puts 'testing rubocop when final new line is missing " \
-                     "after block comments'\n\n=begin\nfirst line\nsecond " \
-                     "line\nthird line\n=end")
-
-      expect(cop.messages).to eq(['Final newline missing.'])
-    end
-
-    it 'auto-corrects unwanted blank lines' do
-      new_source = autocorrect_source(['x = 0', '', '', '', ''])
-      expect(new_source).to eq(['x = 0', ''].join("\n"))
-    end
-
-    it 'auto-corrects unwanted blank lines in an empty file' do
-      new_source = autocorrect_source(['', '', '', '', ''])
-      expect(new_source).to eq(['', ''].join("\n"))
-    end
-
-    it 'auto-corrects even if some lines have space' do
-      new_source = autocorrect_source(['x = 0', '', '  ', '', ''])
-      expect(new_source).to eq(['x = 0', ''].join("\n"))
-    end
   end
 
-  context 'when EnforcedStyle is final_blank_line' do
-    let(:cop_config) { { 'EnforcedStyle' => 'final_blank_line' } }
+  it 'registers an offense for multiple trailing blank lines' do
+    inspect_source(['x = 0', '', '', '', ''])
+    expect(cop.offenses.size).to eq(1)
+    expect(cop.messages).to eq(['3 trailing blank lines detected.'])
+  end
 
-    it 'registers an offense for final newline' do
-      inspect_source(['x = 0', ''])
-      expect(cop.messages).to eq(['Trailing blank line missing.'])
-    end
+  it 'registers an offense for multiple blank lines in an empty file' do
+    inspect_source(['', '', '', '', ''])
+    expect(cop.offenses.size).to eq(1)
+    expect(cop.messages).to eq(['3 trailing blank lines detected.'])
+  end
 
-    it 'registers an offense for multiple trailing blank lines' do
-      inspect_source(['x = 0', '', '', '', ''])
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages)
-        .to eq(['3 trailing blank lines instead of 1 detected.'])
-    end
+  it 'registers an offense for no final newline after assignment' do
+    inspect_source('x = 0')
+    expect(cop.messages).to eq(['Final newline missing.'])
+  end
 
-    it 'registers an offense for multiple blank lines in an empty file' do
-      inspect_source(['', '', '', '', ''])
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages)
-        .to eq(['3 trailing blank lines instead of 1 detected.'])
-    end
+  it 'registers an offense for no final newline after block comment' do
+    inspect_source("puts 'testing rubocop when final new line is missing " \
+                   "after block comments'\n\n=begin\nfirst line\nsecond " \
+                   "line\nthird line\n=end")
 
-    it 'registers an offense for no final newline' do
-      inspect_source('x = 0')
-      expect(cop.messages).to eq(['Final newline missing.'])
-    end
+    expect(cop.messages).to eq(['Final newline missing.'])
+  end
 
-    it 'accepts final blank line' do
-      expect_no_offenses("x = 0\n\n")
-    end
+  it 'auto-corrects unwanted blank lines' do
+    new_source = autocorrect_source(['x = 0', '', '', '', ''])
+    expect(new_source).to eq(['x = 0', ''].join("\n"))
+  end
 
-    it 'auto-corrects unwanted blank lines' do
-      new_source = autocorrect_source(['x = 0', '', '', '', ''])
-      expect(new_source).to eq(['x = 0', '', ''].join("\n"))
-    end
+  it 'auto-corrects unwanted blank lines in an empty file' do
+    new_source = autocorrect_source(['', '', '', '', ''])
+    expect(new_source).to eq(['', ''].join("\n"))
+  end
 
-    it 'auto-corrects unwanted blank lines in an empty file' do
-      new_source = autocorrect_source(['', '', '', '', ''])
-      expect(new_source).to eq(['', '', ''].join("\n"))
-    end
-
-    it 'auto-corrects missing blank line' do
-      new_source = autocorrect_source(['x = 0', ''])
-      expect(new_source).to eq(['x = 0', '', ''].join("\n"))
-    end
-
-    it 'auto-corrects missing newline' do
-      new_source = autocorrect_source(['x = 0'])
-      expect(new_source).to eq(['x = 0', '', ''].join("\n"))
-    end
+  it 'auto-corrects even if some lines have space' do
+    new_source = autocorrect_source(['x = 0', '', '  ', '', ''])
+    expect(new_source).to eq(['x = 0', ''].join("\n"))
   end
 end


### PR DESCRIPTION
Follow up of https://github.com/bbatsov/rubocop/pull/5463/#issuecomment-361879467.

In `EnforcedStyle: final_newline (default)`, the following are checked.

- Superflous trailing blank lines at end of file.
- The presence of final newline `"\ n"`.

The above requirements to be checked by this cop are satisfied.

Thus this PR removes supported `final_blank_line` style which is unclear useful opportunity. This will cause the `SupportedStyles` to be one, so the style configuration will be removed from this cop.
Also change the test codes to leave the test cases of `EnforcedStyle: final_newline (default)` and indent it again.

See the discussion in #5463 for the background of this change.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
