### PR TITLE
[Fix #5683] Fix message for Naming/UncommunicativeXParamName cops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Bug fixes
 
+* [#5683](https://github.com/bbatsov/rubocop/issues/5683): Fix message for Naming/UncommunicativeXParamName cops. ([@jlfaber][])
 * [#5680](https://github.com/bbatsov/rubocop/issues/5680): Fix Layout/ElseAlignment for rescue/else/ensure inside do/end blocks. ([@YukiJikumaru][])
 * [#5642](https://github.com/bbatsov/rubocop/pull/5642): Fix Style/Documentation :nodoc: for compact-style nested modules/classes. ([@ojab][])
 * [#5648](https://github.com/bbatsov/rubocop/issues/5648): Suggest valid memoized instance variable for predicate method. ([@satyap][])
@@ -3255,3 +3256,4 @@
 [@hamada14]: https://github.com/hamada14
 [@anthony-robin]: https://github.com/anthony-robin
 [@YukiJikumaru]: https://github.com/YukiJikumaru
+[@jlfaber]: https://github.com/jlfaber

--- a/lib/rubocop/cop/mixin/uncommunicative_name.rb
+++ b/lib/rubocop/cop/mixin/uncommunicative_name.rb
@@ -6,8 +6,8 @@ module RuboCop
     module UncommunicativeName
       CASE_MSG = 'Only use lowercase characters for %<name_type>s.'.freeze
       NUM_MSG = 'Do not end %<name_type>s with a number.'.freeze
-      LENGTH_MSG = '%<name_type>s must be longer than %<min>s ' \
-                   'characters.'.freeze
+      LENGTH_MSG = '%<name_type>s must be at least %<min>s ' \
+                   'characters long.'.freeze
       FORBIDDEN_MSG = 'Do not use %<name>s as a name for a ' \
                       '%<name_type>s.'.freeze
 

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -1518,7 +1518,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
         expect($stdout.string).to eq(<<-RESULT.strip_indent)
             == example/example1.rb ==
             C:  1: 11: Metrics/ParameterLists: Avoid parameter lists longer than 5 parameters. [6/5]
-            C:  1: 39: Naming/UncommunicativeMethodParamName: Method parameter must be longer than 3 characters.
+            C:  1: 39: Naming/UncommunicativeMethodParamName: Method parameter must be at least 3 characters long.
             C:  1: 46: Style/CommentedKeyword: Do not place comments on the same line as the def keyword.
             E:  1: 81: Metrics/LineLength: Line is too long. [90/80]
 

--- a/spec/rubocop/cop/naming/uncommunicative_block_param_name_spec.rb
+++ b/spec/rubocop/cop/naming/uncommunicative_block_param_name_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe RuboCop::Cop::Naming::UncommunicativeBlockParamName, :config do
   it 'registers offense when param is less than minimum length' do
     expect_offense(<<-RUBY.strip_indent)
       something do |x|
-                    ^ Block parameter must be longer than 2 characters.
+                    ^ Block parameter must be at least 2 characters long.
         do_stuff
       end
     RUBY
@@ -61,7 +61,7 @@ RSpec.describe RuboCop::Cop::Naming::UncommunicativeBlockParamName, :config do
     RUBY
     expect(cop.offenses.size).to eq(3)
     expect(cop.messages).to eq [
-      'Block parameter must be longer than 2 characters.',
+      'Block parameter must be at least 2 characters long.',
       'Do not end block parameter with a number.',
       'Only use lowercase characters for block parameter.'
     ]

--- a/spec/rubocop/cop/naming/uncommunicative_method_param_name_spec.rb
+++ b/spec/rubocop/cop/naming/uncommunicative_method_param_name_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe RuboCop::Cop::Naming::UncommunicativeMethodParamName, :config do
   it 'registers offense when parameter is less than minimum length' do
     expect_offense(<<-RUBY.strip_indent)
       def something(ab)
-                    ^^ Method parameter must be longer than 3 characters.
+                    ^^ Method parameter must be at least 3 characters long.
         do_stuff
       end
     RUBY
@@ -120,7 +120,7 @@ RSpec.describe RuboCop::Cop::Naming::UncommunicativeMethodParamName, :config do
     RUBY
     expect(cop.offenses.size).to eq(3)
     expect(cop.messages).to eq [
-      'Method parameter must be longer than 3 characters.',
+      'Method parameter must be at least 3 characters long.',
       'Do not end method parameter with a number.',
       'Only use lowercase characters for method parameter.'
     ]


### PR DESCRIPTION
Current message says name must be 'longer than N characters.'  Corrected message to say name must be 'at least N characters long.'