### PR TITLE
Remove duplicate entry for @scottmatthewman in contributors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3077,7 +3077,6 @@
 [@groddeck]: https://github.com/groddeck
 [@b-t-g]: https://github.com/b-t-g
 [@coorasse]: https://github.com/coorasse
-[@scottmatthewman]: https://github.com/scottmatthewman
 [@tcdowney]: https://github.com/tcdowney
 [@logicminds]: https://github.com/logicminds
 [@abrom]: https://github.com/abrom


### PR DESCRIPTION
@scottmatthewman had been added twice to the list of contributors in `CHANGELOG.md`

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
