### PR TITLE
Add pry-byebug gem to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,8 @@ gemspec
 
 gem 'bump', require: false
 gem 'pry'
+# pry-byebug requires MRI 2.2.0 or higher.
+gem 'pry-byebug' if RUBY_ENGINE == 'ruby' && RUBY_VERSION >= '2.2.0'
 gem 'rake', '~> 12.0'
 gem 'rspec', '~> 3.7'
 gem 'rubocop-rspec', '~> 1.22.0'


### PR DESCRIPTION
I occasionally want to use pry-byebug when debugging.
This PR adds pry-byebug to Gemfile.
https://github.com/deivid-rodriguez/pry-byebug

pry-byebug (3.6.0) requires MRI 2.2.0 or higher.
https://github.com/deivid-rodriguez/pry-byebug#requirements

So this implementation will switch installation by conditional branch.
We can remove this conditional branch in the future when RuboCop drops
supporting Ruby 2.1.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
