### PR TITLE
[Fix #5640] Only warn about parameter overrides with --debug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@
 * [#5633](https://github.com/bbatsov/rubocop/pull/5633): Fix broken `--fail-fast`. ([@mmyoji][])
 
 ### Changes
+
 * [#5626](https://github.com/bbatsov/rubocop/pull/5626): Change `Naming/UncommunicativeMethodParamName` add `to` to allowed names in default config. ([@unused][])
+* [#5640](https://github.com/bbatsov/rubocop/issues/5640): Warn about user configuration overriding other user configuration only with `--debug`. ([@jonas054][])
 
 ## 0.53.0 (2018-03-05)
 

--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -35,7 +35,6 @@ module RuboCop
       end
 
       def load_file(file)
-        return if file.nil?
         path = File.absolute_path(file.is_a?(RemoteConfig) ? file.file : file)
 
         hash = load_yaml_configuration(path)
@@ -47,7 +46,7 @@ module RuboCop
         target_ruby_version_to_f!(hash)
 
         resolver.resolve_inheritance_from_gems(hash, hash.delete('inherit_gem'))
-        resolver.resolve_inheritance(path, hash, file)
+        resolver.resolve_inheritance(path, hash, file, debug?)
 
         hash.delete('inherit_from')
         hash.delete('inherit_mode')

--- a/lib/rubocop/config_loader_resolver.rb
+++ b/lib/rubocop/config_loader_resolver.rb
@@ -17,7 +17,7 @@ module RuboCop
       end
     end
 
-    def resolve_inheritance(path, hash, file)
+    def resolve_inheritance(path, hash, file, debug)
       inherited_files = Array(hash['inherit_from'])
       base_configs(path, inherited_files, file)
         .reverse.each_with_index do |base_config, index|
@@ -25,7 +25,7 @@ module RuboCop
           next unless v.is_a?(Hash)
           if hash.key?(k)
             v = merge(v, hash[k],
-                      cop_name: k, file: file,
+                      cop_name: k, file: file, debug: debug,
                       inherited_file: inherited_files[index],
                       inherit_mode: determine_inherit_mode(hash, k))
           end
@@ -86,7 +86,7 @@ module RuboCop
           result[key] = merge(base_hash[key], derived_hash[key])
         elsif should_union?(base_hash, key, opts[:inherit_mode])
           result[key] = base_hash[key] | derived_hash[key]
-        else
+        elsif opts[:debug]
           warn_on_duplicate_setting(base_hash, derived_hash, key, opts)
         end
       end
@@ -112,9 +112,9 @@ module RuboCop
       return if base_hash[key].is_a?(Array) &&
                 inherit_mode && inherit_mode.include?(key)
 
-      warn("#{PathUtil.smart_path(opts[:file])}: " \
+      puts "#{PathUtil.smart_path(opts[:file])}: " \
            "#{opts[:cop_name]}:#{key} overrides " \
-           "the same parameter in #{opts[:inherited_file]}")
+           "the same parameter in #{opts[:inherited_file]}"
     end
 
     def determine_inherit_mode(hash, key)

--- a/spec/rubocop/cli/cli_auto_gen_config_spec.rb
+++ b/spec/rubocop/cli/cli_auto_gen_config_spec.rb
@@ -172,11 +172,11 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
               Max: 90
           YAML
           $stdout = StringIO.new
-          expect(described_class.new.run(%w[--format simple])).to eq(1)
-          expect($stderr.string)
-            .to eq('.rubocop.yml: Metrics/LineLength:Max overrides the same ' \
-                   "parameter in .rubocop_todo.yml\n")
-          expect($stdout.string).to eq(<<-OUTPUT.strip_indent)
+          expect(described_class.new.run(%w[--format simple --debug])).to eq(1)
+          expect($stdout.string)
+            .to include('.rubocop.yml: Metrics/LineLength:Max overrides the ' \
+                        "same parameter in .rubocop_todo.yml\n")
+          expect($stdout.string).to include(<<-OUTPUT.strip_indent)
             == example.rb ==
             C:  2: 91: Metrics/LineLength: Line is too long. [99/90]
 


### PR DESCRIPTION
Overriding a parameter within user configuration with another setting -- also in user configuration -- may be a legitimate use case. So we only print the message about overriding if the `--debug` option is given. The message will be on stdout now like the other debug messages.