### PR TITLE
[Fix #5630] Fix false positive `Style/FormatStringToken`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#5623](https://github.com/bbatsov/rubocop/pull/5623): Fix `Bundler/OrderedGems` when a group includes duplicate gems. ([@colorbox][])
 * [#5633](https://github.com/bbatsov/rubocop/pull/5633): Fix broken `--fail-fast`. ([@mmyoji][])
+* [#5630](https://github.com/bbatsov/rubocop/issues/5630): Fix false positive for `Style/FormatStringToken` when using placeholder arguments in `format` method. ([@koic][])
 
 ### Changes
 * [#5626](https://github.com/bbatsov/rubocop/pull/5626): Change `Naming/UncommunicativeMethodParamName` add `to` to allowed names in default config. ([@unused][])

--- a/lib/rubocop/cop/style/format_string_token.rb
+++ b/lib/rubocop/cop/style/format_string_token.rb
@@ -51,6 +51,7 @@ module RuboCop
         }.freeze
 
         def on_str(node)
+          return if placeholder_argument?(node)
           return if node.each_ancestor(:xstr, :regexp).any?
 
           tokens(node) do |detected_style, token_range|
@@ -155,6 +156,13 @@ module RuboCop
             new_begin,
             new_end
           )
+        end
+
+        def placeholder_argument?(node)
+          return false unless node.parent
+          return true if node.parent.pair_type?
+
+          placeholder_argument?(node.parent)
         end
       end
     end

--- a/spec/rubocop/cop/style/format_string_token_spec.rb
+++ b/spec/rubocop/cop/style/format_string_token_spec.rb
@@ -127,6 +127,17 @@ RSpec.describe RuboCop::Cop::Style::FormatStringToken, :config do
     RUBY
   end
 
+  it 'ignores placeholder argumetns' do
+    expect_no_offenses(<<-RUBY.strip_indent)
+      format(
+        '%<day>s %<start>s-%<end>s',
+        day: open_house.starts_at.strftime('%a'),
+        start: open_house.starts_at.strftime('%l'),
+        end: open_house.ends_at.strftime('%l %p').strip
+      )
+    RUBY
+  end
+
   it 'handles __FILE__' do
     expect_no_offenses('__FILE__')
   end


### PR DESCRIPTION
Fixes #5630.

This PR fixes a false positive for `Style/FormatStringToken` when using placeholder arguments in `format` method.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
