### PR TITLE
Add the issue tracker URL to error message

### DIFF
--- a/lib/rubocop/cli.rb
+++ b/lib/rubocop/cli.rb
@@ -258,6 +258,8 @@ module RuboCop
       warn <<-WARNING.strip_indent
         Errors are usually caused by RuboCop bugs.
         Please, report your problems to RuboCop's issue tracker.
+        #{Gem.loaded_specs['rubocop'].metadata['bug_tracker_uri']}
+
         Mention the following information in the issue report:
         #{RuboCop::Version.version(true)}
       WARNING


### PR DESCRIPTION
I think that it is user friendly that there is official issue tracker URL in the error message when a bug occurs.

## Before

```console
Errors are usually caused by RuboCop bugs.
Please, report your problems to RuboCop's issue tracker.
Mention the following information in the issue report:
0.53.0 (using Parser 2.5.0.3, running on ruby 2.5.0 x86_64-darwin17)
```

## After

```console
Errors are usually caused by RuboCop bugs.
Please, report your problems to RuboCop's issue tracker.
https://github.com/bbatsov/rubocop/issues

Mention the following information in the issue report:
0.53.0 (using Parser 2.5.0.3, running on ruby 2.5.0 x86_64-darwin17)
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
