### PR TITLE
[Fix #5574] Fix a false positive for `Rails/FilePath` cop

### DIFF
--- a/lib/rubocop/cop/rails/file_path.rb
+++ b/lib/rubocop/cop/rails/file_path.rb
@@ -33,8 +33,8 @@ module RuboCop
         PATTERN
 
         def on_dstr(node)
-          unless node.children.last.source.start_with?('.')
-            return unless rails_root_nodes?(node)
+          unless rails_root_nodes?(node) &&
+                 node.children.last.source.start_with?('.')
             return unless node.children.last.source.include?(File::SEPARATOR)
           end
 

--- a/spec/rubocop/cop/rails/file_path_spec.rb
+++ b/spec/rubocop/cop/rails/file_path_spec.rb
@@ -95,4 +95,12 @@ RSpec.describe RuboCop::Cop::Rails::FilePath do
       RUBY
     end
   end
+
+  context 'when string contains an interpolation followed by a period' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        puts "test #\{123\}. Hey!"
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Fixes #5574.

This PR fixes a false positive in Rails/FilePath when string contains an interpolation followed by a period.

This regression was due to #5461.
Since this is a regression for changes that have not yet been released, it is not described in CHANGELOG.md.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
