### PR TITLE
[Fix #5038] Fix false positive for `Performance/RegexpMatch` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 * [#5524](https://github.com/bbatsov/rubocop/issues/5524): Return the instance based on the new type when calls `RuboCop::AST::Node#updated`. ([@wata727][])
 * [#5539](https://github.com/bbatsov/rubocop/pull/5539): Fix compilation error and ruby code generation when passing args to funcall and predicates. ([@Edouard-chin][])
 * [#4669](https://github.com/bbatsov/rubocop/issues/4669): Use binary file contents for cache key so changing EOL characters invalidates the cache. ([@jonas054][])
+* [#3947](https://github.com/bbatsov/rubocop/issues/3947): Fix false positive for `Performance::RegexpMatch` when using `MatchData` before guard clause. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/performance/regexp_match.rb
+++ b/lib/rubocop/cop/performance/regexp_match.rb
@@ -154,6 +154,10 @@ module RuboCop
         def last_match_used?(match_node)
           scope_root = scope_root(match_node)
           body = scope_root ? scope_body(scope_root) : match_node.ancestors.last
+
+          return true if match_node.parent.if_type? &&
+                         match_node.parent.modifier_form?
+
           match_node_pos = match_node.loc.expression.begin_pos
 
           next_match_pos = next_match_pos(body, match_node_pos, scope_root)

--- a/spec/rubocop/cop/performance/regexp_match_spec.rb
+++ b/spec/rubocop/cop/performance/regexp_match_spec.rb
@@ -116,6 +116,22 @@ RSpec.describe RuboCop::Cop::Performance::RegexpMatch, :config do
       RUBY
 
       include_examples :accepts,
+                       "#{name} in method with `#{var}` before `if`",
+                       <<-RUBY
+        def foo
+          return #{var} if #{cond}
+        end
+      RUBY
+
+      include_examples :accepts,
+                       "#{name} in method with `#{var}` before `unless`",
+                       <<-RUBY
+        def foo
+          return #{var} unless #{cond}
+        end
+      RUBY
+
+      include_examples :accepts,
                        "#{name} in method with `#{var}` in block", <<-RUBY
         def foo
           bar do


### PR DESCRIPTION
Fixes #5038.

This PR fixes a false positive for `Performance::RegexpMatch` when using `MatchData` before guard clause.

Perhaps other false positives may be considered, but this PR will first solve the problem reported in the above issue.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
