### PR TITLE
Deprecate safe_level of `ERB.new` in Ruby 2.6

### DIFF
--- a/lib/rubocop/formatter/html_formatter.rb
+++ b/lib/rubocop/formatter/html_formatter.rb
@@ -53,7 +53,14 @@ module RuboCop
         context = ERBContext.new(files, summary)
 
         template = File.read(TEMPLATE_PATH, encoding: Encoding::UTF_8)
-        erb = ERB.new(template, nil, '-')
+
+        # The following condition is workaround for until Ruby 2.6 is released.
+        # https://github.com/ruby/ruby/commit/cc777d09f44fa909a336ba14f3aa802ffe16e010
+        erb = if RUBY_VERSION >= '2.6'
+                ERB.new(template, trim_mode: '-')
+              else
+                ERB.new(template, nil, '-')
+              end
         html = erb.result(context.binding)
 
         output.write html


### PR DESCRIPTION
This commit fixes the following build error of ruby-head (Ruby 2.6) .

```console
Failures:
  1) RuboCop::CLI -f/--format builtin formatters when html format is specified and offenses come from the cache and a message has binary encoding outputs HTML code without crashing
     Failure/Error: expect($stderr.string).to eq('')
     
       expected: ""
            got: "/home/travis/build/bbatsov/rubocop/lib/rubocop/formatter/html_formatter.rb:56: warning: Passing safe...rgument of ERB.new is deprecated. Use keyword argument like ERB.new(str, trim_mode: ...) instead.\n"
     
       (compared using ==)
     
       Diff:
       @@ -1 +1,5 @@
       +/home/travis/build/bbatsov/rubocop/lib/rubocop/formatter/html_formatter.rb:56: warning: Passing safe_level with the 2nd argument of ERB.new is deprecated. Do not use it, and specify other arguments as keyword arguments.
       +/home/travis/build/bbatsov/rubocop/lib/rubocop/formatter/html_formatter.rb:56: warning: Passing trim_mode with the 3rd argument of ERB.new is deprecated. Use keyword argument like ERB.new(str, trim_mode: ...) instead.
       +/home/travis/build/bbatsov/rubocop/lib/rubocop/formatter/html_formatter.rb:56: warning: Passing safe_level with the 2nd argument of ERB.new is deprecated. Do not use it, and specify other arguments as keyword arguments.
       +/home/travis/build/bbatsov/rubocop/lib/rubocop/formatter/html_formatter.rb:56: warning: Passing trim_mode with the 3rd argument of ERB.new is deprecated. Use keyword argument like ERB.new(str, trim_mode: ...) instead.
       
     # ./spec/rubocop/cli/cli_options_spec.rb:841:in `block (8 levels) in <top (required)>'
     # ./spec/support/cli_spec_behavior.rb:27:in `block (2 levels) in <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:27:in `block (4 levels) in <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:26:in `chdir'
     # ./lib/rubocop/rspec/shared_contexts.rb:26:in `block (3 levels) in <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:8:in `block (2 levels) in <top (required)>'
Finished in 1 minute 4.48 seconds (files took 4.77 seconds to load)
18679 examples, 1 failure, 6 pending
```

https://travis-ci.org/bbatsov/rubocop/jobs/347098351#L1077-L1100

Until Ruby 2.6 is released, this workaround will switch the interface of `ERB.new` using by RUBY_VERSION.

The following addresses are related commits.

- https://github.com/ruby/ruby/commit/cc777d09f44fa909a336ba14f3aa802ffe16e010
- https://github.com/ruby/ruby/commit/8b9a3eaba6c6af525974f7f41025d3371918931d

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
