### PR TITLE
Fix auto-correction of chained methods in SafeNavigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * [#5651](https://github.com/bbatsov/rubocop/pull/5651): Fix NoMethodError when specified config file that does not exist. ([@onk][])
 * [#5647](https://github.com/bbatsov/rubocop/pull/5647): Fix encoding method of RuboCop::MagicComment::SimpleComment. ([@htwroclau][])
 * [#5619](https://github.com/bbatsov/rubocop/issues/5619): Do not register an offense in `Style/InverseMethods` when comparing constants with `<`, `>`, `<=`, or `>=`. If the code is being used to determine class hierarchy, the correction might not be accurate. ([@rrosenblum][])
+* Fix bug where `Style/SafeNavigation` does not auto-correct all chained methods resulting in a `Lint/SafeNavigationChain` offense. ([@rrosenblum][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/safe_navigation.rb
+++ b/lib/rubocop/cop/style/safe_navigation.rb
@@ -228,9 +228,10 @@ module RuboCop
           start_method.each_ancestor do |ancestor|
             break unless %i[send block].include?(ancestor.type)
             next unless ancestor.send_type?
-            break if ancestor == method_chain
 
             corrector.insert_before(ancestor.loc.dot, '&')
+
+            break if ancestor == method_chain
           end
         end
       end

--- a/spec/rubocop/cop/style/safe_navigation_spec.rb
+++ b/spec/rubocop/cop/style/safe_navigation_spec.rb
@@ -1069,7 +1069,41 @@ RSpec.describe RuboCop::Cop::Style::SafeNavigation, :config do
           end
 
           context 'method chaining' do
-            it 'corrects an object check followed by a chained method call' do
+            it 'corrects an object check followed by ' \
+              'a chained method call' do
+              new_source = autocorrect_source(<<-RUBY.strip_indent)
+                #{variable} && #{variable}.one.two
+              RUBY
+
+              expect(new_source).to eq(<<-RUBY.strip_indent)
+                #{variable}&.one&.two
+              RUBY
+            end
+
+            it 'corrects an object check followed by ' \
+              'a chained method call with params' do
+              new_source = autocorrect_source(<<-RUBY.strip_indent)
+                #{variable} && #{variable}.one.two(baz)
+              RUBY
+
+              expect(new_source).to eq(<<-RUBY.strip_indent)
+                #{variable}&.one&.two(baz)
+              RUBY
+            end
+
+            it 'corrects an object check followed by ' \
+              'a chained method call with a symbol proc' do
+              new_source = autocorrect_source(<<-RUBY.strip_indent)
+                #{variable} && #{variable}.one.two(&:baz)
+              RUBY
+
+              expect(new_source).to eq(<<-RUBY.strip_indent)
+                #{variable}&.one&.two(&:baz)
+              RUBY
+            end
+
+            it 'corrects an object check followed by ' \
+              'a chained method call with a block' do
               new_source = autocorrect_source(<<-RUBY.strip_indent)
                 #{variable} && #{variable}.one.two(baz) { |e| e.qux }
               RUBY


### PR DESCRIPTION
I hate that there is yet another bug fix for this, but I think this is the last one. It looks like I was missing a few test cases before.