### PR TITLE
[Fix #4669] Read file in binary mode in ResultCache#file_checksum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
 * [#5520](https://github.com/bbatsov/rubocop/issues/5520): Fix `Style/RedundantException` auto-correction does not keep parenthesization. ([@dpostorivo][])
 * [#5524](https://github.com/bbatsov/rubocop/issues/5524): Return the instance based on the new type when calls `RuboCop::AST::Node#updated`. ([@wata727][])
 * [#5539](https://github.com/bbatsov/rubocop/pull/5539): Fix compilation error and ruby code generation when passing args to funcall and predicates. ([@Edouard-chin][])
+* [#4669](https://github.com/bbatsov/rubocop/issues/4669): Use binary file contents for cache key so changing EOL characters invalidates the cache. ([@jonas054][])
 
 ### Changes
 

--- a/lib/rubocop/result_cache.rb
+++ b/lib/rubocop/result_cache.rb
@@ -132,7 +132,7 @@ module RuboCop
     end
 
     def file_checksum(file, config_store)
-      Digest::MD5.hexdigest(Dir.pwd + file + IO.read(file) +
+      Digest::MD5.hexdigest(Dir.pwd + file + IO.binread(file) +
                             File.stat(file).mode.to_s +
                             config_store.for(file).to_s)
     rescue Errno::ENOENT

--- a/spec/rubocop/result_cache_spec.rb
+++ b/spec/rubocop/result_cache_spec.rb
@@ -71,6 +71,23 @@ RSpec.describe RuboCop::ResultCache, :isolated_environment do
         end
       end
 
+      context 'when end of line characters have changed' do
+        it 'is invalid' do
+          cache.save(offenses)
+          contents = File.binread(file)
+          File.open(file, 'wb') do |f|
+            if contents.include?("\r")
+              f.write(contents.delete("\r"))
+            else
+              f.write(contents.gsub(/\n/, "\r\n"))
+            end
+          end
+          cache2 = described_class.new(file, options,
+                                       config_store, cache_root)
+          expect(cache2.valid?).to eq(false)
+        end
+      end
+
       context 'when a symlink is present in the cache location' do
         let(:cache2) do
           described_class.new(file, options, config_store, cache_root)


### PR DESCRIPTION
`IO.read` converts `CRLF` to `LF` on Windows. This means that the cached results for a file are still considered valid even if the file has changed EOL characters. This is not good for the `Layout/EndOfLine` cop, which will produce incorrect results taken from the cache. Reading in binary mode fixes the problem.