### PR TITLE
Modify SafeNavigationChain to register an offense for methods that nil responds to

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@
 * `Style/SafeNavigation` will now register an offense for methods that `nil` responds to. ([@rrosenblum][])
 * [#5542](https://github.com/bbatsov/rubocop/pull/5542): Exclude `.git/` by default. ([@pocke][])
 * Tell Read the Docs to build downloadable docs. ([@eostrom][])
+* `Lint/SafeNavigationChain` will now register an offense for methods that `nil` responds to. ([@rrosenblum][])
 
 ## 0.52.1 (2017-12-27)
 


### PR DESCRIPTION
I know we don't normally have multi sentence messages, but I figured it would be important since there is a good chance the current code is likely relying on side effects. I also opted to not automatically auto-correct any method that `nil` responds to since the correction could cause the code to work differently.