### PR TITLE
Tell Read the Docs to build downloadable docs. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@
 * [#5283](https://github.com/bbatsov/rubocop/issues/5283): Change file path output by `Formatter::JSONFormatter` from relative path to smart path. ([@koic][])
 * `Style/SafeNavigation` will now register an offense for methods that `nil` responds to. ([@rrosenblum][])
 * [#5542](https://github.com/bbatsov/rubocop/pull/5542): Exclude `.git/` by default. ([@pocke][])
+* Tell Read the Docs to build downloadable docs. ([@eostrom][])
 
 ## 0.52.1 (2017-12-27)
 
@@ -3193,3 +3194,4 @@
 [@walinga]: https://github.com/walinga
 [@georf]: https://github.com/georf
 [@Edouard-chin]: https://github.com/Edouard-chin
+[@eostrom]: https://github.com/eostrom

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,0 +1,2 @@
+formats:
+    - htmlzip


### PR DESCRIPTION
I'd like to create a docset of RuboCop cops for Dash, the macOS documentation browser (https://kapeli.com/dash). I have a rough version working that lets me quickly look up a cop by name, but it's ugly and not very readable because it's just ten HTML files I downloaded with `curl` from Read the Docs, with no CSS.

I could download the CSS and write scripts to spider the documentation when it changes, but it seems easier and more polite to use the download service Read the Docs offers. I believe with this configuration file Read the Docs will build a zip file of the HTML for easy downloading.

I haven't tested this because setting up my own RtD account seems imposing, but I can do that if it would help.