### PR TITLE
Fix false-negative on EmptyLinesAroundAccessModifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@
 * [#5547](https://github.com/bbatsov/rubocop/issues/5547): Fix auto-correction of of `Layout/BlockEndNewline` when there is top level code outside of a class. ([@rrosenblum][])
 * [#5599](https://github.com/bbatsov/rubocop/issues/5599): Fix the suggestion being used by `Lint/NumberConversion` to use base 10 with Integer. ([@rrosenblum][])
 * [#5534](https://github.com/bbatsov/rubocop/issues/5534): Fix `Style/EachWithObject` auto-correction leaves an empty line. ([@flyerhzm][])
+* Fix `Layout/EmptyLinesAroundAccessModifier` false-negative when next string after access modifier started with end. ([@unkmas][])
 
 ### Changes
 

--- a/lib/rubocop/cop/layout/empty_lines_around_access_modifier.rb
+++ b/lib/rubocop/cop/layout/empty_lines_around_access_modifier.rb
@@ -48,7 +48,7 @@ module RuboCop
               corrector.insert_before(line, "\n")
             end
 
-            unless next_line_empty?(node, next_line)
+            unless next_line_empty?(next_line)
               corrector.insert_after(line, "\n")
             end
           end
@@ -68,8 +68,8 @@ module RuboCop
             previous_line.blank?
         end
 
-        def next_line_empty?(node, next_line)
-          last_children?(node) || next_line.blank?
+        def next_line_empty?(next_line)
+          body_end?(next_line) || next_line.blank?
         end
 
         def empty_lines_around?(node)
@@ -78,8 +78,7 @@ module RuboCop
                                                           send_line)
           next_line = processed_source[send_line]
 
-          previous_line_empty?(previous_line) &&
-            next_line_empty?(node, next_line)
+          previous_line_empty?(previous_line) && next_line_empty?(next_line)
         end
 
         def class_def?(line)
@@ -90,10 +89,8 @@ module RuboCop
           line.match(/ (do|{)( \|.*?\|)?\s?$/)
         end
 
-        def last_children?(node)
-          next_sibling = node.parent.children[node.sibling_index + 1]
-
-          next_sibling.nil?
+        def body_end?(line)
+          line =~ /^\s*end\b/
         end
 
         def message(node)

--- a/lib/rubocop/cop/layout/empty_lines_around_access_modifier.rb
+++ b/lib/rubocop/cop/layout/empty_lines_around_access_modifier.rb
@@ -48,7 +48,7 @@ module RuboCop
               corrector.insert_before(line, "\n")
             end
 
-            unless next_line_empty?(next_line)
+            unless next_line_empty?(node, next_line)
               corrector.insert_after(line, "\n")
             end
           end
@@ -68,8 +68,8 @@ module RuboCop
             previous_line.blank?
         end
 
-        def next_line_empty?(next_line)
-          body_end?(next_line) || next_line.blank?
+        def next_line_empty?(node, next_line)
+          last_children?(node) || next_line.blank?
         end
 
         def empty_lines_around?(node)
@@ -78,7 +78,8 @@ module RuboCop
                                                           send_line)
           next_line = processed_source[send_line]
 
-          previous_line_empty?(previous_line) && next_line_empty?(next_line)
+          previous_line_empty?(previous_line) &&
+            next_line_empty?(node, next_line)
         end
 
         def class_def?(line)
@@ -89,8 +90,10 @@ module RuboCop
           line.match(/ (do|{)( \|.*?\|)?\s?$/)
         end
 
-        def body_end?(line)
-          line =~ /^\s*end/
+        def last_children?(node)
+          next_sibling = node.parent.children[node.sibling_index + 1]
+
+          next_sibling.nil?
         end
 
         def message(node)

--- a/spec/rubocop/cop/layout/empty_lines_around_access_modifier_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_access_modifier_spec.rb
@@ -234,6 +234,19 @@ RSpec.describe RuboCop::Cop::Layout::EmptyLinesAroundAccessModifier do
       RUBY
     end
 
+    it 'requires blank line when next line started with end' do
+      inspect_source(<<-RUBY.strip_indent)
+        class Test
+          #{access_modifier}
+          end_this!
+        end
+      RUBY
+
+      expect(cop.offenses.size).to eq(1)
+      expect(cop.messages)
+        .to eq(["Keep a blank line after `#{access_modifier}`."])
+    end
+
     it 'recognizes blank lines with DOS style line endings' do
       expect_no_offenses(<<-RUBY.strip_indent)
         class Test\r


### PR DESCRIPTION
Fixes false-negative for EmptyLineAccessModifier when next line is a string starting with "end":

```ruby
  class Test
    private
    end_this!
  end
```
-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
