### PR TITLE
[Fix #5694] Match Rails versions with multiple digits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * [#5436](https://github.com/bbatsov/rubocop/issues/5436): Allow empty kwrest args in UncommunicativeName cops. ([@pocke][])
 * [#5674](https://github.com/bbatsov/rubocop/issues/5674): Fix auto-correction of `Layout/EmptyComment` when the empty comment appears on the same line as code. ([@rrosenblum][])
 * [#5679](https://github.com/bbatsov/rubocop/pull/5679): Fix a false positive for `Style/EmptyLineAfterGuardClause` when guard clause is before `rescue` or `ensure`. ([@koic][])
+* [#5694](https://github.com/bbatsov/rubocop/issues/5694): Match Rails versions with multiple digits when reading the TargetRailsVersion from the bundler lock files. ([@roberts1000][])
 
 ### Changes
 

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -626,7 +626,7 @@ module RuboCop
       File.foreach(lock_file_path) do |line|
         # If rails is in Gemfile.lock or gems.lock, there should be a line like:
         #         rails (X.X.X)
-        result = line.match(/^\s+rails\s+\((\d\.\d\.\d)/)
+        result = line.match(/^\s+rails\s+\((\d+\.\d+)/)
         return result.captures.first.to_f if result
       end
     end

--- a/spec/rubocop/config_spec.rb
+++ b/spec/rubocop/config_spec.rb
@@ -678,7 +678,7 @@ RSpec.describe RuboCop::Config do
           let(:base_path) { configuration.base_dir_for_path_parameters }
           let(:lock_file_path) { File.join(base_path, file_name) }
 
-          it 'uses the Rails version when Rails is present in the lock file' do
+          it "uses the single digit Rails version in #{file_name}" do
             content =
               <<-HEREDOC
                 GEM
@@ -710,6 +710,64 @@ RSpec.describe RuboCop::Config do
               HEREDOC
             create_file(lock_file_path, content)
             expect(configuration.target_rails_version).to eq 4.1
+          end
+
+          it "uses the multi digit Rails version in #{file_name}" do
+            content =
+              <<-HEREDOC
+                GEM
+                  remote: https://rubygems.org/
+                  specs:
+                    actionmailer (4.1.0)
+                    actionpack (= 4.1.0)
+                    actionview (= 4.1.0)
+                    mail (~> 2.5.4)
+                  rails (400.33.22)
+                    actionmailer (= 4.1.0)
+                    actionpack (= 4.1.0)
+                    actionview (= 4.1.0)
+                    activemodel (= 4.1.0)
+                    activerecord (= 4.1.0)
+                    activesupport (= 4.1.0)
+                    bundler (>= 1.3.0, < 2.0)
+                    railties (= 4.1.0)
+                    sprockets-rails (~> 2.0)
+
+                PLATFORMS
+                  ruby
+
+                DEPENDENCIES
+                  rails (= 900.88.77)
+
+                BUNDLED WITH
+                  1.16.1
+              HEREDOC
+            create_file(lock_file_path, content)
+            expect(configuration.target_rails_version).to eq 400.33
+          end
+
+          it "does not use the DEPENDENCIES Rails version in #{file_name}" do
+            content =
+              <<-HEREDOC
+                GEM
+                  remote: https://rubygems.org/
+                  specs:
+                    actionmailer (4.1.0)
+                    actionpack (= 4.1.0)
+                    actionview (= 4.1.0)
+                    mail (~> 2.5.4)
+
+                PLATFORMS
+                  ruby
+
+                DEPENDENCIES
+                  rails (= 900.88.77)
+
+                BUNDLED WITH
+                  1.16.1
+              HEREDOC
+            create_file(lock_file_path, content)
+            expect(configuration.target_rails_version).not_to eq 900.88
           end
 
           it "uses the default Rails when Rails is not in #{file_name}" do


### PR DESCRIPTION
Closes  #5694

Adjust the regex so it can match **multi digit** Rails versions when trying to determine the TargetRailsVersion from the Gemfile.lock or gems.locked.  We currently only matches single digit Rails versions.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
