### PR TITLE
[Fix #5436] Allow empty kwrest args in UncommunicativeName cops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master (unreleased)
 
 ### New features
+
 * [#5597](https://github.com/bbatsov/rubocop/pull/5597): Add new `Rails/HttpStatus` cop. ([@anthony-robin][])
 
 ### Bug fixes
@@ -15,6 +16,7 @@
 * [#5651](https://github.com/bbatsov/rubocop/pull/5651): Fix NoMethodError when specified config file that does not exist. ([@onk][])
 * [#5647](https://github.com/bbatsov/rubocop/pull/5647): Fix encoding method of RuboCop::MagicComment::SimpleComment. ([@htwroclau][])
 * [#5619](https://github.com/bbatsov/rubocop/issues/5619): Do not register an offense in `Style/InverseMethods` when comparing constants with `<`, `>`, `<=`, or `>=`. If the code is being used to determine class hierarchy, the correction might not be accurate. ([@rrosenblum][])
+* [#5436](https://github.com/bbatsov/rubocop/issues/5436): Allow empty kwrest args in UncommunicativeName cops. ([@pocke][])
 
 ### Changes
 

--- a/lib/rubocop/cop/mixin/uncommunicative_name.rb
+++ b/lib/rubocop/cop/mixin/uncommunicative_name.rb
@@ -14,7 +14,7 @@ module RuboCop
       def check(node, args)
         args.each do |arg|
           name = arg.children.first.to_s
-          next if arg.restarg_type? && name.empty?
+          next if (arg.restarg_type? || arg.kwrestarg_type?) && name.empty?
           next if allowed_names.include?(name)
           range = arg_range(arg, name.size)
           issue_offenses(node, range, name)

--- a/spec/rubocop/cop/naming/uncommunicative_method_param_name_spec.rb
+++ b/spec/rubocop/cop/naming/uncommunicative_method_param_name_spec.rb
@@ -58,6 +58,14 @@ RSpec.describe RuboCop::Cop::Naming::UncommunicativeMethodParamName, :config do
     RUBY
   end
 
+  it 'does not register offense for empty kwrestarg' do
+    expect_no_offenses(<<-RUBY.strip_indent)
+      def qux(**)
+        stuff!
+      end
+    RUBY
+  end
+
   it 'registers offense when parameter ends in number' do
     expect_offense(<<-RUBY.strip_indent)
       def something(foo1, bar)


### PR DESCRIPTION
Follow up this comment https://github.com/bbatsov/rubocop/issues/5436#issuecomment-372063395

See also  https://github.com/bbatsov/rubocop/pull/5462



-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
