### PR TITLE
Improve examples of `Rails/SkipsModelValidations` cop

### DIFF
--- a/lib/rubocop/cop/rails/skips_model_validations.rb
+++ b/lib/rubocop/cop/rails/skips_model_validations.rb
@@ -16,12 +16,12 @@ module RuboCop
       #   person.toggle :active
       #   product.touch
       #   Billing.update_all("category = 'authorized', author = 'David'")
-      #   user.update_attribute(website: 'example.com')
+      #   user.update_attribute(:website, 'example.com')
       #   user.update_columns(last_request_at: Time.current)
       #   Post.update_counters 5, comment_count: -1, action_count: 1
       #
       #   # good
-      #   user.update_attributes(website: 'example.com')
+      #   user.update(website: 'example.com')
       #   FileUtils.touch('file')
       class SkipsModelValidations < Cop
         MSG = 'Avoid using `%<method>s` because it skips validations.'.freeze

--- a/manual/cops_rails.md
+++ b/manual/cops_rails.md
@@ -1585,12 +1585,12 @@ DiscussionBoard.increment_counter(:post_count, 5)
 person.toggle :active
 product.touch
 Billing.update_all("category = 'authorized', author = 'David'")
-user.update_attribute(website: 'example.com')
+user.update_attribute(:website, 'example.com')
 user.update_columns(last_request_at: Time.current)
 Post.update_counters 5, comment_count: -1, action_count: 1
 
 # good
-user.update_attributes(website: 'example.com')
+user.update(website: 'example.com')
 FileUtils.touch('file')
 ```
 

--- a/spec/rubocop/cop/rails/skips_model_validations_spec.rb
+++ b/spec/rubocop/cop/rails/skips_model_validations_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe RuboCop::Cop::Rails::SkipsModelValidations, :config do
 
     it 'registers an offense for `update_attribute`' do
       expect_offense(<<-RUBY.strip_indent)
-        user.update_attribute('website': 'example.com')
+        user.update_attribute(:website, 'example.com')
              ^^^^^^^^^^^^^^^^ Avoid using `update_attribute` because it skips validations.
       RUBY
     end


### PR DESCRIPTION
Follow up of #5592.

`update_attributes` will be deprecated in Rails 6.0.
This PR changed to indicate `update` instead of `update_attributes` according to `RailsActiveRecordAliases` cop.

Also fixed because the number of arguments of `update_attribute` was wrong.

```console
> Model.update_attribute(attr: 'value')
ArgumentError: wrong number of arguments (given 1, expected 2)
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
