### PR TITLE
Better error messages for MemoizedInstanceVariableName cop

### DIFF
--- a/lib/rubocop/cop/naming/memoized_instance_variable_name.rb
+++ b/lib/rubocop/cop/naming/memoized_instance_variable_name.rb
@@ -33,7 +33,8 @@ module RuboCop
       #   end
       #
       class MemoizedInstanceVariableName < Cop
-        MSG = 'Memoized variable does not match method name.'.freeze
+        MSG = 'Memoized variable `%<var>s` does not match ' \
+          'method name `%<method>s`. Use `@%<method>s` instead.'.freeze
 
         def self.node_pattern
           memo_assign = '(or_asgn $(ivasgn _) _)'
@@ -51,7 +52,12 @@ module RuboCop
         def on_def(node)
           (method_name, ivar_assign) = memoized?(node)
           return if matches?(method_name, ivar_assign)
-          add_offense(node, location: ivar_assign.source_range)
+          msg = format(
+            MSG,
+            var: ivar_assign.children.first.to_s,
+            method: method_name
+          )
+          add_offense(node, location: ivar_assign.source_range, message: msg)
         end
         alias on_defs on_def
 

--- a/spec/rubocop/cop/naming/memoized_instance_variable_name_spec.rb
+++ b/spec/rubocop/cop/naming/memoized_instance_variable_name_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe RuboCop::Cop::Naming::MemoizedInstanceVariableName do
       expect_offense(<<-RUBY.strip_indent)
       def x
         @my_var ||= :foo
-        ^^^^^^^ Memoized variable does not match method name.
+        ^^^^^^^ Memoized variable `@my_var` does not match method name `x`. Use `@x` instead.
       end
       RUBY
     end
@@ -19,7 +19,7 @@ RSpec.describe RuboCop::Cop::Naming::MemoizedInstanceVariableName do
       expect_offense(<<-RUBY.strip_indent)
       def self.x
         @my_var ||= :foo
-        ^^^^^^^ Memoized variable does not match method name.
+        ^^^^^^^ Memoized variable `@my_var` does not match method name `x`. Use `@x` instead.
       end
       RUBY
     end
@@ -30,7 +30,7 @@ RSpec.describe RuboCop::Cop::Naming::MemoizedInstanceVariableName do
       expect_offense(<<-RUBY.strip_indent)
       foo = def x
         @y ||= :foo
-        ^^ Memoized variable does not match method name.
+        ^^ Memoized variable `@y` does not match method name `x`. Use `@x` instead.
       end
       RUBY
     end
@@ -41,7 +41,7 @@ RSpec.describe RuboCop::Cop::Naming::MemoizedInstanceVariableName do
       expect_offense(<<-RUBY.strip_indent)
       def x
         @y ||= begin
-        ^^ Memoized variable does not match method name.
+        ^^ Memoized variable `@y` does not match method name `x`. Use `@x` instead.
           :foo
         end
       end
@@ -55,7 +55,7 @@ RSpec.describe RuboCop::Cop::Naming::MemoizedInstanceVariableName do
         def foo
           helper_variable = something_we_need_to_calculate_foo
           @bar ||= calculate_expensive_thing(helper_variable)
-          ^^^^ Memoized variable does not match method name.
+          ^^^^ Memoized variable `@bar` does not match method name `foo`. Use `@foo` instead.
         end
       RUBY
     end


### PR DESCRIPTION
Error message should mention the variable name and suggest fix:
https://github.com/bbatsov/rubocop/pull/5445#pullrequestreview-99538395


-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
