### PR TITLE
Fix false positive for `Style/EmptyLineAfterGuardClause`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * [#5651](https://github.com/bbatsov/rubocop/pull/5651): Fix NoMethodError when specified config file that does not exist. ([@onk][])
 * [#5647](https://github.com/bbatsov/rubocop/pull/5647): Fix encoding method of RuboCop::MagicComment::SimpleComment. ([@htwroclau][])
 * [#5619](https://github.com/bbatsov/rubocop/issues/5619): Do not register an offense in `Style/InverseMethods` when comparing constants with `<`, `>`, `<=`, or `>=`. If the code is being used to determine class hierarchy, the correction might not be accurate. ([@rrosenblum][])
+* [#5679](https://github.com/bbatsov/rubocop/pull/5679): Fix a false positive for `Style/EmptyLineAfterGuardClause` when guard clause is before `rescue` or `ensure`. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/empty_line_after_guard_clause.rb
+++ b/lib/rubocop/cop/style/empty_line_after_guard_clause.rb
@@ -43,7 +43,7 @@ module RuboCop
         def on_if(node)
           return unless contains_guard_clause?(node)
 
-          return if node.parent.nil? || node.parent.single_line?
+          return if next_line_rescue_or_ensure?(node)
           return if next_sibling_empty_or_guard_clause?(node)
 
           return if next_line_empty?(node)
@@ -66,6 +66,11 @@ module RuboCop
 
         def next_line_empty?(node)
           processed_source[node.last_line].blank?
+        end
+
+        def next_line_rescue_or_ensure?(node)
+          parent = node.parent
+          parent.nil? || parent.rescue_type? || parent.ensure_type?
         end
 
         def next_sibling_empty_or_guard_clause?(node)

--- a/spec/rubocop/cop/style/empty_line_after_guard_clause_spec.rb
+++ b/spec/rubocop/cop/style/empty_line_after_guard_clause_spec.rb
@@ -23,6 +23,20 @@ RSpec.describe RuboCop::Cop::Style::EmptyLineAfterGuardClause do
     RUBY
   end
 
+  it 'registers offence when guard clause is before `begin`' do
+    expect_offense(<<-RUBY.strip_indent)
+      def foo
+        return another_object if something_different?
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Add empty line after guard clause.
+        begin
+          bar
+        rescue SomeException
+          baz
+        end
+      end
+    RUBY
+  end
+
   it 'does not register offence for modifier if' do
     expect_no_offenses(<<-RUBY.strip_indent)
       def foo
@@ -67,6 +81,30 @@ RSpec.describe RuboCop::Cop::Style::EmptyLineAfterGuardClause do
     expect_no_offenses(<<-RUBY.strip_indent)
       def foo
         return another_object if something_different?
+      end
+    RUBY
+  end
+
+  it 'does not register offence when guard clause is before `rescue`' do
+    expect_no_offenses(<<-RUBY.strip_indent)
+      def foo
+        begin
+          return another_object if something_different?
+        rescue SomeException
+          bar
+        end
+      end
+    RUBY
+  end
+
+  it 'does not register offence when guard clause is before `ensure`' do
+    expect_no_offenses(<<-RUBY.strip_indent)
+      def foo
+        begin
+          return another_object if something_different?
+        ensure
+          bar
+        end
       end
     RUBY
   end


### PR DESCRIPTION
This PR fixes a false positive for `Style/EmptyLineAfterGuardClause` when guard clause is before `rescue` or `ensure`.

## Reproduction code

```ruby
def foo
  begin
    return another_object if something_different?
  rescue SomeException
    bar
  end
end
```

and

```ruby
def foo
  begin
    return another_object if something_different?
  ensure
    bar
  end
end
```

## Expected behavior

No offenses.

## Actual behavior and Steps to reproduce the problem

```console
% rubocop /tmp/example.rb --only Style/EmptyLineAfterGuardClause
Inspecting 1 file
C

Offenses:

/tmp/example.rb:3:5: C: Style/EmptyLineAfterGuardClause: Add empty line after guard clause.
    return another_object if something_different?
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

1 file inspected, 1 offense detected
```

## RuboCop version

```console
% rubocop -V
0.53.0 (using Parser 2.5.0.4, running on ruby 2.5.0 x86_64-darwin17)
```

This PR fixes the above false positive.
Also, the condition `node.parent.single_line?` seems to have no effect on behavior, so this PR removes it.

cc @unkmas 

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
