### PR TITLE
[Fix #5534] remove empty line after `Style/EachWithObject` autocorrect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@
 * [#5603](https://github.com/bbatsov/rubocop/pull/5603): Fix falsy offense for `Style/RedundantSelf` with pseudo variables. ([@pocke][])
 * [#5547](https://github.com/bbatsov/rubocop/issues/5547): Fix auto-correction of of `Layout/BlockEndNewline` when there is top level code outside of a class. ([@rrosenblum][])
 * [#5599](https://github.com/bbatsov/rubocop/issues/5599): Fix the suggestion being used by `Lint/NumberConversion` to use base 10 with Integer. ([@rrosenblum][])
+* [#5534](https://github.com/bbatsov/rubocop/issues/5534): Fix `Style/EachWithObject` auto-correction leaves an empty line. ([@flyerhzm][])
 
 ### Changes
 

--- a/spec/rubocop/cop/style/each_with_object_spec.rb
+++ b/spec/rubocop/cop/style/each_with_object_spec.rb
@@ -27,7 +27,6 @@ RSpec.describe RuboCop::Cop::Style::EachWithObject do
 
     expect(corrected).to eq(['[1, 2, 3].each_with_object({}) do |i, h|',
                              '  h[i] = i',
-                             '  ',
                              'end',
                              ''].join("\n"))
   end
@@ -40,7 +39,6 @@ RSpec.describe RuboCop::Cop::Style::EachWithObject do
     RUBY
 
     expect(corrected).to eq(['[1, 2, 3].each_with_object({}) do |i, h|',
-                             '  ',
                              'end',
                              ''].join("\n"))
   end


### PR DESCRIPTION
See #5534 

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
