### PR TITLE
Fix encoding method of RuboCop::MagicComment::SimpleComment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [#5633](https://github.com/bbatsov/rubocop/pull/5633): Fix broken `--fail-fast`. ([@mmyoji][])
 * [#5630](https://github.com/bbatsov/rubocop/issues/5630): Fix false positive for `Style/FormatStringToken` when using placeholder arguments in `format` method. ([@koic][])
 * [#5651](https://github.com/bbatsov/rubocop/pull/5651): Fix NoMethodError when specified config file that does not exist. ([@onk][])
+* [#5647](https://github.com/bbatsov/rubocop/pull/5647): Fix encoding method of RuboCop::MagicComment::SimpleComment. ([@htwroclau][])
 
 ### Changes
 
@@ -3241,3 +3242,4 @@
 [@colorbox]: https://github.com/colorbox
 [@mmyoji]: https://github.com/mmyoji
 [@unused]: https://github.com/unused
+[@htwroclau]: https://github.com/htwroclau

--- a/lib/rubocop/magic_comment.rb
+++ b/lib/rubocop/magic_comment.rb
@@ -190,7 +190,7 @@ module RuboCop
     class SimpleComment < MagicComment
       # Match `encoding` or `coding`
       def encoding
-        extract(/\b(?:en)?coding: (#{TOKEN})/i)
+        extract(/\#* \b(?:en)?coding: (#{TOKEN})/i)
       end
 
       private

--- a/spec/rubocop/magic_comment_spec.rb
+++ b/spec/rubocop/magic_comment_spec.rb
@@ -84,6 +84,11 @@ RSpec.describe RuboCop::MagicComment do
                    encoding: 'ascii-8bit',
                    frozen_string_literal: nil
 
+  include_examples 'magic comment',
+                   ' CSV.generate(encoding: Encoding::UTF_8) do |csv|',
+                   encoding: nil,
+                   frozen_string_literal: nil
+
   include_examples(
     'magic comment',
     '# -*- encoding: ASCII-8BIT; frozen_string_literal: true -*-',


### PR DESCRIPTION
This PR fixes encoding method of RuboCop::MagicComment::SimpleComment for extracting by mistake of Lint/OrderedMagicComments.
example: `CSV.generate(encoding: Encoding::UTF_8) do |csv|`

I think that is solved by adding the condition of ‘# ’ before ‘encoding:’.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
