### PR TITLE
Add a TODO comment to `FrozenStringLiteral` module

### DIFF
--- a/lib/rubocop/cop/mixin/frozen_string_literal.rb
+++ b/lib/rubocop/cop/mixin/frozen_string_literal.rb
@@ -21,6 +21,10 @@ module RuboCop
       def frozen_string_literals_enabled?
         ruby_version = processed_source.ruby_version
         return false unless ruby_version
+        # TODO: Frozen string literal will be default in Ruby 3.0
+        # or not yet determinable.
+        # It is necessary to change according to trend in the future.
+        # https://bugs.ruby-lang.org/issues/8976#note-41
         return true if ruby_version >= 3.0
         return false unless ruby_version >= 2.3
 


### PR DESCRIPTION
Follow up of #5036.

This PR adds a memorandum to source code.

If frozen string literal is default in Ruby 3.0 it will remove this TODO comment and if not default it will need to change the conditional expression of `return true if ruby_version >= 3.0`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
