### PR TITLE
Add progress bar to offense formatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 * [#5637](https://github.com/bbatsov/rubocop/issues/5637): Fix error for `Layout/SpaceInsideArrayLiteralBrackets` when contains an array literal as an argument after a heredoc is started. ([@koic][])
 * [#5498](https://github.com/bbatsov/rubocop/issues/5498): Correct IndentHeredoc message for Ruby 2.3 when using `<<~` operator with invalid indentation. ([@hamada14][])
 * [#5610](https://github.com/bbatsov/rubocop/issues/5610): Use `gems.locked` or `Gemfile.lock` to determine the best `TargetRubyVersion` when it is not specified in the config. ([@roberts1000][])
+* Add progress bar to offenses formatter. ([@drewpterry][])
 
 ## 0.53.0 (2018-03-05)
 
@@ -3265,3 +3266,4 @@
 [@anthony-robin]: https://github.com/anthony-robin
 [@YukiJikumaru]: https://github.com/YukiJikumaru
 [@jlfaber]: https://github.com/jlfaber
+[@drewpterry]: https://github.com/drewpterry

--- a/spec/rubocop/formatter/offense_count_formatter_spec.rb
+++ b/spec/rubocop/formatter/offense_count_formatter_spec.rb
@@ -53,6 +53,7 @@ RSpec.describe RuboCop::Formatter::OffenseCountFormatter do
       end
 
       before do
+        allow(output).to receive(:tty?).and_return(false)
         formatter.started(files)
         finish
       end
@@ -68,6 +69,23 @@ RSpec.describe RuboCop::Formatter::OffenseCountFormatter do
           4  Total
 
         OUTPUT
+      end
+    end
+
+    context 'when output tty is true' do
+      let(:offenses) do
+        %w[CopB CopA CopC CopC].map { |c| double('offense', cop_name: c) }
+      end
+
+      before do
+        allow(output).to receive(:tty?).and_return(true)
+        formatter.started(files)
+        finish
+      end
+
+      it 'has a progresbar' do
+        formatter.finished(files)
+        expect(formatter.instance_variable_get(:@progressbar).progress).to eq 1
       end
     end
   end


### PR DESCRIPTION
When you run `bundle exec rubocop --format offenses` there is no output until rubocop has run completely. It is not very user friendly when run over large codebases where you might go a few minutes before rubocop shows any sign that it is indeed properly running.

This PR simply adds a progress bar so the user knows rubocop is running.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
