### PR TITLE
Add `Rails/ActiveRecordAliases` cop.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * [#5473](https://github.com/bbatsov/rubocop/issues/5473): Use `gems.locked` or `Gemfile.lock` to determine the best `TargetRailsVersion` when it is not specified in the config. ([@roberts1000][])
 * Add new `Naming/MemoizedInstanceVariableName` cop. ([@satyap][])
 * [#5376](https://github.com/bbatsov/rubocop/issues/5376): Add new `Style/EmptyLineAfterGuardClause` cop. ([@unkmas][])
+* Add new `Rails/ActiveRecordAliases` cop. ([@elebow][])
 
 ### Bug fixes
 
@@ -3217,3 +3218,4 @@
 [@georf]: https://github.com/georf
 [@satyap]: https://github.com/satyap
 [@unkmas]: https://github.com/unkmas
+[@elebow]: https://github.com/elebow

--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -1066,6 +1066,13 @@ Rails/ActionFilter:
   Description: 'Enforces consistent use of action filter methods.'
   Enabled: true
 
+Rails/ActiveRecordAliases:
+  Description: >-
+                  Avoid Active Record aliases:
+                  Use `update` instead of `update_attributes`.
+                  Use `update!` instead of `update_attributes!`.
+  Enabled: true
+
 Rails/ActiveSupportAliases:
   Description: >-
                   Avoid ActiveSupport aliases of standard ruby methods:

--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -531,6 +531,7 @@ require_relative 'rubocop/cop/style/yoda_condition'
 require_relative 'rubocop/cop/style/zero_length_predicate'
 
 require_relative 'rubocop/cop/rails/action_filter'
+require_relative 'rubocop/cop/rails/active_record_aliases'
 require_relative 'rubocop/cop/rails/active_support_aliases'
 require_relative 'rubocop/cop/rails/application_job'
 require_relative 'rubocop/cop/rails/application_record'

--- a/lib/rubocop/cop/rails/active_record_aliases.rb
+++ b/lib/rubocop/cop/rails/active_record_aliases.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Rails
+      # Checks that ActiveRecord aliases are not used. The direct method names
+      # are more clear and easier to read.
+      #
+      # @example
+      #   #bad
+      #   Book.update_attributes!(author: 'Alice')
+      #
+      #   #good
+      #   Book.update!(author: 'Alice')
+      class ActiveRecordAliases < Cop
+        MSG = 'Use `%<prefer>s` instead of `%<current>s`.'.freeze
+
+        ALIASES = {
+          update_attributes: :update,
+          update_attributes!: :update!
+        }.freeze
+
+        def on_send(node)
+          ALIASES.each do |bad, good|
+            next unless node.method?(bad)
+
+            add_offense(node,
+                        message: format(MSG, prefer: good, current: bad),
+                        location: :selector,
+                        severity: :warning)
+            break
+          end
+        end
+
+        def autocorrect(node)
+          lambda do |corrector|
+            corrector.replace(
+              node.loc.selector,
+              ALIASES[node.method_name].to_s
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/manual/cops.md
+++ b/manual/cops.md
@@ -321,6 +321,7 @@ In the following section you find all available cops:
 #### Department [Rails](cops_rails.md)
 
 * [Rails/ActionFilter](cops_rails.md#railsactionfilter)
+* [Rails/ActiveRecordAliases](cops_rails.md#railsactiverecordaliases)
 * [Rails/ActiveSupportAliases](cops_rails.md#railsactivesupportaliases)
 * [Rails/ApplicationJob](cops_rails.md#railsapplicationjob)
 * [Rails/ApplicationRecord](cops_rails.md#railsapplicationrecord)

--- a/manual/cops_rails.md
+++ b/manual/cops_rails.md
@@ -50,6 +50,25 @@ Name | Default value | Configurable values
 EnforcedStyle | `action` | `action`, `filter`
 Include | `app/controllers/**/*.rb` | Array
 
+## Rails/ActiveRecordAliases
+
+Enabled by default | Supports autocorrection
+--- | ---
+Enabled | Yes
+
+Checks that ActiveRecord aliases are not used. The direct method names
+are more clear and easier to read.
+
+### Examples
+
+```ruby
+#bad
+Book.update_attributes!(author: 'Alice')
+
+#good
+Book.update!(author: 'Alice')
+```
+
 ## Rails/ActiveSupportAliases
 
 Enabled by default | Supports autocorrection

--- a/spec/rubocop/cop/rails/active_record_aliases_spec.rb
+++ b/spec/rubocop/cop/rails/active_record_aliases_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Rails::ActiveRecordAliases do
+  subject(:cop) { described_class.new }
+
+  describe '#update_attributes' do
+    it 'registers an offense' do
+      expect_offense(<<-RUBY.strip_indent)
+        book.update_attributes(author: "Alice")
+             ^^^^^^^^^^^^^^^^^ Use `update` instead of `update_attributes`.
+      RUBY
+    end
+
+    it 'is autocorrected' do
+      new_source = autocorrect_source(
+        'book.update_attributes(author: "Alice")'
+      )
+      expect(new_source).to eq 'book.update(author: "Alice")'
+    end
+  end
+
+  describe '#update_attributes!' do
+    it 'registers an offense' do
+      expect_offense(<<-RUBY.strip_indent)
+        book.update_attributes!(author: "Bob")
+             ^^^^^^^^^^^^^^^^^^ Use `update!` instead of `update_attributes!`.
+      RUBY
+    end
+
+    it 'is autocorrected' do
+      new_source = autocorrect_source(
+        'book.update_attributes!(author: "Bob")'
+      )
+      expect(new_source).to eq 'book.update!(author: "Bob")'
+    end
+  end
+
+  describe '#update' do
+    it 'does not register an offense' do
+      expect_no_offenses('book.update(author: "Alice")')
+    end
+
+    it 'is not autocorrected' do
+      source = 'book.update(author: "Alice")'
+      new_source = autocorrect_source(source)
+      expect(new_source).to eq source
+    end
+  end
+
+  describe '#update!' do
+    it 'does not register an offense' do
+      expect_no_offenses('book.update!(author: "Bob")')
+    end
+
+    it 'is not autocorrected' do
+      source = 'book.update!(author: "Bob")'
+      new_source = autocorrect_source(source)
+      expect(new_source).to eq source
+    end
+  end
+
+  describe 'other use of the `update_attributes` string' do
+    it 'does not autocorrect the other usage' do
+      new_source = autocorrect_source(
+        'update_attributes_book.update_attributes(author: "Alice")'
+      )
+      expect(new_source).to eq 'update_attributes_book.update(author: "Alice")'
+    end
+  end
+end


### PR DESCRIPTION
This finds usage of `update_attributes`/`!`, which is an alias for `update`/`!`. The unaliased names should be preferred for clarity, and the aliases will be deprecated in Rails 6.0 (https://github.com/rails/rails/commit/5645149d3a27054450bd1130ff5715504638a5f5).

```ruby
#bad
Book.update_attributes!(author: 'Alice')

#good
Book.update!(author: 'Alice')
```

-----------------

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/