### PR TITLE
[#5390] Allow exceptions to Style/InlineComment for Rubocop comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 * [#5637](https://github.com/bbatsov/rubocop/issues/5637): Fix error for `Layout/SpaceInsideArrayLiteralBrackets` when contains an array literal as an argument after a heredoc is started. ([@koic][])
 * [#5498](https://github.com/bbatsov/rubocop/issues/5498): Correct IndentHeredoc message for Ruby 2.3 when using `<<~` operator with invalid indentation. ([@hamada14][])
 * [#5610](https://github.com/bbatsov/rubocop/issues/5610): Use `gems.locked` or `Gemfile.lock` to determine the best `TargetRubyVersion` when it is not specified in the config. ([@roberts1000][])
+* [#5390](https://github.com/bbatsov/rubocop/issues/5390): Allow exceptions to `Style/InlineComment` for inline comments which enable or disable rubocop cops. ([@jfelchner][])
 
 ## 0.53.0 (2018-03-05)
 

--- a/lib/rubocop/cop/style/inline_comment.rb
+++ b/lib/rubocop/cop/style/inline_comment.rb
@@ -22,7 +22,9 @@ module RuboCop
 
         def investigate(processed_source)
           processed_source.each_comment do |comment|
-            next if comment_line?(processed_source[comment.loc.line - 1])
+            next if comment_line?(processed_source[comment.loc.line - 1]) ||
+                    comment.text.match(/\A# rubocop:(enable|disable)/)
+
             add_offense(comment)
           end
         end

--- a/spec/rubocop/cop/style/inline_comment_spec.rb
+++ b/spec/rubocop/cop/style/inline_comment_spec.rb
@@ -10,6 +10,12 @@ RSpec.describe RuboCop::Cop::Style::InlineComment do
     RUBY
   end
 
+  it 'does not register an offense for special rubocop inline comments' do
+    expect_no_offenses(<<-RUBY.strip_indent)
+      two = 1 + 1 # rubocop:disable Layout/ExtraSpacing
+    RUBY
+  end
+
   it 'does not register an offense for a standalone comment' do
     expect_no_offenses('# A standalone comment')
   end


### PR DESCRIPTION
Previously if InlineComment was enabled, any Rubocop inline comments
which disabled a cop would require also disabling the InlineComment cop.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/