### PR TITLE
[Fix #5619] - Do not register an offense when in InverseMethods when determining class hierarchy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [#5630](https://github.com/bbatsov/rubocop/issues/5630): Fix false positive for `Style/FormatStringToken` when using placeholder arguments in `format` method. ([@koic][])
 * [#5651](https://github.com/bbatsov/rubocop/pull/5651): Fix NoMethodError when specified config file that does not exist. ([@onk][])
 * [#5647](https://github.com/bbatsov/rubocop/pull/5647): Fix encoding method of RuboCop::MagicComment::SimpleComment. ([@htwroclau][])
+* [#5619](https://github.com/bbatsov/rubocop/issues/5619): Do not register an offense in `Style/InverseMethods` when comparing constants with `<`, `>`, `<=`, or `>=`. If the code is being used to determine class hierarchy, the correction might not be accurate. ([@rrosenblum][])
 
 ### Changes
 

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -2508,6 +2508,7 @@ foo.any? { |f| f.even? }
 foo != bar
 foo == bar
 !!('foo' =~ /^\w+$/)
+!(foo.class < Numeric) # Checking class hierarchy is allowed
 ```
 
 ### Configurable attributes

--- a/spec/rubocop/cop/style/inverse_methods_spec.rb
+++ b/spec/rubocop/cop/style/inverse_methods_spec.rb
@@ -150,6 +150,36 @@ RSpec.describe RuboCop::Cop::Style::InverseMethods do
     end
   end
 
+  it 'allows comparing camel case constants on the right' do
+    expect_no_offenses(<<-RUBY.strip_indent)
+      klass = self.class
+      !(klass < BaseClass)
+    RUBY
+  end
+
+  it 'allows comparing camel case constants on the left' do
+    expect_no_offenses(<<-RUBY.strip_indent)
+      klass = self.class
+      !(BaseClass < klass)
+    RUBY
+  end
+
+  it 'registers an offense for comparing snake case constants on the right' do
+    expect_offense(<<-RUBY.strip_indent)
+      klass = self.class
+      !(klass < FOO_BAR)
+      ^^^^^^^^^^^^^^^^^^ Use `>=` instead of inverting `<`.
+    RUBY
+  end
+
+  it 'registers an offense for comparing snake case constants on the left' do
+    expect_offense(<<-RUBY.strip_indent)
+      klass = self.class
+      !(FOO_BAR < klass)
+      ^^^^^^^^^^^^^^^^^^ Use `>=` instead of inverting `<`.
+    RUBY
+  end
+
   context 'inverse blocks' do
     { select: :reject,
       reject: :select,


### PR DESCRIPTION
This fixes #5619. Unfortunately the only way to safe guard against this is to eliminate any comparison to a constant.

The alternative would be to stop checking for negated `>`, `<`, `>=`, and `<=`.