### PR TITLE
Restyle example formatting for `Rails/UniqBeforePluck`

### DIFF
--- a/lib/rubocop/cop/rails/uniq_before_pluck.rb
+++ b/lib/rubocop/cop/rails/uniq_before_pluck.rb
@@ -8,13 +8,6 @@ module RuboCop
       # The use of uniq before pluck is preferred because it executes within
       # the database.
       #
-      # @example
-      #   # bad
-      #   Model.pluck(:id).uniq
-      #
-      #   # good
-      #   Model.uniq.pluck(:id)
-      #
       # This cop has two different enforcement modes. When the EnforcedStyle
       # is conservative (the default) then only calls to pluck on a constant
       # (i.e. a model class) before uniq are added as offenses.
@@ -24,15 +17,30 @@ module RuboCop
       # cannot distinguish between calls to pluck on an ActiveRecord::Relation
       # vs a call to pluck on an ActiveRecord::Associations::CollectionProxy.
       #
-      # @example
+      # Autocorrect is disabled by default for this cop since it may generate
+      # false positives.
+      #
+      # @example EnforcedStyle: conservative (default)
+      #   # bad
+      #   Model.pluck(:id).uniq
+      #
+      #   # good
+      #   Model.uniq.pluck(:id)
+      #
+      # @example EnforcedStyle: aggressive
+      #   # bad
       #   # this will return a Relation that pluck is called on
       #   Model.where(cond: true).pluck(:id).uniq
       #
+      #   # bad
       #   # an association on an instance will return a CollectionProxy
       #   instance.assoc.pluck(:id).uniq
       #
-      # Autocorrect is disabled by default for this cop since it may generate
-      # false positives.
+      #   # bad
+      #   Model.pluck(:id).uniq
+      #
+      #   # good
+      #   Model.uniq.pluck(:id)
       #
       class UniqBeforePluck < RuboCop::Cop::Cop
         include ConfigurableEnforcedStyle

--- a/manual/cops_rails.md
+++ b/manual/cops_rails.md
@@ -1674,6 +1674,8 @@ false positives.
 
 ### Examples
 
+#### EnforcedStyle: conservative (default)
+
 ```ruby
 # bad
 Model.pluck(:id).uniq
@@ -1681,12 +1683,22 @@ Model.pluck(:id).uniq
 # good
 Model.uniq.pluck(:id)
 ```
+#### EnforcedStyle: aggressive
+
 ```ruby
+# bad
 # this will return a Relation that pluck is called on
 Model.where(cond: true).pluck(:id).uniq
 
+# bad
 # an association on an instance will return a CollectionProxy
 instance.assoc.pluck(:id).uniq
+
+# bad
+Model.pluck(:id).uniq
+
+# good
+Model.uniq.pluck(:id)
 ```
 
 ### Configurable attributes


### PR DESCRIPTION
Follow up of https://github.com/bbatsov/rubocop/pull/4880#issuecomment-338499947.

This commit is a change of document format for `Rails/UniqBeforePluck` cop.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
