### PR TITLE
Fix falsy offense for `Style/RedundantSelf` with pseudo variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@
 * [#5515](https://github.com/bbatsov/rubocop/issues/5515): Fix `Style/EmptyElse` autocorrect for nested if and case statements. ([@asherkach][])
 * [#5582](https://github.com/bbatsov/rubocop/issues/5582): Fix `end` alignment for variable assignment with line break after `=` in `Layout/EndAlignment`. ([@jonas054][])
 * [#5602](https://github.com/bbatsov/rubocop/pull/5602): Fix false positive for `Style/ColonMethodCall` when using Java package namespace. ([@koic][])
+* [#5603](https://github.com/bbatsov/rubocop/pull/5603): Fix falsy offense for `Style/RedundantSelf` with pseudo variables. ([@pocke][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/redundant_self.rb
+++ b/lib/rubocop/cop/style/redundant_self.rb
@@ -138,7 +138,7 @@ module RuboCop
              else elsif end ensure false for if in module
              next nil not or redo rescue retry return self
              super then true undef unless until when while
-             yield].include?(method_name)
+             yield __FILE__ __LINE__ __ENCODING__].include?(method_name)
         end
 
         def allow_self(node)

--- a/spec/rubocop/cop/style/redundant_self_spec.rb
+++ b/spec/rubocop/cop/style/redundant_self_spec.rb
@@ -79,6 +79,9 @@ RSpec.describe RuboCop::Cop::Style::RedundantSelf do
       self.when
       self.while
       self.yield
+      self.__FILE__
+      self.__LINE__
+      self.__ENCODING__
     RUBY
   end
 


### PR DESCRIPTION
Problem
=====

RuboCop says "Redundant self detected" for `self.__FILE__`, but the `self` cannot be omitted.

```ruby
class A
  def __FILE__
    '__FILE__ method'
  end

  def __LINE__
    '__LINE__ method'
  end

  def __ENCODING__
    '__ENCODING__ method'
  end

  def a
    p self.__FILE__
    p __FILE__
    p self.__LINE__
    p __LINE__
    p self.__ENCODING__
    p __ENCODING__
  end
end

A.new.a
```

```bash
$ ruby test.rb
"__FILE__ method"
"test.rb"
"__LINE__ method"
18
"__ENCODING__ method"
#<Encoding:UTF-8>
```

```bash
$ rubocop --only RedundantSelf
Inspecting 1 file
C

Offenses:

test.rb:15:7: C: Style/RedundantSelf: Redundant self detected.
    p self.__FILE__
      ^^^^^^^^^^^^^
test.rb:17:7: C: Style/RedundantSelf: Redundant self detected.
    p self.__LINE__
      ^^^^^^^^^^^^^
test.rb:19:7: C: Style/RedundantSelf: Redundant self detected.
    p self.__ENCODING__
      ^^^^^^^^^^^^^^^^^

1 file inspected, 3 offenses detected
```

Solution
===

Add pseudo variables to the keyword list.



-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
