### PR TITLE
Fix broken `--fail-fast`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 * [#5623](https://github.com/bbatsov/rubocop/pull/5623): Fix `Bundler/OrderedGems` when a group includes duplicate gems. ([@colorbox][])
+* [#5633](https://github.com/bbatsov/rubocop/pull/5633): Fix broken `--fail-fast`. ([@mmyoji][])
 
 ## 0.53.0 (2018-03-05)
 
@@ -3230,3 +3231,4 @@
 [@unkmas]: https://github.com/unkmas
 [@elebow]: https://github.com/elebow
 [@colorbox]: https://github.com/colorbox
+[@mmyoji]: https://github.com/mmyoji

--- a/lib/rubocop/target_finder.rb
+++ b/lib/rubocop/target_finder.rb
@@ -121,7 +121,7 @@ module RuboCop
       end
 
       # Most recently modified file first.
-      target_files.sort_by! { |path| Integer(-File.mtime(path)) } if fail_fast?
+      target_files.sort_by! { |path| -Integer(File.mtime(path)) } if fail_fast?
 
       target_files
     end

--- a/spec/rubocop/target_finder_spec.rb
+++ b/spec/rubocop/target_finder_spec.rb
@@ -268,5 +268,20 @@ RSpec.describe RuboCop::TargetFinder, :isolated_environment do
         end
       end
     end
+
+    context 'w/ --fail-fast option' do
+      let(:options) do
+        {
+          force_exclusion: force_exclusion,
+          debug: debug,
+          fail_fast: true
+        }
+      end
+
+      it 'works' do
+        rb_file_count = found_files.count { |f| f.end_with?('.rb') }
+        expect(rb_file_count).to eq(3)
+      end
+    end
   end
 end


### PR DESCRIPTION
`rubocop --fail-fast` was broken at 43a157f1a674da16b45a13f69e242565382f7ac5

I fixed this and add minimum test for it.