### PR TITLE
Fix EndAlignment and line break

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@
 * [#4669](https://github.com/bbatsov/rubocop/issues/4669): Use binary file contents for cache key so changing EOL characters invalidates the cache. ([@jonas054][])
 * [#3947](https://github.com/bbatsov/rubocop/issues/3947): Fix false positive for `Performance::RegexpMatch` when using `MatchData` before guard clause. ([@koic][])
 * [#5515](https://github.com/bbatsov/rubocop/issues/5515): Fix `Style/EmptyElse` autocorrect for nested if and case statements. ([@asherkach][])
+* [#5582](https://github.com/bbatsov/rubocop/issues/5582): Fix `end` alignment for variable assignment with line break after `=` in `Layout/EndAlignment`. ([@jonas054][])
 
 ### Changes
 

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -1512,6 +1512,10 @@ variable = if true
 
 variable = if true
            end
+
+variable =
+  if true
+  end
 ```
 #### EnforcedStyleAlignWith: variable
 
@@ -1525,6 +1529,10 @@ variable = if true
 
 variable = if true
 end
+
+variable =
+  if true
+  end
 ```
 #### EnforcedStyleAlignWith: start_of_line
 
@@ -1534,10 +1542,20 @@ end
 variable = if true
     end
 
+puts(if true
+     end)
+
 # good
+
+variable = if true
+end
 
 puts(if true
 end)
+
+variable =
+  if true
+  end
 ```
 
 ### Configurable attributes

--- a/spec/rubocop/cop/layout/def_end_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/def_end_alignment_spec.rb
@@ -20,8 +20,15 @@ RSpec.describe RuboCop::Cop::Layout::DefEndAlignment, :config do
       { 'EnforcedStyleAlignWith' => 'start_of_line', 'AutoCorrect' => true }
     end
 
-    include_examples 'misaligned', '', 'def', 'test',      '  end'
-    include_examples 'misaligned', '', 'def', 'Test.test', '  end', 'defs'
+    include_examples 'misaligned', <<-RUBY, false
+      def test
+        end
+        ^^^ `end` at 2, 2 is not aligned with `def` at 1, 0.
+
+      def Test.test
+        end
+        ^^^ `end` at 2, 2 is not aligned with `def` at 1, 0.
+    RUBY
 
     include_examples 'aligned', "\xef\xbb\xbfdef", 'test', 'end'
     include_examples 'aligned', 'def',       'test',       'end'
@@ -31,9 +38,11 @@ RSpec.describe RuboCop::Cop::Layout::DefEndAlignment, :config do
       include_examples 'aligned', 'foo def', 'test', 'end'
       include_examples 'aligned', 'foo bar def', 'test', 'end'
 
-      include_examples('misaligned', '',
-                       'foo def', 'test',
-                       '    end')
+      include_examples 'misaligned', <<-RUBY, :def
+        foo def test
+            end
+            ^^^ `end` at 2, 4 is not aligned with `foo def` at 1, 0.
+      RUBY
     end
 
     context 'correct + opposite' do
@@ -66,8 +75,15 @@ RSpec.describe RuboCop::Cop::Layout::DefEndAlignment, :config do
       { 'EnforcedStyleAlignWith' => 'def', 'AutoCorrect' => true }
     end
 
-    include_examples 'misaligned', '', 'def', 'test',      '  end'
-    include_examples 'misaligned', '', 'def', 'Test.test', '  end', 'defs'
+    include_examples 'misaligned', <<-RUBY, false
+      def test
+        end
+        ^^^ `end` at 2, 2 is not aligned with `def` at 1, 0.
+
+      def Test.test
+        end
+        ^^^ `end` at 2, 2 is not aligned with `def` at 1, 0.
+    RUBY
 
     include_examples 'aligned', 'def', 'test',      'end'
     include_examples 'aligned', 'def', 'Test.test', 'end', 'defs'
@@ -77,9 +93,11 @@ RSpec.describe RuboCop::Cop::Layout::DefEndAlignment, :config do
                        'foo def', 'test',
                        '    end')
 
-      include_examples('misaligned',
-                       'foo ', 'def', 'test',
-                       'end')
+      include_examples 'misaligned', <<-RUBY, :start_of_line
+        foo def test
+        end
+        ^^^ `end` at 2, 0 is not aligned with `def` at 1, 4.
+      RUBY
 
       context 'correct + opposite' do
         it 'registers an offense' do

--- a/spec/rubocop/cop/layout/end_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/end_alignment_spec.rb
@@ -7,14 +7,6 @@ RSpec.describe RuboCop::Cop::Layout::EndAlignment, :config do
     { 'EnforcedStyleAlignWith' => 'keyword', 'AutoCorrect' => true }
   end
 
-  include_examples 'misaligned', '', 'class',  'Test',      '  end'
-  include_examples 'misaligned', '', 'module', 'Test',      '  end'
-  include_examples 'misaligned', '', 'if',     'test',      '  end'
-  include_examples 'misaligned', '', 'unless', 'test',      '  end'
-  include_examples 'misaligned', '', 'while',  'test',      '  end'
-  include_examples 'misaligned', '', 'until',  'test',      '  end'
-  include_examples 'misaligned', '', 'case',   'a when b',  '  end'
-
   include_examples 'aligned', "\xef\xbb\xbfclass", 'Test', 'end'
 
   include_examples 'aligned', 'class',  'Test',      'end'
@@ -25,13 +17,63 @@ RSpec.describe RuboCop::Cop::Layout::EndAlignment, :config do
   include_examples 'aligned', 'until',  'test',      'end'
   include_examples 'aligned', 'case',   'a when b',  'end'
 
-  include_examples 'misaligned', 'puts 1; ', 'class',  'Test',      'end'
-  include_examples 'misaligned', 'puts 1; ', 'module', 'Test',      'end'
-  include_examples 'misaligned', 'puts 1; ', 'if',     'test',      'end'
-  include_examples 'misaligned', 'puts 1; ', 'unless', 'test',      'end'
-  include_examples 'misaligned', 'puts 1; ', 'while',  'test',      'end'
-  include_examples 'misaligned', 'puts 1; ', 'until',  'test',      'end'
-  include_examples 'misaligned', 'puts 1; ', 'case',   'a when b',  'end'
+  include_examples 'misaligned', <<-RUBY, false
+    puts 1; class Test
+      end
+      ^^^ `end` at 2, 2 is not aligned with `class` at 1, 8.
+
+    module Test
+      end
+      ^^^ `end` at 2, 2 is not aligned with `module` at 1, 0.
+
+    puts 1; class Test
+      end
+      ^^^ `end` at 2, 2 is not aligned with `class` at 1, 8.
+
+    module Test
+      end
+      ^^^ `end` at 2, 2 is not aligned with `module` at 1, 0.
+
+    puts 1; if test
+      end
+      ^^^ `end` at 2, 2 is not aligned with `if` at 1, 8.
+
+    if test
+      end
+      ^^^ `end` at 2, 2 is not aligned with `if` at 1, 0.
+
+    puts 1; unless test
+      end
+      ^^^ `end` at 2, 2 is not aligned with `unless` at 1, 8.
+
+    unless test
+      end
+      ^^^ `end` at 2, 2 is not aligned with `unless` at 1, 0.
+
+    puts 1; while test
+      end
+      ^^^ `end` at 2, 2 is not aligned with `while` at 1, 8.
+
+    while test
+      end
+      ^^^ `end` at 2, 2 is not aligned with `while` at 1, 0.
+
+    puts 1; until test
+      end
+      ^^^ `end` at 2, 2 is not aligned with `until` at 1, 8.
+
+    until test
+      end
+      ^^^ `end` at 2, 2 is not aligned with `until` at 1, 0.
+
+    puts 1; case a when b
+      end
+      ^^^ `end` at 2, 2 is not aligned with `case` at 1, 8.
+
+    case a when b
+      end
+      ^^^ `end` at 2, 2 is not aligned with `case` at 1, 0.
+  RUBY
 
   include_examples 'aligned', 'puts 1; class',  'Test',     '        end'
   include_examples 'aligned', 'puts 1; module', 'Test',     '        end'
@@ -54,14 +96,6 @@ RSpec.describe RuboCop::Cop::Layout::EndAlignment, :config do
       { 'EnforcedStyleAlignWith' => 'start_of_line', 'AutoCorrect' => true }
     end
 
-    include_examples 'misaligned', '', 'class Test',    '', '  end'
-    include_examples 'misaligned', '', 'module Test',   '', '  end'
-    include_examples 'misaligned', '', 'if test',       '', '  end'
-    include_examples 'misaligned', '', 'unless test',   '', '  end'
-    include_examples 'misaligned', '', 'while test',    '', '  end'
-    include_examples 'misaligned', '', 'until test',    '', '  end'
-    include_examples 'misaligned', '', 'case a when b', '', '  end'
-
     include_examples 'aligned', 'puts 1; class',  'Test',     'end'
     include_examples 'aligned', 'puts 1; module', 'Test',     'end'
     include_examples 'aligned', 'puts 1; if',     'test',     'end'
@@ -70,13 +104,69 @@ RSpec.describe RuboCop::Cop::Layout::EndAlignment, :config do
     include_examples 'aligned', 'puts 1; until',  'test',     'end'
     include_examples 'aligned', 'puts 1; case',   'a when b', 'end'
 
-    include_examples 'misaligned', '', 'puts 1; class Test',    '', '  end'
-    include_examples 'misaligned', '', 'puts 1; module Test',   '', '  end'
-    include_examples 'misaligned', '', 'puts 1; if test',       '', '  end'
-    include_examples 'misaligned', '', 'puts 1; unless test',   '', '  end'
-    include_examples 'misaligned', '', 'puts 1; while test',    '', '  end'
-    include_examples 'misaligned', '', 'puts 1; until test',    '', '  end'
-    include_examples 'misaligned', '', 'puts 1; case a when b', '', '  end'
+    include_examples 'misaligned', <<-RUBY, false
+      puts 1; class Test
+        end
+        ^^^ `end` at 2, 2 is not aligned with `puts 1; class Test` at 1, 0.
+
+      class Test
+        end
+        ^^^ `end` at 2, 2 is not aligned with `class Test` at 1, 0.
+
+      puts 1; module Test
+        end
+        ^^^ `end` at 2, 2 is not aligned with `puts 1; module Test` at 1, 0.
+
+      module Test
+        end
+        ^^^ `end` at 2, 2 is not aligned with `module Test` at 1, 0.
+
+      puts 1; if test
+        end
+        ^^^ `end` at 2, 2 is not aligned with `puts 1; if test` at 1, 0.
+
+      if test
+        end
+        ^^^ `end` at 2, 2 is not aligned with `if test` at 1, 0.
+
+      puts 1; unless test
+        end
+        ^^^ `end` at 2, 2 is not aligned with `puts 1; unless test` at 1, 0.
+
+      unless test
+        end
+        ^^^ `end` at 2, 2 is not aligned with `unless test` at 1, 0.
+
+      puts 1; while test
+        end
+        ^^^ `end` at 2, 2 is not aligned with `puts 1; while test` at 1, 0.
+
+      while test
+        end
+        ^^^ `end` at 2, 2 is not aligned with `while test` at 1, 0.
+
+      puts 1; until test
+        end
+        ^^^ `end` at 2, 2 is not aligned with `puts 1; until test` at 1, 0.
+
+      until test
+        end
+        ^^^ `end` at 2, 2 is not aligned with `until test` at 1, 0.
+
+      puts 1; case a when b
+        end
+        ^^^ `end` at 2, 2 is not aligned with `puts 1; case a when b` at 1, 0.
+
+      case a when b
+        end
+        ^^^ `end` at 2, 2 is not aligned with `case a when b` at 1, 0.
+    RUBY
+
+    include_examples 'misaligned', <<-RUBY, :keyword
+      puts(if test
+           end)
+           ^^^ `end` at 2, 5 is not aligned with `puts(if test` at 1, 0.
+    RUBY
   end
 
   context 'when EnforcedStyleAlignWith is variable' do
@@ -86,13 +176,35 @@ RSpec.describe RuboCop::Cop::Layout::EndAlignment, :config do
       { 'EnforcedStyleAlignWith' => 'variable', 'AutoCorrect' => true }
     end
 
-    include_examples 'misaligned', '', 'class',  'Test',      '  end'
-    include_examples 'misaligned', '', 'module', 'Test',      '  end'
-    include_examples 'misaligned', '', 'if',     'test',      '  end'
-    include_examples 'misaligned', '', 'unless', 'test',      '  end'
-    include_examples 'misaligned', '', 'while',  'test',      '  end'
-    include_examples 'misaligned', '', 'until',  'test',      '  end'
-    include_examples 'misaligned', '', 'case',   'a when b',  '  end'
+    include_examples 'misaligned', <<-RUBY, false
+      class Test
+        end
+        ^^^ `end` at 2, 2 is not aligned with `class` at 1, 0.
+
+      module Test
+             end
+             ^^^ `end` at 2, 7 is not aligned with `module` at 1, 0.
+
+      if test
+        end
+        ^^^ `end` at 2, 2 is not aligned with `if` at 1, 0.
+
+      unless test
+        end
+        ^^^ `end` at 2, 2 is not aligned with `unless` at 1, 0.
+
+      while test
+        end
+        ^^^ `end` at 2, 2 is not aligned with `while` at 1, 0.
+
+      until test
+        end
+        ^^^ `end` at 2, 2 is not aligned with `until` at 1, 0.
+
+      case a when b
+        end
+        ^^^ `end` at 2, 2 is not aligned with `case` at 1, 0.
+    RUBY
 
     include_examples 'aligned', 'class',  'Test',      'end'
     include_examples 'aligned', 'module', 'Test',      'end'
@@ -102,13 +214,35 @@ RSpec.describe RuboCop::Cop::Layout::EndAlignment, :config do
     include_examples 'aligned', 'until',  'test',      'end'
     include_examples 'aligned', 'case',   'a when b',  'end'
 
-    include_examples 'misaligned', 'puts 1; ', 'class',  'Test',      'end'
-    include_examples 'misaligned', 'puts 1; ', 'module', 'Test',      'end'
-    include_examples 'misaligned', 'puts 1; ', 'if',     'test',      'end'
-    include_examples 'misaligned', 'puts 1; ', 'unless', 'test',      'end'
-    include_examples 'misaligned', 'puts 1; ', 'while',  'test',      'end'
-    include_examples 'misaligned', 'puts 1; ', 'until',  'test',      'end'
-    include_examples 'misaligned', 'puts 1; ', 'case',   'a when b',  'end'
+    include_examples 'misaligned', <<-RUBY, :start_of_line
+      puts 1; class Test
+      end
+      ^^^ `end` at 2, 0 is not aligned with `class` at 1, 8.
+
+      puts 1; module Test
+      end
+      ^^^ `end` at 2, 0 is not aligned with `module` at 1, 8.
+
+      puts 1; if test
+      end
+      ^^^ `end` at 2, 0 is not aligned with `if` at 1, 8.
+
+      puts 1; unless test
+      end
+      ^^^ `end` at 2, 0 is not aligned with `unless` at 1, 8.
+
+      puts 1; while test
+      end
+      ^^^ `end` at 2, 0 is not aligned with `while` at 1, 8.
+
+      puts 1; until test
+      end
+      ^^^ `end` at 2, 0 is not aligned with `until` at 1, 8.
+
+      puts 1; case a when b
+      end
+      ^^^ `end` at 2, 0 is not aligned with `case` at 1, 8.
+    RUBY
 
     include_examples 'aligned', 'puts 1; class',  'Test',     '        end'
     include_examples 'aligned', 'puts 1; module', 'Test',     '        end'
@@ -183,7 +317,12 @@ RSpec.describe RuboCop::Cop::Layout::EndAlignment, :config do
       end
 
       include_examples 'aligned', 'test case', 'a when b', '     end'
-      include_examples 'misaligned', 'test ', 'case', 'a when b', 'end'
+
+      include_examples 'misaligned', <<-RUBY, :start_of_line
+        test case a when b
+        end
+        ^^^ `end` at 2, 0 is not aligned with `case` at 1, 5.
+      RUBY
     end
 
     context 'when EnforcedStyleAlignWith is variable' do
@@ -192,7 +331,12 @@ RSpec.describe RuboCop::Cop::Layout::EndAlignment, :config do
       end
 
       include_examples 'aligned', 'test case', 'a when b', 'end'
-      include_examples 'misaligned', '', 'test case', 'a when b', '     end'
+
+      include_examples 'misaligned', <<-RUBY, :keyword
+        test case a when b
+             end
+             ^^^ `end` at 2, 5 is not aligned with `test case` at 1, 0.
+      RUBY
     end
 
     context 'when EnforcedStyleAlignWith is start_of_line' do
@@ -200,18 +344,35 @@ RSpec.describe RuboCop::Cop::Layout::EndAlignment, :config do
         { 'EnforcedStyleAlignWith' => 'start_of_line', 'AutoCorrect' => true }
       end
 
-      include_examples 'aligned',        'test case a when b', '', 'end'
-      include_examples 'misaligned', '', 'test case a when b', '', '     end'
+      include_examples 'aligned', 'test case a when b', '', 'end'
+
+      include_examples 'misaligned', <<-RUBY, :keyword
+        test case a when b
+             end
+             ^^^ `end` at 2, 5 is not aligned with `test case a when b` at 1, 0.
+      RUBY
     end
   end
 
   context 'regarding assignment' do
     context 'when EnforcedStyleAlignWith is keyword' do
-      include_examples 'misaligned', 'var = ', 'if',     'test',     'end'
-      include_examples 'misaligned', 'var = ', 'unless', 'test',     'end'
-      include_examples 'misaligned', 'var = ', 'while',  'test',     'end'
-      include_examples 'misaligned', 'var = ', 'until',  'test',     'end'
-      include_examples 'misaligned', 'var = ', 'case',   'a when b', 'end'
+      include_examples 'misaligned', <<-RUBY, :start_of_line
+        var = if test
+        end
+        ^^^ `end` at 2, 0 is not aligned with `if` at 1, 6.
+
+        var = unless test
+        end
+        ^^^ `end` at 2, 0 is not aligned with `unless` at 1, 6.
+
+        var = while test
+        end
+        ^^^ `end` at 2, 0 is not aligned with `while` at 1, 6.
+
+        var = until test
+        end
+        ^^^ `end` at 2, 0 is not aligned with `until` at 1, 6.
+      RUBY
 
       include_examples 'aligned', 'var = if',     'test',     '      end'
       include_examples 'aligned', 'var = unless', 'test',     '      end'
@@ -232,15 +393,31 @@ RSpec.describe RuboCop::Cop::Layout::EndAlignment, :config do
       include_examples 'aligned', 'var = until',  'test',     'end.ab.join("")'
       include_examples 'aligned', 'var = until',  'test',     'end.ab.tap {}'
       include_examples 'aligned', 'var = case',   'a when b', 'end'
-
       include_examples 'aligned', "var =\n  if",  'test', '  end'
 
-      include_examples 'misaligned', '', 'var = if',     'test',     '      end'
-      include_examples 'misaligned', '', 'var = unless', 'test',     '      end'
-      include_examples 'misaligned', '', 'var = while',  'test',     '      end'
-      include_examples 'misaligned', '', 'var = until',  'test',     '      end'
-      include_examples 'misaligned', '', 'var = until',  'test',     '    end.j'
-      include_examples 'misaligned', '', 'var = case',   'a when b', '      end'
+      include_examples 'misaligned', <<-RUBY, :keyword
+        var = if test
+              end
+              ^^^ `end` at 2, 6 is not aligned with `var = if` at 1, 0.
+
+        var = unless test
+              end
+              ^^^ `end` at 2, 6 is not aligned with `var = unless` at 1, 0.
+
+        var = while test
+              end
+              ^^^ `end` at 2, 6 is not aligned with `var = while` at 1, 0.
+
+        var = until test
+              end
+              ^^^ `end` at 2, 6 is not aligned with `var = until` at 1, 0.
+      RUBY
+
+      include_examples 'misaligned', <<-RUBY, :keyword
+        var = until test
+              end.j
+              ^^^ `end` at 2, 6 is not aligned with `var = until` at 1, 0.
+      RUBY
 
       include_examples 'aligned', '@var = if',  'test', 'end'
       include_examples 'aligned', '@@var = if', 'test', 'end'
@@ -253,16 +430,53 @@ RSpec.describe RuboCop::Cop::Layout::EndAlignment, :config do
       include_examples 'aligned', 'h[k] = if',  'test', 'end'
       include_examples 'aligned', 'h.k = if',   'test', 'end'
 
-      include_examples 'misaligned', '', '@var = if',  'test',    '      end'
-      include_examples 'misaligned', '', '@@var = if', 'test',    '      end'
-      include_examples 'misaligned', '', '$var = if',  'test',    '      end'
-      include_examples 'misaligned', '', 'CNST = if',  'test',    '      end'
-      include_examples 'misaligned', '', 'a, b = if',  'test',    '      end'
-      include_examples 'misaligned', '', 'var ||= if', 'test',    '      end'
-      include_examples 'misaligned', '', 'var &&= if', 'test',    '      end'
-      include_examples 'misaligned', '', 'var += if',  'test',    '      end'
-      include_examples 'misaligned', '', 'h[k] = if',  'test',    '      end'
-      include_examples 'misaligned', '', 'h.k = if',   'test',    '      end'
+      include_examples 'misaligned', <<-RUBY, :keyword
+        var = case a when b
+              end
+              ^^^ `end` at 2, 6 is not aligned with `var = case` at 1, 0.
+
+        @var = if test
+               end
+               ^^^ `end` at 2, 7 is not aligned with `@var = if` at 1, 0.
+
+        @@var = if test
+                end
+                ^^^ `end` at 2, 8 is not aligned with `@@var = if` at 1, 0.
+
+        $var = if test
+               end
+               ^^^ `end` at 2, 7 is not aligned with `$var = if` at 1, 0.
+
+        CNST = if test
+               end
+               ^^^ `end` at 2, 7 is not aligned with `CNST = if` at 1, 0.
+
+        a, b = if test
+               end
+               ^^^ `end` at 2, 7 is not aligned with `a, b = if` at 1, 0.
+
+        var ||= if test
+                end
+                ^^^ `end` at 2, 8 is not aligned with `var ||= if` at 1, 0.
+
+        var &&= if test
+                end
+                ^^^ `end` at 2, 8 is not aligned with `var &&= if` at 1, 0.
+
+        var += if test
+               end
+               ^^^ `end` at 2, 7 is not aligned with `var += if` at 1, 0.
+
+        h[k] = if test
+               end
+               ^^^ `end` at 2, 7 is not aligned with `h[k] = if` at 1, 0.
+      RUBY
+
+      include_examples 'misaligned', <<-RUBY, false
+        h.k = if test
+                 end
+                 ^^^ `end` at 2, 9 is not aligned with `h.k = if` at 1, 0.
+      RUBY
     end
   end
 
@@ -271,11 +485,27 @@ RSpec.describe RuboCop::Cop::Layout::EndAlignment, :config do
       { 'EnforcedStyleAlignWith' => 'start_of_line', 'AutoCorrect' => true }
     end
 
-    include_examples 'misaligned', '', 'var = if test',       '', '      end'
-    include_examples 'misaligned', '', 'var = unless test',   '', '      end'
-    include_examples 'misaligned', '', 'var = while test',    '', '      end'
-    include_examples 'misaligned', '', 'var = until test',    '', '      end'
-    include_examples 'misaligned', '', 'var = case a when b', '', '      end'
+    include_examples 'misaligned', <<-RUBY, :keyword
+      var = if test
+            end
+            ^^^ `end` at 2, 6 is not aligned with `var = if test` at 1, 0.
+
+      var = unless test
+            end
+            ^^^ `end` at 2, 6 is not aligned with `var = unless test` at 1, 0.
+
+      var = while test
+            end
+            ^^^ `end` at 2, 6 is not aligned with `var = while test` at 1, 0.
+
+      var = until test
+            end
+            ^^^ `end` at 2, 6 is not aligned with `var = until test` at 1, 0.
+
+      var = case a when b
+            end
+            ^^^ `end` at 2, 6 is not aligned with `var = case a when b` at 1, 0.
+    RUBY
 
     include_examples 'aligned', 'var = if',     'test',     'end'
     include_examples 'aligned', 'var = unless', 'test',     'end'

--- a/spec/rubocop/cop/layout/end_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/end_alignment_spec.rb
@@ -413,6 +413,32 @@ RSpec.describe RuboCop::Cop::Layout::EndAlignment, :config do
               ^^^ `end` at 2, 6 is not aligned with `var = until` at 1, 0.
       RUBY
 
+      # If there's a line break after = we align with the keyword even if the
+      # style is `variable`.
+      include_examples 'misaligned', <<-RUBY, false
+        var =
+          if test
+        end
+        ^^^ `end` at 3, 0 is not aligned with `if` at 2, 2.
+
+        var =
+          unless test
+         end
+         ^^^ `end` at 3, 1 is not aligned with `unless` at 2, 2.
+
+        var =
+          # comment
+          while test
+           end
+           ^^^ `end` at 4, 3 is not aligned with `while` at 3, 2.
+
+        var =
+          until test
+            do_something
+            end
+            ^^^ `end` at 4, 4 is not aligned with `until` at 2, 2.
+      RUBY
+
       include_examples 'misaligned', <<-RUBY, :keyword
         var = until test
               end.j
@@ -507,10 +533,19 @@ RSpec.describe RuboCop::Cop::Layout::EndAlignment, :config do
             ^^^ `end` at 2, 6 is not aligned with `var = case a when b` at 1, 0.
     RUBY
 
+    include_examples 'misaligned', <<-RUBY, false
+      var =
+        if test
+      end
+      ^^^ `end` at 3, 0 is not aligned with `if test` at 2, 2.
+    RUBY
+
     include_examples 'aligned', 'var = if',     'test',     'end'
     include_examples 'aligned', 'var = unless', 'test',     'end'
     include_examples 'aligned', 'var = while',  'test',     'end'
     include_examples 'aligned', 'var = until',  'test',     'end'
     include_examples 'aligned', 'var = case',   'a when b', 'end'
+
+    include_examples 'aligned', "var =\n  if",  'test', '  end'
   end
 end


### PR DESCRIPTION
I found a problem while casually running `rubocop` on the `rake` code. I needed to make the specs more readable and strict before implementing the fix, so there are two commits.

Reported in #5582.