### PR TITLE
Improve examples of Style/RedundantBegin cop

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -118,7 +118,7 @@ end
 
 desc 'Syntax check for the documentation comments'
 task documentation_syntax_check: :yard_for_generate_documentation do
-  require 'parser/ruby24'
+  require 'parser/ruby25'
 
   ok = true
   YARD::Registry.load!
@@ -134,7 +134,7 @@ task documentation_syntax_check: :yard_for_generate_documentation do
       begin
         buffer = Parser::Source::Buffer.new('<code>', 1)
         buffer.source = example.text
-        parser = Parser::Ruby24.new(RuboCop::AST::Builder.new)
+        parser = Parser::Ruby25.new(RuboCop::AST::Builder.new)
         parser.diagnostics.all_errors_are_fatal = true
         parser.parse(buffer)
       rescue Parser::SyntaxError => ex

--- a/lib/rubocop/cop/style/redundant_begin.rb
+++ b/lib/rubocop/cop/style/redundant_begin.rb
@@ -9,6 +9,7 @@ module RuboCop
       #
       # @example
       #
+      #   # bad
       #   def redundant
       #     begin
       #       ala
@@ -18,11 +19,30 @@ module RuboCop
       #     end
       #   end
       #
+      #   # good
       #   def preferred
       #     ala
       #     bala
       #   rescue StandardError => e
       #     something
+      #   end
+      #
+      #   # bad
+      #   # When using Ruby 2.5 or later.
+      #   do_something do
+      #     begin
+      #       something
+      #     rescue => ex
+      #       anything
+      #     end
+      #   end
+      #
+      #   # good
+      #   # In Ruby 2.5 or later, you can omit `begin` in `do-end` block.
+      #   do_something do
+      #     something
+      #   rescue => ex
+      #     anything
       #   end
       class RedundantBegin < Cop
         MSG = 'Redundant `begin` block detected.'.freeze

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -4268,6 +4268,7 @@ Currently it checks for code like this:
 ### Examples
 
 ```ruby
+# bad
 def redundant
   begin
     ala
@@ -4277,11 +4278,30 @@ def redundant
   end
 end
 
+# good
 def preferred
   ala
   bala
 rescue StandardError => e
   something
+end
+
+# bad
+# When using Ruby 2.5 or later.
+do_something do
+  begin
+    something
+  rescue => ex
+    anything
+  end
+end
+
+# good
+# In Ruby 2.5 or later, you can omit `begin` in `do-end` block.
+do_something do
+  something
+rescue => ex
+  anything
 end
 ```
 


### PR DESCRIPTION
It adds an example using `do-end` block in Ruby 2.5, and annotates with bad/good tags like any other cops.

A related commit is 5bbdfdd9dbecbfd627480a75d6a508c330d65b79. (PR is https://github.com/bbatsov/rubocop/pull/5175)

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
