### PR TITLE
[#5610] Infer TargetRubyVersion from bundler lock files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@
 * [#5637](https://github.com/bbatsov/rubocop/issues/5637): Fix error for `Layout/SpaceInsideArrayLiteralBrackets` when contains an array literal as an argument after a heredoc is started. ([@koic][])
 * [#5498](https://github.com/bbatsov/rubocop/issues/5498): Correct IndentHeredoc message for Ruby 2.3 when using `<<~` operator with invalid indentation. ([@hamada14][])
 
+* [#5610](https://github.com/bbatsov/rubocop/issues/5610): Use `gems.locked` or `Gemfile.lock` to determine the best `TargetRubyVersion` when it is not specified in the config. ([@roberts1000][])
+
 ## 0.53.0 (2018-03-05)
 
 ### New features

--- a/config/default.yml
+++ b/config/default.yml
@@ -115,9 +115,15 @@ AllCops:
   AllowSymlinksInCacheRootDirectory: false
   # What MRI version of the Ruby interpreter is the inspected code intended to
   # run on? (If there is more than one, set this to the lowest version.)
-  # If a value is specified for TargetRubyVersion then it is used.
-  # Else if .ruby-version exists and it contains an MRI version it is used.
-  # Otherwise we fallback to the oldest officially supported Ruby version (2.1).
+  # If a value is specified for TargetRubyVersion then it is used. Acceptable
+  # values are specificed as a float (i.e. 2.5); the teeny version of Ruby
+  # should not be included. If the project specifies a Ruby version in the
+  # .ruby-version file, Gemfile or gems.rb file, RuboCop will try to determine
+  # the desired version of Ruby by inspecting the .ruby-version file first,
+  # followed by the Gemfile.lock or gems.locked file. (Although the Ruby version
+  # is specified in the Gemfile or gems.rb file, RuboCop reads the final value
+  # from the lock file.) If the Ruby version is still unresolved, RuboCop will
+  # use the oldest officially supported Ruby version (currently Ruby 2.1).
   TargetRubyVersion: ~
   # What version of Rails is the inspected code using?  If a value is specified
   # for TargetRailsVersion then it is used.  Acceptable values are specificed

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -425,6 +425,10 @@ module RuboCop
           @target_ruby_version_source = :ruby_version_file
 
           target_ruby_version_from_version_file
+        elsif target_ruby_version_from_bundler_lock_file
+          @target_ruby_version_source = :bundler_lock_file
+
+          target_ruby_version_from_bundler_lock_file
         else
           DEFAULT_RUBY_VERSION
         end
@@ -557,6 +561,8 @@ module RuboCop
       case @target_ruby_version_source
       when :ruby_version_file
         "`#{RUBY_VERSION_FILENAME}`"
+      when :bundler_lock_file
+        "`#{bundler_lock_file_path}`"
       when :rubocop_yml
         "`TargetRubyVersion` parameter (in #{smart_loaded_path})"
       end
@@ -577,6 +583,37 @@ module RuboCop
         end
     end
 
+    def target_ruby_version_from_bundler_lock_file
+      @target_ruby_version_from_bundler_lock_file ||=
+        read_ruby_version_from_bundler_lock_file
+    end
+
+    def read_ruby_version_from_bundler_lock_file
+      lock_file_path = bundler_lock_file_path
+      return nil unless lock_file_path
+
+      in_ruby_section = false
+      File.foreach(lock_file_path) do |line|
+        # If ruby is in Gemfile.lock or gems.lock, there should be two lines
+        # towards the bottom of the file that look like:
+        #     RUBY VERSION
+        #       ruby W.X.YpZ
+        # We ultimately want to match the "ruby W.X.Y.pZ" line, but there's
+        # extra logic to make sure we only start looking once we've seen the
+        # "RUBY VERSION" line.
+        in_ruby_section ||= line.match(/^\s*RUBY\s*VERSION\s*$/)
+        next unless in_ruby_section
+        # We currently only allow this feature to work with MRI ruby.  If jruby
+        # (or something else) is used by the project, it's lock file will have a
+        # line that looks like:
+        #     RUBY VERSION
+        #       ruby W.X.YpZ (jruby x.x.x.x)
+        # The regex won't match in this situation.
+        result = line.match(/^\s*ruby\s+(\d+\.\d+)[p.\d]*\s*$/)
+        return result.captures.first.to_f if result
+      end
+    end
+
     def target_rails_version_from_bundler_lock_file
       @target_rails_version_from_bundler_lock_file ||=
         read_rails_version_from_bundler_lock_file
@@ -587,7 +624,7 @@ module RuboCop
       return nil unless lock_file_path
 
       File.foreach(lock_file_path) do |line|
-        # If rails is in the Gemfile, the lock file should have a line like:
+        # If rails is in Gemfile.lock or gems.lock, there should be a line like:
         #         rails (X.X.X)
         result = line.match(/^\s+rails\s+\((\d\.\d\.\d)/)
         return result.captures.first.to_f if result
@@ -598,8 +635,8 @@ module RuboCop
       return nil unless loaded_path
       base_path = base_dir_for_path_parameters
       ['gems.locked', 'Gemfile.lock'].each do |file_name|
-        path = File.join(base_path, file_name)
-        return path if File.file?(path)
+        path = find_file_upwards(file_name, base_path)
+        return path if path
       end
       nil
     end


### PR DESCRIPTION
Closes #5610.

Change the config init process slightly, for setting TargetRubyVersion, to consider the gems.locked or Gemfile.lock when trying to determine the best value.  If the user adds `ruby ...` to the Gemfile, bundler will lock Ruby to a specific version and we can use that information to dynamically pick the best value for TargetRubyVersion.  The .ruby-version file is still considered first before looking at lock file.

If TargetRubyVersion is set in the config file, it still takes precedence and is always used. If Ruby is not in gems.locked or Gemfile.lock, and the user hasn't specified a version in the config, the default version is still used as the fallback.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
