### PR TITLE
Fix issues related to passing arguments to funcall and predicates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 * [#5503](https://github.com/bbatsov/rubocop/issues/5503): Fix `Rails/CreateTableWithTimestamps` false positive when using `to_proc` syntax. ([@wata727][])
 * [#5520](https://github.com/bbatsov/rubocop/issues/5520): Fix `Style/RedundantException` auto-correction does not keep parenthesization. ([@dpostorivo][])
 * [#5524](https://github.com/bbatsov/rubocop/issues/5524): Return the instance based on the new type when calls `RuboCop::AST::Node#updated`. ([@wata727][])
+* [#5539](https://github.com/bbatsov/rubocop/pull/5539): Fix compilation error and ruby code generation when passing args to funcall and predicates. ([@Edouard-chin][])
 
 ### Changes
 
@@ -3189,3 +3190,4 @@
 [@leklund]: https://github.com/leklund
 [@walinga]: https://github.com/walinga
 [@georf]: https://github.com/georf
+[@Edouard-chin]: https://github.com/Edouard-chin

--- a/lib/rubocop/node_pattern.rb
+++ b/lib/rubocop/node_pattern.rb
@@ -369,7 +369,7 @@ module RuboCop
         if method.end_with?('(') # is there an arglist?
           args = compile_args(tokens)
           method = method[0..-2] # drop the trailing (
-          "(#{method}(#{cur_node}#{'.type' if seq_head}),#{args.join(',')})"
+          "(#{method}(#{cur_node}#{'.type' if seq_head},#{args.join(',')}))"
         else
           "(#{method}(#{cur_node}#{'.type' if seq_head}))"
         end

--- a/lib/rubocop/node_pattern.rb
+++ b/lib/rubocop/node_pattern.rb
@@ -384,10 +384,13 @@ module RuboCop
       end
 
       def compile_args(tokens)
-        args = []
-        args << compile_arg(tokens.shift) until tokens.first == ')'
-        tokens.shift # drop the )
-        args
+        index = tokens.find_index { |token| token == ')' }
+
+        tokens.slice!(0..index).each_with_object([]) do |token, args|
+          next if [')', ','].include?(token)
+
+          args << compile_arg(token)
+        end
       end
 
       def compile_arg(token)

--- a/spec/rubocop/node_pattern_spec.rb
+++ b/spec/rubocop/node_pattern_spec.rb
@@ -1052,12 +1052,12 @@ RSpec.describe RuboCop::NodePattern do
           false
         end
 
-        def witharg(_foo, bar)
-          bar
+        def witharg(foo, bar)
+          foo == bar
         end
 
-        def withargs(_foo, _bar, qux)
-          qux
+        def withargs(foo, bar, qux)
+          foo.between?(bar, qux)
         end
       end
     end
@@ -1065,6 +1065,22 @@ RSpec.describe RuboCop::NodePattern do
     context 'without extra arguments' do
       let(:pattern) { '(lvasgn #goodmatch ...)' }
       let(:ruby) { 'a = 1' }
+
+      it_behaves_like :matching
+    end
+
+    context 'with one argument' do
+      let(:pattern) { '(str #witharg(%1))' }
+      let(:ruby) { '"foo"' }
+      let(:params) { %w[foo] }
+
+      it_behaves_like :matching
+    end
+
+    context 'with multiple arguments' do
+      let(:pattern) { '(str #withargs(%1, %2))' }
+      let(:ruby) { '"c"' }
+      let(:params) { %w[a d] }
 
       it_behaves_like :matching
     end

--- a/spec/rubocop/node_pattern_spec.rb
+++ b/spec/rubocop/node_pattern_spec.rb
@@ -848,6 +848,23 @@ RSpec.describe RuboCop::NodePattern do
         it_behaves_like :nonmatching
       end
     end
+
+    context 'with multiple arguments' do
+      let(:pattern) { '(str between?(%1, %2))' }
+      let(:ruby) { '"c"' }
+
+      context 'for which the predicate is true' do
+        let(:params) { %w[a d] }
+
+        it_behaves_like :matching
+      end
+
+      context 'for which the predicate is false' do
+        let(:params) { %w[a b] }
+
+        it_behaves_like :nonmatching
+      end
+    end
   end
 
   describe 'params' do


### PR DESCRIPTION
Hey guys, thanks for creating and maintaining this gem 😸 
This PR fixes 2 issues I found with the compiler:

Fixed an issue with multiple args on predicates:

- Any predicate method call was able to receive only a single argument, otherwise an error was thrown during compilation
- The reason is because the `compile_arg` method was stumbling into the `,` token (used to split earch args)

---------------------

Fixed an issue when funcall were passed argument:

- Passing argument to funcall (any numbers) wasn't working, the ruby code generate from the compiler wasn't valid, a closing parenthesis was misplaced. The code was looking something like
```
#before
(my_method(node0), arg1, arg2)

#after
(my_method(node0, arg1, arg2))
```
