### PR TITLE
Add arb to the list of known ruby extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * [#5490](https://github.com/bbatsov/rubocop/issues/5490): Add new `Lint/OrderedMagicComments` cop. ([@koic][])
 * [#4008](https://github.com/bbatsov/rubocop/issues/4008): Add new `Style/ExpandPathArguments` cop. ([@koic][])
 * [#4812](https://github.com/bbatsov/rubocop/issues/4812): Add `beginning_only` and `ending_only` style options to `Layout/EmptyLinesAroundClassBody` cop. ([@jmks][])
+* [#5591](https://github.com/bbatsov/rubocop/pull/5591): Include `.arb` file by default. ([@deivid-rodriguez][])
 
 ### Bug fixes
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -9,6 +9,7 @@ inherit_from:
 AllCops:
   # Include common Ruby source files.
   Include:
+    - '**/*.arb'
     - '**/*.axlsx'
     - '**/*.builder'
     - '**/*.fcgi'

--- a/lib/rubocop/target_finder.rb
+++ b/lib/rubocop/target_finder.rb
@@ -4,6 +4,7 @@ require 'set'
 
 module RuboCop
   RUBY_EXTENSIONS = %w[.rb
+                       .arb
                        .axlsx
                        .builder
                        .fcgi


### PR DESCRIPTION
Reference: https://github.com/activeadmin/arbre/blob/2968b4a8a4fdbe23e04d1e5e90b9dce4759e6d3c/docs/index.md

This is somewhat common due to activeadmin's popularity.

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/