### PR TITLE
Fix a false positive for `Style/ColonMethodCall`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@
 * [#3947](https://github.com/bbatsov/rubocop/issues/3947): Fix false positive for `Performance::RegexpMatch` when using `MatchData` before guard clause. ([@koic][])
 * [#5515](https://github.com/bbatsov/rubocop/issues/5515): Fix `Style/EmptyElse` autocorrect for nested if and case statements. ([@asherkach][])
 * [#5582](https://github.com/bbatsov/rubocop/issues/5582): Fix `end` alignment for variable assignment with line break after `=` in `Layout/EndAlignment`. ([@jonas054][])
+* [#5602](https://github.com/bbatsov/rubocop/pull/5602): Fix false positive for `Style/ColonMethodCall` when using Java package namespace. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/colon_method_call.rb
+++ b/lib/rubocop/cop/style/colon_method_call.rb
@@ -22,8 +22,7 @@ module RuboCop
 
         def_node_matcher :java_type_node?, <<-PATTERN
           (send
-            (const nil? :Java)
-            {:boolean :byte :char :double :float :int :long :short})
+            (const nil? :Java) _)
         PATTERN
 
         def self.autocorrect_incompatible_with

--- a/spec/rubocop/cop/style/colon_method_call_spec.rb
+++ b/spec/rubocop/cop/style/colon_method_call_spec.rb
@@ -51,6 +51,10 @@ RSpec.describe RuboCop::Cop::Style::ColonMethodCall do
     expect_no_offenses('Java::int')
   end
 
+  it 'does not register an offense for Java package namespaces' do
+    expect_no_offenses('Java::com')
+  end
+
   it 'auto-corrects "::" with "."' do
     new_source = autocorrect_source('test::method')
     expect(new_source).to eq('test.method')


### PR DESCRIPTION
## Summary

AFAIK, It is customary to continue with `::` after `Java` used in Java package namespace in JRuby.
e.g. `Java::com` (https://github.com/jruby/jruby/wiki/JDBC)

If it use a class method, I think `.` is good after `Java`, but it is maybe a rare case. In this PR, it prioritize that false positives don't occur in customary usage.

## Other Information

I have learned about this false positive by the following address.
rsim/oracle-enhanced#1658.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
