### PR TITLE
[Fix #5553] Fix a false positive for `Rails/FilePath` cop

### DIFF
--- a/lib/rubocop/cop/rails/file_path.rb
+++ b/lib/rubocop/cop/rails/file_path.rb
@@ -33,8 +33,8 @@ module RuboCop
 
         def on_dstr(node)
           unless node.children.last.source.start_with?('.')
-            return if rails_root_nodes?(node) &&
-                      !node.children.last.source.include?(File::SEPARATOR)
+            return unless rails_root_nodes?(node)
+            return unless node.children.last.source.include?(File::SEPARATOR)
           end
 
           register_offense(node)

--- a/spec/rubocop/cop/rails/file_path_spec.rb
+++ b/spec/rubocop/cop/rails/file_path_spec.rb
@@ -15,6 +15,14 @@ RSpec.describe RuboCop::Cop::Rails::FilePath do
     end
   end
 
+  context 'when using string interpolation without Rails.root' do
+    it 'does not registers an offense' do
+      expect_no_offenses(<<-'RUBY'.strip_indent)
+        repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?('/')
+      RUBY
+    end
+  end
+
   context 'when using File.join with Rails.root' do
     it 'registers an offense' do
       expect_offense(<<-RUBY.strip_indent)


### PR DESCRIPTION
Fixes #5553.

This PR fixes the following false positve.

```console
% cat /tmp/a.rb
repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?('/')

% rubocop --only Rails/FilePath /tmp/a.rb
/tmp/a.rb:1:13: C: Rails/FilePath: Please use Rails.root.join('path', 'to') instead.
repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?('/')
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^

1 file inspected, 1 offense detected
```

This regression was due to #5461.
Since this is a regression for changes that have not yet been released, it is not described in CHANGELOG.md.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
