### PR TITLE
[#4257] `BlockLength`: allow specifying modules in `ExcludedMethods`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 
 * [#5752](https://github.com/bbatsov/rubocop/pull/5752): Add `String#delete_{prefix,suffix}` to Lint/Void cop. ([@bdewater][])
 * [#5734](https://github.com/bbatsov/rubocop/pull/5734): Add `by`, `on`, `in` and `at` to allowed names of `Naming/UncommunicativeMethodParamName` cop in default config. ([@AlexWayfer][])
+* [#4257](https://github.com/bbatsov/rubocop/issues/4257): Allow specifying module name in `Metrics/BlockLength`'s `ExcludedMethods` configuration option. ([@akhramov][])
 
 ## 0.54.0 (2018-03-21)
 
@@ -90,7 +91,6 @@
 * Add new `Naming/MemoizedInstanceVariableName` cop. ([@satyap][])
 * [#5376](https://github.com/bbatsov/rubocop/issues/5376): Add new `Style/EmptyLineAfterGuardClause` cop. ([@unkmas][])
 * Add new `Rails/ActiveRecordAliases` cop. ([@elebow][])
-* [#4257](https://github.com/bbatsov/rubocop/issues/4257): Allow specifying module name in `Metrics/BlockLength`'s `ExcludedMethods` configuration option. ([@akhramov][])
 
 ### Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@
 * Add new `Naming/MemoizedInstanceVariableName` cop. ([@satyap][])
 * [#5376](https://github.com/bbatsov/rubocop/issues/5376): Add new `Style/EmptyLineAfterGuardClause` cop. ([@unkmas][])
 * Add new `Rails/ActiveRecordAliases` cop. ([@elebow][])
+* [#4257](https://github.com/bbatsov/rubocop/issues/4257): Allow specifying module name in `Metrics/BlockLength`'s `ExcludedMethods` configuration option. ([@akhramov][])
 
 ### Bug fixes
 

--- a/lib/rubocop/cop/metrics/block_length.rb
+++ b/lib/rubocop/cop/metrics/block_length.rb
@@ -13,7 +13,7 @@ module RuboCop
         LABEL = 'Block'.freeze
 
         def on_block(node)
-          return if excluded_methods.include?(node.send_node.method_name.to_s)
+          return if excluded_methods.include?(node.send_node.source)
           check_code_length(node)
         end
 

--- a/lib/rubocop/cop/metrics/block_length.rb
+++ b/lib/rubocop/cop/metrics/block_length.rb
@@ -13,11 +13,27 @@ module RuboCop
         LABEL = 'Block'.freeze
 
         def on_block(node)
-          return if excluded_methods.include?(node.send_node.source)
+          return if excluded_method?(node)
           check_code_length(node)
         end
 
         private
+
+        def excluded_method?(node)
+          node_receiver = node.receiver && node.receiver.source.gsub(/\s+/, '')
+          node_method = String(node.method_name)
+
+          excluded_methods.any? do |config|
+            receiver, method = config.split('.')
+
+            unless method
+              method = receiver
+              receiver = node_receiver
+            end
+
+            method == node_method && receiver == node_receiver
+          end
+        end
 
         def excluded_methods
           cop_config['ExcludedMethods'] || []

--- a/spec/rubocop/cop/metrics/block_length_spec.rb
+++ b/spec/rubocop/cop/metrics/block_length_spec.rb
@@ -156,7 +156,33 @@ RSpec.describe RuboCop::Cop::Metrics::BlockLength, :config do
     it_behaves_like('ignoring an offense on an excluded method',
                     'Gem::Specification.new')
 
-    it_behaves_like('ignoring an offense on an excluded method',
-                    'cool.method.chain')
+    context 'when receiver contains whitespaces' do
+      before { cop_config['ExcludedMethods'] = ['Foo::Bar.baz'] }
+
+      it 'ignores whitespaces' do
+        expect_no_offenses(<<-RUBY.strip_indent)
+          Foo::
+            Bar.baz do
+            a = 1
+            a = 2
+            a = 3
+          end
+        RUBY
+      end
+    end
+
+    context 'when a method is ignored, but receiver is a module' do
+      before { cop_config['ExcludedMethods'] = ['baz'] }
+
+      it 'does not report an offense' do
+        expect_no_offenses(<<-RUBY.strip_indent)
+          Foo::Bar.baz do
+            a = 1
+            a = 2
+            a = 3
+          end
+        RUBY
+      end
+    end
   end
 end


### PR DESCRIPTION
Currently `Metrics/BlockLength` cop has `ExcludedMethods`
configuration option, which only allows to specify method names,
without a module, i.e. the following works:
```yaml
Metrics/BlockLength:
  ExcludedMethods: ['new']
```
But the following doesn't:
```yaml
Metrics/BlockLength:
  ExcludedMethods: ['Gem::Specification.new']
```

This change tweaks `Cop::Metrics::BlockLength#on_block` so it looks
not on the method being called, but rather on the whole
`SendNode`. This preserves current behavior, but also lets specifying
more interesting constructs like `Gem::Specification.new` or even
method chains (`foo.bar.baz`).

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
