### PR TITLE
Remove workaround for parser gem in the Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -124,9 +124,6 @@ task documentation_syntax_check: :yard_for_generate_documentation do
   YARD::Registry.load!
   cops = RuboCop::Cop::Cop.registry
   cops.each do |cop|
-    # TODO: parser cannot parse the example, so skip it.
-    #       https://github.com/whitequark/parser/issues/407
-    next if cop == RuboCop::Cop::Layout::SpaceAroundKeyword
     next if %i[RSpec Capybara FactoryBot].include?(cop.department)
     examples = YARD::Registry.all(:class).find do |code_object|
       next unless RuboCop::Cop::Badge.for(code_object.to_s) == cop.badge


### PR DESCRIPTION
`documentation_syntax_check` task has a workaround. Parser gem had a bug
for `1i` ( https://github.com/whitequark/parser/issues/407 ), so the task did not work without the workaround.

But the bug has been fixed since Parser gem 2.5.0.0 ( https://github.com/whitequark/parser/blob/master/CHANGELOG.md#v2500-2018-02-16 ), and RuboCop requires parser 2.5 or newer, so we can remove the workaround.



