### PR TITLE
[Fix #5498] Correct Heredoc message when using '<<~' with invalid ind…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * [#5626](https://github.com/bbatsov/rubocop/pull/5626): Change `Naming/UncommunicativeMethodParamName` add `to` to allowed names in default config. ([@unused][])
 * [#5640](https://github.com/bbatsov/rubocop/issues/5640): Warn about user configuration overriding other user configuration only with `--debug`. ([@jonas054][])
 * [#5637](https://github.com/bbatsov/rubocop/issues/5637): Fix error for `Layout/SpaceInsideArrayLiteralBrackets` when contains an array literal as an argument after a heredoc is started. ([@koic][])
+* [#5498](https://github.com/bbatsov/rubocop/issues/5498): Correct IndentHeredoc message for Ruby 2.3 when using `<<~` operator with invalid indentation. ([@hamada14][])
 
 ## 0.53.0 (2018-03-05)
 
@@ -3244,3 +3245,4 @@
 [@mmyoji]: https://github.com/mmyoji
 [@unused]: https://github.com/unused
 [@htwroclau]: https://github.com/htwroclau
+[@hamada14]: https://github.com/hamada14

--- a/lib/rubocop/cop/layout/indent_heredoc.rb
+++ b/lib/rubocop/cop/layout/indent_heredoc.rb
@@ -73,9 +73,11 @@ module RuboCop
         include ConfigurableEnforcedStyle
         include SafeMode
 
-        RUBY23_MSG = 'Use %<indentation_width>d spaces for indentation in a ' \
-                     'heredoc by using `<<~` instead of ' \
-                     '`%<current_indent_type>s`.'.freeze
+        RUBY23_TYPE_MSG = 'Use %<indentation_width>d spaces for indentation ' \
+                          'in a heredoc by using `<<~` instead of ' \
+                          '`%<current_indent_type>s`.'.freeze
+        RUBY23_WIDTH_MSG = 'Use %<indentation_width>d spaces for '\
+                           'indentation in a heredoc.'.freeze
         LIBRARY_MSG = 'Use %<indentation_width>d spaces for indentation in a ' \
                       'heredoc by using %<method>s.'.freeze
         STRIP_METHODS = {
@@ -148,10 +150,25 @@ module RuboCop
         end
 
         def ruby23_message(indentation_width, current_indent_type)
+          if current_indent_type == '<<~'
+            ruby23_width_message(indentation_width)
+          else
+            ruby23_type_message(indentation_width, current_indent_type)
+          end
+        end
+
+        def ruby23_type_message(indentation_width, current_indent_type)
           format(
-            RUBY23_MSG,
+            RUBY23_TYPE_MSG,
             indentation_width: indentation_width,
             current_indent_type: current_indent_type
+          )
+        end
+
+        def ruby23_width_message(indentation_width)
+          format(
+            RUBY23_WIDTH_MSG,
+            indentation_width: indentation_width
           )
         end
 


### PR DESCRIPTION
This commit addresses using `<<~` with Heredoc but using an invalid indentation which results in this message, `Use 2 spaces for indentation in a heredoc by using <<~ instead of <<~`.
The message logic was modified where it can address both the operator and the indenation or only the indentation to avoid any confusion.

fixes #5498

As mentioned in #5498 using an invalid indentation with the operator `<<~` results in a weird message which causes confusion.
* Modified the message to mention the operator only when the user is using a wrong operator such as `<<`.
* Modified the existing tests where the message has been modified.
* Added a new test to validate the modification and prevent anyone from breaking it again.

---
- [x]  Wrote good commit messages.
- [x]  Commit message starts with [Fix #issue-number] (if the related issue exists).
- [x]  Feature branch is up-to-date with master (if not - rebase it).
- [x]  Squashed related commits together.
- [x]  Added tests.
- [x]  Added an entry to the Changelog if the new code introduces user-observable changes. See changelog entry format.
- [x]  The PR relates to only one subject with a clear title and description in grammatically correct, complete sentences.
- [x]  Run rake default or rake parallel. It executes all tests and RuboCop for itself, and generates the documentation.