### PR TITLE
Limit SafeNavigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@
 * Tell Read the Docs to build downloadable docs. ([@eostrom][])
 * Change `Style/SafeNavigation` to no longer register an offense for method chains exceeding 2 methods. ([@rrosenblum][])
 * Remove auto-correction from `Lint/SafeNavigationChain`. ([@rrosenblum][])
+* Change the highlighting of `Lint/SafeNavigationChain` to highlight the entire method chain beyond the safe navigation portion. ([@rrosenblum][])
 
 ## 0.52.1 (2017-12-27)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@
 * `Style/SafeNavigation` will now register an offense for methods that `nil` responds to. ([@rrosenblum][])
 * [#5542](https://github.com/bbatsov/rubocop/pull/5542): Exclude `.git/` by default. ([@pocke][])
 * Tell Read the Docs to build downloadable docs. ([@eostrom][])
+* Change `Style/SafeNavigation` to no longer register an offense for method chains exceeding 2 methods. ([@rrosenblum][])
 
 ## 0.52.1 (2017-12-27)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@
 * [#5542](https://github.com/bbatsov/rubocop/pull/5542): Exclude `.git/` by default. ([@pocke][])
 * Tell Read the Docs to build downloadable docs. ([@eostrom][])
 * Change `Style/SafeNavigation` to no longer register an offense for method chains exceeding 2 methods. ([@rrosenblum][])
+* Remove auto-correction from `Lint/SafeNavigationChain`. ([@rrosenblum][])
 
 ## 0.52.1 (2017-12-27)
 

--- a/lib/rubocop/cop/lint/safe_navigation_chain.rb
+++ b/lib/rubocop/cop/lint/safe_navigation_chain.rb
@@ -45,16 +45,6 @@ module RuboCop
             add_offense(node, location: loc)
           end
         end
-
-        def autocorrect(node)
-          dot = node.loc.dot
-
-          return unless dot
-
-          lambda do |corrector|
-            corrector.insert_before(dot, '&')
-          end
-        end
       end
     end
   end

--- a/manual/cops_lint.md
+++ b/manual/cops_lint.md
@@ -1593,7 +1593,7 @@ end
 
 Enabled by default | Supports autocorrection
 --- | ---
-Enabled | Yes
+Enabled | No
 
 The safe navigation operator returns nil if the receiver is
 nil.  If you chain an ordinary method call after a safe

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -4762,7 +4762,8 @@ This cop transforms usages of a method call safeguarded by a non `nil`
 check for the variable whose method is being called to
 safe navigation (`&.`). If there is a method chain, all of the methods
 in the chain need to be checked for safety, and all of the methods will
-need to be changed to use safe navigation.
+need to be changed to use safe navigation. We have limited the cop to
+not register an offense for method chains that exceed 2 methods.
 
 Configuration option: ConvertCodeThatCanStartToReturnNil
 The default for this is `false`. When configured to `true`, this will
@@ -4798,6 +4799,8 @@ foo&.bar&.baz
 foo&.bar(param1, param2)
 foo&.bar { |e| e.something }
 foo&.bar(param) { |e| e.something }
+foo && foo.bar.baz.qux # method chain with more than 2 methods
+foo && foo.nil? # method that `nil` responds to
 
 # Method calls that do not use `.`
 foo && foo < bar

--- a/spec/rubocop/cop/lint/safe_navigation_chain_spec.rb
+++ b/spec/rubocop/cop/lint/safe_navigation_chain_spec.rb
@@ -15,17 +15,6 @@ RSpec.describe RuboCop::Cop::Lint::SafeNavigationChain, :config do
     end
   end
 
-  shared_examples :offense do |name, code|
-    it "registers an offense for #{name}" do
-      inspect_source(code)
-
-      expect(cop.messages)
-        .to eq(
-          ['Do not chain ordinary method call after safe navigation operator.']
-        )
-    end
-  end
-
   context 'TargetRubyVersion >= 2.3', :ruby23 do
     [
       ['ordinary method chain', 'x.foo.bar.baz'],
@@ -51,26 +40,129 @@ RSpec.describe RuboCop::Cop::Lint::SafeNavigationChain, :config do
       include_examples :accepts, name, code
     end
 
-    [
-      ['ordinary method call exists after safe navigation method call',
-       'x&.foo.bar'],
-      ['ordinary method call exists after safe navigation method call' \
-       'with argument',
-       'x&.foo(x).bar(y)'],
-      ['ordinary method chain exists after safe navigation method call',
-       'x&.foo.bar.baz'],
-      ['ordinary method chain exists after safe navigation method call' \
-      'with argument',
-       'x&.foo(x).bar(y).baz(z)'],
-      ['safe navigation with < operator', 'x&.foo < bar'],
-      ['safe navigation with > operator', 'x&.foo > bar'],
-      ['safe navigation with <= operator', 'x&.foo <= bar'],
-      ['safe navigation with >= operator', 'x&.foo >= bar'],
-      ['safe navigation with + operator', 'x&.foo + bar'],
-      ['safe navigation with []', 'x&.foo[bar]'],
-      ['safe navigation with []=', 'x&.foo[bar] = baz']
-    ].each do |name, code|
-      include_examples :offense, name, code
+    it 'registers an offense for ordinary method call exists after ' \
+      'safe navigation method call' do
+      expect_offense(<<-RUBY.strip_indent)
+        x&.foo.bar
+              ^^^^ Do not chain ordinary method call after safe navigation operator.
+      RUBY
+    end
+
+    it 'registers an offense for ordinary method call exists after ' \
+      'safe navigation method call with an argument' do
+      expect_offense(<<-RUBY.strip_indent)
+        x&.foo(x).bar(y)
+                 ^^^^^^^ Do not chain ordinary method call after safe navigation operator.
+      RUBY
+    end
+
+    it 'registers an offense for ordinary method chain exists after ' \
+      'safe navigation method call' do
+      expect_offense(<<-RUBY.strip_indent)
+        something
+        x&.foo.bar.baz
+              ^^^^^^^^ Do not chain ordinary method call after safe navigation operator.
+      RUBY
+    end
+
+    it 'registers an offense for ordinary method chain exists after ' \
+      'safe navigation method call with an argument' do
+      expect_offense(<<-RUBY.strip_indent)
+        x&.foo(x).bar(y).baz(z)
+                 ^^^^^^^^^^^^^^ Do not chain ordinary method call after safe navigation operator.
+      RUBY
+    end
+
+    it 'registers an offense for safe navigation with < operator' do
+      expect_offense(<<-RUBY.strip_indent)
+        x&.foo < bar
+              ^^^^^^ Do not chain ordinary method call after safe navigation operator.
+      RUBY
+    end
+
+    it 'registers an offense for safe navigation with > operator' do
+      expect_offense(<<-RUBY.strip_indent)
+        x&.foo > bar
+              ^^^^^^ Do not chain ordinary method call after safe navigation operator.
+      RUBY
+    end
+
+    it 'registers an offense for safe navigation with <= operator' do
+      expect_offense(<<-RUBY.strip_indent)
+        x&.foo <= bar
+              ^^^^^^^ Do not chain ordinary method call after safe navigation operator.
+      RUBY
+    end
+
+    it 'registers an offense for safe navigation with >= operator' do
+      expect_offense(<<-RUBY.strip_indent)
+        x&.foo >= bar
+              ^^^^^^^ Do not chain ordinary method call after safe navigation operator.
+      RUBY
+    end
+
+    it 'registers an offense for safe navigation with + operator' do
+      expect_offense(<<-RUBY.strip_indent)
+        x&.foo + bar
+              ^^^^^^ Do not chain ordinary method call after safe navigation operator.
+      RUBY
+    end
+
+    it 'registers an offense for safe navigation with [] operator' do
+      expect_offense(<<-RUBY.strip_indent)
+        x&.foo[bar]
+              ^^^^^ Do not chain ordinary method call after safe navigation operator.
+      RUBY
+    end
+
+    it 'registers an offense for safe navigation with []= operator' do
+      expect_offense(<<-RUBY.strip_indent)
+        x&.foo[bar] = baz
+              ^^^^^^^^^^^ Do not chain ordinary method call after safe navigation operator.
+      RUBY
+    end
+
+    context 'proper highlighting' do
+      it 'when there are methods before' do
+        expect_offense(<<-RUBY.strip_indent)
+        something
+        x&.foo.bar.baz
+              ^^^^^^^^ Do not chain ordinary method call after safe navigation operator.
+        RUBY
+      end
+
+      it 'when there are methods after' do
+        expect_offense(<<-RUBY.strip_indent)
+          x&.foo.bar.baz
+                ^^^^^^^^ Do not chain ordinary method call after safe navigation operator.
+          something
+        RUBY
+      end
+
+      it 'when in a method' do
+        expect_offense(<<-RUBY.strip_indent)
+          def something
+            x&.foo.bar.baz
+                  ^^^^^^^^ Do not chain ordinary method call after safe navigation operator.
+          end
+        RUBY
+      end
+
+      it 'when in a begin' do
+        expect_offense(<<-RUBY.strip_indent)
+          begin
+            x&.foo.bar.baz
+                  ^^^^^^^^ Do not chain ordinary method call after safe navigation operator.
+          end
+        RUBY
+      end
+
+      it 'when used with a modifier if' do
+        expect_offense(<<-RUBY.strip_indent)
+          x&.foo.bar.baz if something
+                ^^^^^^^^ Do not chain ordinary method call after safe navigation operator.
+        RUBY
+      end
     end
   end
 end

--- a/spec/rubocop/cop/lint/safe_navigation_chain_spec.rb
+++ b/spec/rubocop/cop/lint/safe_navigation_chain_spec.rb
@@ -26,14 +26,6 @@ RSpec.describe RuboCop::Cop::Lint::SafeNavigationChain, :config do
     end
   end
 
-  shared_examples :autocorrect do |name, source, correction|
-    it "corrects #{name}" do
-      new_source = autocorrect_source_with_loop(source)
-
-      expect(new_source).to eq(correction)
-    end
-  end
-
   context 'TargetRubyVersion >= 2.3', :ruby23 do
     [
       ['ordinary method chain', 'x.foo.bar.baz'],
@@ -79,29 +71,6 @@ RSpec.describe RuboCop::Cop::Lint::SafeNavigationChain, :config do
       ['safe navigation with []=', 'x&.foo[bar] = baz']
     ].each do |name, code|
       include_examples :offense, name, code
-    end
-
-    [
-      ['ordinary method call exists after safe navigation method call',
-       'x&.foo.bar', 'x&.foo&.bar'],
-      ['ordinary method call exists after safe navigation method call' \
-       'with argument',
-       'x&.foo(x).bar(y)', 'x&.foo(x)&.bar(y)'],
-      ['ordinary method chain exists after safe navigation method call',
-       'x&.foo.bar.baz', 'x&.foo&.bar&.baz'],
-      ['ordinary method chain exists after safe navigation method call' \
-      'with argument',
-       'x&.foo(x).bar(y).baz(z)', 'x&.foo(x)&.bar(y)&.baz(z)'],
-      # Do not autocorrect the followings
-      ['safe navigation with < operator', 'x&.foo < bar', 'x&.foo < bar'],
-      ['safe navigation with > operator', 'x&.foo > bar', 'x&.foo > bar'],
-      ['safe navigation with <= operator', 'x&.foo <= bar', 'x&.foo <= bar'],
-      ['safe navigation with >= operator', 'x&.foo >= bar', 'x&.foo >= bar'],
-      ['safe navigation with + operator', 'x&.foo + bar', 'x&.foo + bar'],
-      ['safe navigation with []', 'x&.foo[bar]', 'x&.foo[bar]'],
-      ['safe navigation with []=', 'x&.foo[bar] = baz', 'x&.foo[bar] = baz']
-    ].each do |name, code, correction|
-      include_examples :autocorrect, name, code, correction
     end
   end
 end


### PR DESCRIPTION
This addresses the changes mentioned in #5595. I will start working on a separate cop to handle consistent usage of safe navigation on all sides of `&&` and `||`.