### PR TITLE
Parser::TreeRewriter compatibility (Parser 2.5+)

### DIFF
--- a/lib/rubocop/cop/cop.rb
+++ b/lib/rubocop/cop/cop.rb
@@ -97,6 +97,8 @@ module RuboCop
 
         @offenses = []
         @corrections = []
+        @corrected_nodes = {}
+        @corrected_nodes.compare_by_identity
         @processed_source = nil
       end
 
@@ -145,7 +147,9 @@ module RuboCop
       def correct(node)
         return :unsupported unless support_autocorrect?
         return :uncorrected unless autocorrect?
+        return :already_corrected if @corrected_nodes.key?(node)
 
+        @corrected_nodes[node] = true
         correction = autocorrect(node)
         return :uncorrected unless correction
         @corrections << correction

--- a/lib/rubocop/cop/corrector.rb
+++ b/lib/rubocop/cop/corrector.rb
@@ -33,7 +33,12 @@ module RuboCop
       def initialize(source_buffer, corrections = [])
         @source_buffer = source_buffer
         @corrections = corrections
-        @source_rewriter = Parser::Source::Rewriter.new(source_buffer)
+        @source_rewriter = Parser::Source::TreeRewriter.new(
+          source_buffer,
+          different_replacements: :raise,
+          swallowed_insertions: :raise,
+          crossing_deletions: :accept
+        )
 
         @diagnostics = []
         # Don't print warnings to stderr if corrections conflict with each other

--- a/lib/rubocop/cop/corrector.rb
+++ b/lib/rubocop/cop/corrector.rb
@@ -75,6 +75,11 @@ module RuboCop
       # @param [Parser::Source::Range] range
       # @param [String] content
       def insert_before(range, content)
+        # TODO: Fix Cops using bad ranges instead
+        if range.end_pos > @source_buffer.source.size
+          range = range.with(end_pos: @source_buffer.source.size)
+        end
+
         @source_rewriter.insert_before(range, content)
       end
 

--- a/lib/rubocop/cop/correctors/alignment_corrector.rb
+++ b/lib/rubocop/cop/correctors/alignment_corrector.rb
@@ -45,7 +45,8 @@ module RuboCop
 
           if column_delta > 0
             unless range.source == "\n"
-              corrector.insert_before(range, ' ' * column_delta)
+              # TODO: Fix ranges instead of using `begin`
+              corrector.insert_before(range.begin, ' ' * column_delta)
             end
           elsif range.source =~ /\A[ \t]+\z/
             remove(range, corrector)

--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |s|
   end
 
   s.add_runtime_dependency('parallel', '~> 1.10')
-  s.add_runtime_dependency('parser', '>= 2.4.0.2', '< 2.5')
+  s.add_runtime_dependency('parser', '>= 2.5')
   s.add_runtime_dependency('powerpack', '~> 0.1')
   s.add_runtime_dependency('rainbow', '>= 2.2.2', '< 4.0')
   s.add_runtime_dependency('ruby-progressbar', '~> 1.7')

--- a/spec/rubocop/cop/lint/script_permission_spec.rb
+++ b/spec/rubocop/cop/lint/script_permission_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe RuboCop::Cop::Lint::ScriptPermission do
 
   let(:file) { Tempfile.new('') }
   let(:filename) { file.path.split('/').last }
-  let(:source) { '#!/usr/bin/ruby' }
+  # HACK: extra empty line to bypass Parser 2.5.0.2 issue:
+  let(:source) { "#!/usr/bin/ruby\n\n" }
 
   after do
     file.close
@@ -27,6 +28,7 @@ RSpec.describe RuboCop::Cop::Lint::ScriptPermission do
         it 'allows any file permissions' do
           expect_no_offenses(<<-RUBY.strip_indent, file)
         #!/usr/bin/ruby
+
           RUBY
         end
       end
@@ -35,6 +37,7 @@ RSpec.describe RuboCop::Cop::Lint::ScriptPermission do
         expect_offense(<<-RUBY.strip_indent, file)
         #!/usr/bin/ruby
         ^^^^^^^^^^^^^^^ Script file #{filename} doesn't have execute permission.
+
           RUBY
       end
     end

--- a/spec/rubocop/cop/lint/script_permission_spec.rb
+++ b/spec/rubocop/cop/lint/script_permission_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe RuboCop::Cop::Lint::ScriptPermission do
 
   let(:file) { Tempfile.new('') }
   let(:filename) { file.path.split('/').last }
+  let(:source) { '#!/usr/bin/ruby' }
 
   after do
     file.close
@@ -16,8 +17,6 @@ RSpec.describe RuboCop::Cop::Lint::ScriptPermission do
   end
 
   context 'with file permission 0644' do
-    let(:source) { '#!/usr/bin/ruby' }
-
     before do
       File.write(file.path, source)
       FileUtils.chmod(0644, file.path)
@@ -47,7 +46,7 @@ RSpec.describe RuboCop::Cop::Lint::ScriptPermission do
     end
 
     it 'accepts with shebang line' do
-      File.write(file.path, '#!/usr/bin/ruby')
+      File.write(file.path, source)
 
       expect_no_offenses(file.read, file)
     end
@@ -69,14 +68,14 @@ RSpec.describe RuboCop::Cop::Lint::ScriptPermission do
     let(:options) { { stdin: '' } }
 
     it 'skips investigation' do
-      expect_no_offenses('#!/usr/bin/ruby')
+      expect_no_offenses(source)
     end
   end
 
   unless RuboCop::Platform.windows?
     context 'auto-correct' do
       it 'adds execute permissions to the file' do
-        File.write(file.path, '#!/usr/bin/ruby')
+        File.write(file.path, source)
 
         autocorrect_source(file.read, file)
 


### PR DESCRIPTION
This is a minimal PR to update to parser 2.5.0.2 and avoid a deprecation warning [#5579].

Only the first commit is a meaningful change. It keeps track of autocorrected nodes to avoid attempting to correct it twice. Given the fact that the interface for autocorrection only passes the node to correct, I can not see any circumstance where we'd want the corrector to be called twice on it, so this is a net improvement.

Other commits are hacks to avoid some cops' imperfect auto-correctors.

HTH.