### PR TITLE
[#4910] Add example for `Lint/ScriptPermission` cop

### DIFF
--- a/lib/rubocop/cop/lint/script_permission.rb
+++ b/lib/rubocop/cop/lint/script_permission.rb
@@ -5,6 +5,31 @@ module RuboCop
     module Lint
       # This cop checks if a file which has a shebang line as
       # its first line is granted execute permission.
+      #
+      # @example
+      #   # bad
+      #
+      #   # A file which has a shebang line as its first line is not
+      #   # granted execute permission.
+      #
+      #   #!/usr/bin/env ruby
+      #   puts 'hello, world'
+      #
+      #   # good
+      #
+      #   # A file which has a shebang line as its first line is
+      #   # granted execute permission.
+      #
+      #   #!/usr/bin/env ruby
+      #   puts 'hello, world'
+      #
+      #   # good
+      #
+      #   # A file which has not a shebang line as its first line is not
+      #   # granted execute permission.
+      #
+      #   puts 'hello, world'
+      #
       class ScriptPermission < Cop
         MSG = "Script file %<file>s doesn't have execute permission.".freeze
         SHEBANG = '#!'.freeze

--- a/manual/cops_lint.md
+++ b/manual/cops_lint.md
@@ -1632,6 +1632,33 @@ Enabled | Yes
 This cop checks if a file which has a shebang line as
 its first line is granted execute permission.
 
+### Examples
+
+```ruby
+# bad
+
+# A file which has a shebang line as its first line is not
+# granted execute permission.
+
+#!/usr/bin/env ruby
+puts 'hello, world'
+
+# good
+
+# A file which has a shebang line as its first line is
+# granted execute permission.
+
+#!/usr/bin/env ruby
+puts 'hello, world'
+
+# good
+
+# A file which has not a shebang line as its first line is not
+# granted execute permission.
+
+puts 'hello, world'
+```
+
 ## Lint/ShadowedArgument
 
 Enabled by default | Supports autocorrection


### PR DESCRIPTION
Related to issue #4910.
This commit adds an example to `Lint/ScriptPermission` cop.

Representation of file permission for shebang is indicated by a comment.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
