### PR TITLE
[#5641] Disable `Style/TrivialAccessors` auto-correction for `def` with `private`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * [#5651](https://github.com/bbatsov/rubocop/pull/5651): Fix NoMethodError when specified config file that does not exist. ([@onk][])
 * [#5647](https://github.com/bbatsov/rubocop/pull/5647): Fix encoding method of RuboCop::MagicComment::SimpleComment. ([@htwroclau][])
 * [#5619](https://github.com/bbatsov/rubocop/issues/5619): Do not register an offense in `Style/InverseMethods` when comparing constants with `<`, `>`, `<=`, or `>=`. If the code is being used to determine class hierarchy, the correction might not be accurate. ([@rrosenblum][])
+* [#5641](https://github.com/bbatsov/rubocop/issues/5641): Disable `Style/TrivialAccessors` auto-correction for `def` with `private`. ([@pocke][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/trivial_accessors.rb
+++ b/lib/rubocop/cop/style/trivial_accessors.rb
@@ -39,6 +39,9 @@ module RuboCop
         alias on_defs on_def
 
         def autocorrect(node)
+          parent = node.parent
+          return if parent && parent.send_type?
+
           if node.def_type?
             autocorrect_instance(node)
           elsif node.defs_type? && node.children.first.self_type?

--- a/spec/rubocop/cop/style/trivial_accessors_spec.rb
+++ b/spec/rubocop/cop/style/trivial_accessors_spec.rb
@@ -101,11 +101,20 @@ RSpec.describe RuboCop::Cop::Style::TrivialAccessors, :config do
     RUBY
   end
 
-  it 'register an offense on DSL-style trivial writer' do
+  it 'registers an offense on DSL-style trivial writer' do
     expect_offense(<<-RUBY.strip_indent)
       def foo(val)
       ^^^ Use `attr_writer` to define trivial writer methods.
-       @foo = val
+        @foo = val
+      end
+    RUBY
+  end
+
+  it 'registers an offense on reader with `private`' do
+    expect_offense(<<-RUBY.strip_indent)
+      private def foo
+              ^^^ Use `attr_reader` to define trivial reader methods.
+        @foo
       end
     RUBY
   end
@@ -379,6 +388,19 @@ RSpec.describe RuboCop::Cop::Style::TrivialAccessors, :config do
 
       it 'autocorrects' do
         expect(autocorrect_source(source)).to eq(corrected_source)
+      end
+    end
+
+    context 'with `private`' do
+      let(:source) { <<-RUBY.strip_indent }
+        private def foo
+          @foo
+        end
+      RUBY
+
+      it 'does not autocorrect' do
+        expect(autocorrect_source(source)).to eq(source)
+        expect(cop.offenses.map(&:corrected?)).to eq [false]
       end
     end
 


### PR DESCRIPTION

See https://github.com/bbatsov/rubocop/issues/5641

This cop should not auto-correct `private def foo() @foo end`. Because `def foo() @foo end` returns `:foo`, but `attr_reader :foo` returns `nil`.

The `autocorrect` method checks only the parent is a `send` type. It does not check method name. Because the cop also should handle methods other than `private`, `public`, `protected`. For example, [finalist](https://github.com/joker1007/finalist) gem defines `final` method (`final def foo; end`).

Note
===

This pull-request does not close the related issue since the issue still has an problem if the auto-correction is fixed.
I think we should discuss the cop should have or not an option to ignore `private def foo() @foo end` on the issue.


-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
