### PR TITLE
Allow `to` as method parameter in default config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 * [#5623](https://github.com/bbatsov/rubocop/pull/5623): Fix `Bundler/OrderedGems` when a group includes duplicate gems. ([@colorbox][])
 ### Changes
-* Change `Naming/UncommunicativeMethodParamName` add `to` to allowed names in default config. ([@unused][])
+* [#5626](https://github.com/bbatsov/rubocop/pull/5626): Change `Naming/UncommunicativeMethodParamName` add `to` to allowed names in default config. ([@unused][])
 
 ## 0.53.0 (2018-03-05)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Bug fixes
 
 * [#5623](https://github.com/bbatsov/rubocop/pull/5623): Fix `Bundler/OrderedGems` when a group includes duplicate gems. ([@colorbox][])
+### Changes
+* Change `Naming/UncommunicativeMethodParamName` add `to` to allowed names in default config. ([@unused][])
 
 ## 0.53.0 (2018-03-05)
 
@@ -3230,3 +3232,4 @@
 [@unkmas]: https://github.com/unkmas
 [@elebow]: https://github.com/elebow
 [@colorbox]: https://github.com/colorbox
+[@unused]: https://github.com/unused

--- a/config/default.yml
+++ b/config/default.yml
@@ -762,6 +762,7 @@ Naming/UncommunicativeMethodParamName:
   AllowedNames:
     - io
     - id
+    - to
   # Blacklisted names that will register an offense
   ForbiddenNames: []
 

--- a/manual/cops_naming.md
+++ b/manual/cops_naming.md
@@ -186,7 +186,7 @@ Name | Default value | Configurable values
 --- | --- | ---
 Exclude | `[]` | Array
 ExpectMatchingDefinition | `false` | Boolean
-Regex | `<none>` |
+Regex | `<none>` | 
 IgnoreExecutableScripts | `true` | Boolean
 AllowedAcronyms | `CLI`, `DSL`, `ACL`, `API`, `ASCII`, `CPU`, `CSS`, `DNS`, `EOF`, `GUID`, `HTML`, `HTTP`, `HTTPS`, `ID`, `IP`, `JSON`, `LHS`, `QPS`, `RAM`, `RHS`, `RPC`, `SLA`, `SMTP`, `SQL`, `SSH`, `TCP`, `TLS`, `TTL`, `UDP`, `UI`, `UID`, `UUID`, `URI`, `URL`, `UTF8`, `VM`, `XML`, `XMPP`, `XSRF`, `XSS` | Array
 

--- a/manual/cops_naming.md
+++ b/manual/cops_naming.md
@@ -186,7 +186,7 @@ Name | Default value | Configurable values
 --- | --- | ---
 Exclude | `[]` | Array
 ExpectMatchingDefinition | `false` | Boolean
-Regex | `<none>` | 
+Regex | `<none>` |
 IgnoreExecutableScripts | `true` | Boolean
 AllowedAcronyms | `CLI`, `DSL`, `ACL`, `API`, `ASCII`, `CPU`, `CSS`, `DNS`, `EOF`, `GUID`, `HTML`, `HTTP`, `HTTPS`, `ID`, `IP`, `JSON`, `LHS`, `QPS`, `RAM`, `RHS`, `RPC`, `SLA`, `SMTP`, `SQL`, `SSH`, `TCP`, `TLS`, `TTL`, `UDP`, `UI`, `UID`, `UUID`, `URI`, `URL`, `UTF8`, `VM`, `XML`, `XMPP`, `XSRF`, `XSS` | Array
 
@@ -508,7 +508,7 @@ Name | Default value | Configurable values
 --- | --- | ---
 MinNameLength | `3` | Integer
 AllowNamesEndingInNumbers | `true` | Boolean
-AllowedNames | `io`, `id` | Array
+AllowedNames | `io`, `id`, `to` | Array
 ForbiddenNames | `[]` | Array
 
 ## Naming/VariableName


### PR DESCRIPTION
Add `to` to AllowedNames in default configuration for cop
Naming/UncommunicativeMethodParamName in order to allow common
methods handling date ranges with parameter `set_date_range(from, to)`