### PR TITLE
[Fix #5615] Fix false positive `Rails/FilePath` when using `File::SEPARATOR` string

### DIFF
--- a/lib/rubocop/cop/rails/file_path.rb
+++ b/lib/rubocop/cop/rails/file_path.rb
@@ -33,10 +33,9 @@ module RuboCop
         PATTERN
 
         def on_dstr(node)
-          unless rails_root_nodes?(node) &&
-                 node.children.last.source.start_with?('.')
-            return unless node.children.last.source.include?(File::SEPARATOR)
-          end
+          return unless rails_root_nodes?(node)
+          return unless node.children.last.source.start_with?('.') ||
+                        node.children.last.source.include?(File::SEPARATOR)
 
           register_offense(node)
         end

--- a/spec/rubocop/cop/rails/file_path_spec.rb
+++ b/spec/rubocop/cop/rails/file_path_spec.rb
@@ -23,6 +23,14 @@ RSpec.describe RuboCop::Cop::Rails::FilePath do
     end
   end
 
+  context 'when using File::SEPARATOR string without Rails.root' do
+    it 'does not registers an offense' do
+      expect_no_offenses(<<-'RUBY'.strip_indent)
+        "#{42}/"
+      RUBY
+    end
+  end
+
   context 'when using File.join with Rails.root' do
     it 'registers an offense' do
       expect_offense(<<-RUBY.strip_indent)


### PR DESCRIPTION
Fixes #5615.

This PR fixes a false positive in `Rails/FilePath` cop when using `File::SEPARATOR` string (e.g. `'/'`) without `Rails.root.join`.

This regression was due to #5461.
Since this is a regression for changes that have not yet been released, it is not described in CHANGELOG.md.

Cc @bquorning 

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
