### PR TITLE
[Fix #5547] Fix auto-correction of Layout/BlockEndNewline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@
 * [#5582](https://github.com/bbatsov/rubocop/issues/5582): Fix `end` alignment for variable assignment with line break after `=` in `Layout/EndAlignment`. ([@jonas054][])
 * [#5602](https://github.com/bbatsov/rubocop/pull/5602): Fix false positive for `Style/ColonMethodCall` when using Java package namespace. ([@koic][])
 * [#5603](https://github.com/bbatsov/rubocop/pull/5603): Fix falsy offense for `Style/RedundantSelf` with pseudo variables. ([@pocke][])
+* [#5547](https://github.com/bbatsov/rubocop/issues/5547): Fix auto-correction of of `Layout/BlockEndNewline` when there is top level code outside of a class. ([@rrosenblum][])
 
 ### Changes
 

--- a/spec/rubocop/cop/layout/block_end_newline_spec.rb
+++ b/spec/rubocop/cop/layout/block_end_newline_spec.rb
@@ -60,4 +60,24 @@ RSpec.describe RuboCop::Cop::Layout::BlockEndNewline do
                               '}',
                               ''].join("\n"))
   end
+
+  it 'autocorrects a {} block where the } is top level code ' \
+    'outside of a class' do
+    new_source = autocorrect_source(<<-RUBY.strip_indent)
+      # frozen_string_literal: true
+
+      test {[
+        foo
+      ]}
+    RUBY
+
+    expect(new_source).to eq(<<-RUBY.strip_indent)
+      # frozen_string_literal: true
+
+      test {[
+        foo
+      ]
+      }
+    RUBY
+  end
 end

--- a/spec/rubocop/cop/layout/block_end_newline_spec.rb
+++ b/spec/rubocop/cop/layout/block_end_newline_spec.rb
@@ -3,18 +3,16 @@
 RSpec.describe RuboCop::Cop::Layout::BlockEndNewline do
   subject(:cop) { described_class.new }
 
-  it 'does not register an offense for a one-liner' do
+  it 'accepts a one-liner' do
     expect_no_offenses('test do foo end')
   end
 
-  it 'does not register an offense for multiline blocks with newlines before '\
-     'the end' do
-    inspect_source(<<-RUBY.strip_indent)
+  it 'accepts multiline blocks with newlines before the end' do
+    expect_no_offenses(<<-RUBY.strip_indent)
       test do
         foo
       end
     RUBY
-    expect(cop.messages.empty?).to be(true)
   end
 
   it 'registers an offense when multiline block end is not on its own line' do
@@ -34,31 +32,29 @@ RSpec.describe RuboCop::Cop::Layout::BlockEndNewline do
   end
 
   it 'autocorrects a do/end block where the end is not on its own line' do
-    src = <<-RUBY.strip_indent
+    new_source = autocorrect_source(<<-RUBY.strip_indent)
       test do
         foo  end
     RUBY
 
-    new_source = autocorrect_source(src)
-
-    expect(new_source).to eq(['test do',
-                              '  foo',
-                              'end',
-                              ''].join("\n"))
+    expect(new_source).to eq(<<-RUBY.strip_indent)
+      test do
+        foo
+      end
+    RUBY
   end
 
   it 'autocorrects a {} block where the } is not on its own line' do
-    src = <<-RUBY.strip_indent
+    new_source = autocorrect_source(<<-RUBY.strip_indent)
       test {
         foo  }
     RUBY
 
-    new_source = autocorrect_source(src)
-
-    expect(new_source).to eq(['test {',
-                              '  foo',
-                              '}',
-                              ''].join("\n"))
+    expect(new_source).to eq(<<-RUBY.strip_indent)
+      test {
+        foo
+      }
+    RUBY
   end
 
   it 'autocorrects a {} block where the } is top level code ' \


### PR DESCRIPTION
The bug appears to happen when there is code or a comment at the top level of a file outside of a class. This was somehow an issue with the range that was being used for the correction. I was also able to simplify some of the code.

