### PR TITLE
 [Fix #5680] Support Layout/ElseAlignment in do/end blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Bug fixes
 
+* [#5680](https://github.com/bbatsov/rubocop/issues/5680): Fix Layout/ElseAlignment for rescue/else/ensure inside do/end blocks. ([@YukiJikumaru][])
 * [#5642](https://github.com/bbatsov/rubocop/pull/5642): Fix Style/Documentation :nodoc: for compact-style nested modules/classes. ([@ojab][])
 * [#5648](https://github.com/bbatsov/rubocop/issues/5648): Suggest valid memoized instance variable for predicate method. ([@satyap][])
 * [#5623](https://github.com/bbatsov/rubocop/pull/5623): Fix `Bundler/OrderedGems` when a group includes duplicate gems. ([@colorbox][])
@@ -3253,3 +3254,4 @@
 [@htwroclau]: https://github.com/htwroclau
 [@hamada14]: https://github.com/hamada14
 [@anthony-robin]: https://github.com/anthony-robin
+[@YukiJikumaru]: https://github.com/YukiJikumaru

--- a/spec/rubocop/cop/layout/else_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/else_alignment_spec.rb
@@ -535,4 +535,35 @@ RSpec.describe RuboCop::Cop::Layout::ElseAlignment do
       RUBY
     end
   end
+
+  context '>= Ruby 2.5 ensure/rescue/else in Block Argument', :ruby25 do
+    it 'accepts a correctly aligned else' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        array_like.each do |n|
+          puts 'do something error prone'
+        rescue SomeException
+          puts 'error handling'
+        rescue
+          puts 'error handling'
+        else
+          puts 'normal handling'
+        end
+      RUBY
+    end
+
+    it 'registers an offense for misaligned else' do
+      expect_offense(<<-RUBY.strip_indent)
+        array_like.each do |n|
+          puts 'do something error prone'
+        rescue SomeException
+          puts 'error handling'
+        rescue
+          puts 'error handling'
+          else
+          ^^^^ Align `else` with `array_like.each`.
+          puts 'normal handling'
+        end
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Ruby 2.5 introduces a new feature ["do/end blocks work with ensure/rescue/else"](https://bugs.ruby-lang.org/issues/12906).

However Layout/ElseAlignment cop did not support this syntax, and raise an error ["undefined method `line' for nil:NilClass"](https://github.com/bbatsov/rubocop/issues/5680).

This PR fixes the error and enable Layout/ElseAlignment cop to lint inside do/end blocks.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
