### PR TITLE
[#4136] Change ClosingParenthesisIndentation to be relative to parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New features
 
 * [#5801](https://github.com/bbatsov/rubocop/pull/5801): Add new `Rails/RefuteMethods` cop. ([@koic][])
+* [#4136](https://github.com/bbatsov/rubocop/issues/4136): Allow more robust `Layout/ClosingParenthesisIndentation` detection including method chaining. ([@jfelchner][])
 
 ### Bug fixes
 

--- a/lib/rubocop/cop/layout/closing_parenthesis_indentation.rb
+++ b/lib/rubocop/cop/layout/closing_parenthesis_indentation.rb
@@ -9,23 +9,65 @@ module RuboCop
       #
       # @example
       #
-      #   # good: when x is on its own line, indent this way
-      #   func(
-      #     x,
-      #     y
+      #   # bad
+      #   some_method(
+      #     a,
+      #     b
+      #     )
+      #
+      #   some_method(
+      #     a, b
+      #     )
+      #
+      #   some_method(a, b, c
+      #     )
+      #
+      #   some_method(a,
+      #               b,
+      #               c
+      #     )
+      #
+      #   some_method(a,
+      #     x: 1,
+      #     y: 2
+      #     )
+      #
+      #   # Scenario 1: When First Parameter Is On Its Own Line
+      #
+      #   # good: when first param is on a new line, right paren is *always*
+      #   #       outdented by IndentationWidth
+      #   some_method(
+      #     a,
+      #     b
       #   )
       #
-      #   # good: when x follows opening parenthesis, align parentheses
-      #   a = b * (x +
-      #            y
-      #           )
+      #   # good
+      #   some_method(
+      #     a, b
+      #   )
       #
-      #   # bad
-      #   def func(
-      #     x,
-      #     y
-      #     )
-      #   end
+      #   # Scenario 2: When First Parameter Is On The Same Line
+      #
+      #   # good: when all other params are also on the same line, outdent
+      #   #       right paren by IndentationWidth
+      #   some_method(a, b, c
+      #              )
+      #
+      #   # good: when all other params are on multiple lines, but are lined
+      #   #       up, align right paren with left paren
+      #   some_method(a,
+      #               b,
+      #               c
+      #              )
+      #
+      #   # good: when other params are not lined up on multiple lines, outdent
+      #   #       right paren by IndentationWidth
+      #   some_method(a,
+      #     x: 1,
+      #     y: 2
+      #   )
+      #
+      #
       class ClosingParenthesisIndentation < Cop
         include Alignment
 
@@ -53,35 +95,51 @@ module RuboCop
         private
 
         def check(node, elements)
+          left_paren  = node.loc.begin
           right_paren = node.loc.end
 
           return unless right_paren && begins_its_line?(right_paren)
 
-          correct_column = expected_column(node, elements)
+          correct_column = expected_column(left_paren, elements)
+
           @column_delta = correct_column - right_paren.column
 
           return if @column_delta.zero?
 
-          left_paren = node.loc.begin
           msg = correct_column == left_paren.column ? MSG_ALIGN : MSG_INDENT
 
           add_offense(right_paren, location: right_paren, message: msg)
         end
 
-        def expected_column(node, elements)
-          left_paren = node.loc.begin
-
-          if node.send_type? && fixed_parameter_indentation? ||
-             line_break_after_left_paren?(left_paren, elements)
-            left_paren.source_line =~ /\S/
-          else
+        def expected_column(left_paren, elements)
+          if !line_break_after_left_paren?(left_paren, elements) &&
+             all_elements_aligned?(elements)
             left_paren.column
+          else
+            source_indent = processed_source
+                            .line_indentation(last_argument_line(elements))
+            new_indent    = source_indent - indentation_width
+
+            new_indent < 0 ? 0 : new_indent
           end
         end
 
-        def fixed_parameter_indentation?
-          config.for_cop('Layout/AlignParameters')['EnforcedStyle'] ==
-            'with_fixed_indentation'
+        def all_elements_aligned?(elements)
+          elements
+            .map { |e| e.loc.column }
+            .uniq
+            .count == 1
+        end
+
+        def last_argument_line(elements)
+          elements
+            .last
+            .loc
+            .first_line
+        end
+
+        def indentation_width
+          @config.for_cop('IndentationWidth')['Width'] || 2
         end
 
         def line_break_after_left_paren?(left_paren, elements)

--- a/lib/rubocop/cop/layout/closing_parenthesis_indentation.rb
+++ b/lib/rubocop/cop/layout/closing_parenthesis_indentation.rb
@@ -71,8 +71,8 @@ module RuboCop
       class ClosingParenthesisIndentation < Cop
         include Alignment
 
-        MSG_INDENT =
-          'Indent `)` the same as the start of the line where `(` is.'.freeze
+        MSG_INDENT = 'Indent `)` to column %<expected>d (not %<actual>d)'
+                     .freeze
         MSG_ALIGN = 'Align `)` with `(`.'.freeze
 
         def on_send(node)
@@ -106,9 +106,11 @@ module RuboCop
 
           return if @column_delta.zero?
 
-          msg = correct_column == left_paren.column ? MSG_ALIGN : MSG_INDENT
-
-          add_offense(right_paren, location: right_paren, message: msg)
+          add_offense(right_paren,
+                      location: right_paren,
+                      message:  message(correct_column,
+                                        left_paren,
+                                        right_paren))
         end
 
         def expected_column(left_paren, elements)
@@ -136,6 +138,18 @@ module RuboCop
             .last
             .loc
             .first_line
+        end
+
+        def message(correct_column, left_paren, right_paren)
+          if correct_column == left_paren.column
+            MSG_ALIGN
+          else
+            format(
+              MSG_INDENT,
+              expected: correct_column,
+              actual: right_paren.column
+            )
+          end
         end
 
         def indentation_width

--- a/lib/rubocop/processed_source.rb
+++ b/lib/rubocop/processed_source.rb
@@ -127,6 +127,13 @@ module RuboCop
       lines[token.line]
     end
 
+    def line_indentation(line_number)
+      lines[line_number - 1]
+        .match(/^(\s*)/)[1]
+        .to_s
+        .length
+    end
+
     private
 
     def comment_lines

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -666,23 +666,63 @@ closing parenthesis means `)` preceded by a line break.
 ### Examples
 
 ```ruby
-# good: when x is on its own line, indent this way
-func(
-  x,
-  y
+# bad
+some_method(
+  a,
+  b
+  )
+
+some_method(
+  a, b
+  )
+
+some_method(a, b, c
+  )
+
+some_method(a,
+            b,
+            c
+  )
+
+some_method(a,
+  x: 1,
+  y: 2
+  )
+
+# Scenario 1: When First Parameter Is On Its Own Line
+
+# good: when first param is on a new line, right paren is *always*
+#       outdented by IndentationWidth
+some_method(
+  a,
+  b
 )
 
-# good: when x follows opening parenthesis, align parentheses
-a = b * (x +
-         y
-        )
+# good
+some_method(
+  a, b
+)
 
-# bad
-def func(
-  x,
-  y
-  )
-end
+# Scenario 2: When First Parameter Is On The Same Line
+
+# good: when all other params are also on the same line, outdent
+#       right paren by IndentationWidth
+some_method(a, b, c
+           )
+
+# good: when all other params are on multiple lines, but are lined
+#       up, align right paren with left paren
+some_method(a,
+            b,
+            c
+           )
+
+# good: when other params are not lined up on multiple lines, outdent
+#       right paren by IndentationWidth
+some_method(a,
+  x: 1,
+  y: 2
+)
 ```
 
 ## Layout/CommentIndentation

--- a/spec/rubocop/cop/layout/closing_parenthesis_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/closing_parenthesis_indentation_spec.rb
@@ -1,14 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Layout::ClosingParenthesisIndentation do
-  subject(:cop) { described_class.new(config) }
-
-  let(:config) do
-    RuboCop::Config.new('Layout/AlignParameters' => {
-                          'EnforcedStyle' => align_parameters_config
-                        })
-  end
-  let(:align_parameters_config) { 'with_first_parameter' }
+  subject(:cop) { described_class.new }
 
   context 'for method calls' do
     context 'with line break before 1st parameter' do
@@ -74,9 +67,6 @@ RSpec.describe RuboCop::Cop::Layout::ClosingParenthesisIndentation do
         expect_no_offenses('some_method()')
       end
 
-      context 'with fixed indentation of parameters' do
-        let(:align_parameters_config) { 'with_fixed_indentation' }
-
         it 'accepts a correctly indented )' do
           expect_no_offenses(<<-RUBY.strip_indent)
             some_method(a,
@@ -85,7 +75,7 @@ RSpec.describe RuboCop::Cop::Layout::ClosingParenthesisIndentation do
             )
             b =
               some_method(a,
-              )
+                         )
           RUBY
         end
 
@@ -94,10 +84,10 @@ RSpec.describe RuboCop::Cop::Layout::ClosingParenthesisIndentation do
             some_method(a,
               x: 1,
               y: 2
-                       )
+                        )
             b =
               some_method(a,
-                         )
+                          )
           RUBY
           expect(corrected).to eq <<-RUBY.strip_indent
             some_method(a,
@@ -106,10 +96,210 @@ RSpec.describe RuboCop::Cop::Layout::ClosingParenthesisIndentation do
             )
             b =
               some_method(a,
-              )
+                         )
           RUBY
         end
+    end
+  end
+
+  context 'for method assignments with indented parameters' do
+    context 'with line break before 1st parameter' do
+      it 'registers an offense for misaligned )' do
+        expect_offense(<<-RUBY.strip_indent)
+          foo = some_method(
+                             a
+            )
+            ^ Align `)` with `(`.
+        RUBY
       end
+
+      it 'autocorrects misaligned )' do
+        corrected = autocorrect_source(<<-RUBY.strip_indent)
+          foo = some_method(
+                             a
+            )
+        RUBY
+        expect(corrected).to eq <<-RUBY.strip_indent
+          foo = some_method(
+                             a
+                           )
+        RUBY
+      end
+
+      it 'accepts a correctly aligned )' do
+        expect_no_offenses(<<-RUBY.strip_indent)
+          foo = some_method(
+                             a
+                           )
+        RUBY
+      end
+    end
+
+    context 'with no line break before 1st parameter' do
+      it 'registers an offense for misaligned )' do
+        expect_offense(<<-RUBY.strip_indent)
+          foo = some_method(a
+          )
+          ^ Align `)` with `(`.
+        RUBY
+      end
+
+      it 'can handle inner method calls' do
+        expect_no_offenses(<<-RUBY.strip_indent)
+          expect(response).to contain_exactly(
+                                { a: 1, b: 'x' },
+                                { a: 2, b: 'y' }
+                              )
+        RUBY
+      end
+
+      it 'can handle individual arguments that are broken over lines' do
+        expect_no_offenses(<<-RUBY.strip_indent)
+          corrector.insert_before(
+            range,
+            "\n" + ' ' * (node.loc.keyword.column +
+                          indent_steps * configured_width)
+          )
+        RUBY
+      end
+
+      it 'can handle indentation up against the left edge' do
+        expect_no_offenses(<<-RUBY.strip_indent)
+          foo(
+          a: b
+          )
+        RUBY
+      end
+
+      it 'can handle hash arguments that are not broken over lines' do
+        expect_no_offenses(<<-RUBY.strip_indent)
+          corrector.insert_before(
+                                   range,
+                                   arg_1: 'foo', arg_2: 'bar'
+                                 )
+        RUBY
+      end
+
+      it 'autocorrects misaligned )' do
+        corrected = autocorrect_source(<<-RUBY.strip_indent)
+          foo = some_method(a
+          )
+        RUBY
+        expect(corrected).to eq <<-RUBY.strip_indent
+          foo = some_method(a
+                           )
+        RUBY
+      end
+
+      it 'accepts a correctly aligned )' do
+        expect_no_offenses(<<-RUBY.strip_indent)
+          foo = some_method(a
+                           )
+        RUBY
+      end
+
+      it 'accepts empty ()' do
+        expect_no_offenses('foo = some_method()')
+      end
+
+      it 'accepts a correctly indented )' do
+        expect_no_offenses(<<-RUBY.strip_indent)
+          foo = some_method(a,
+                            x: 1,
+                            y: 2
+                           )
+          b =
+            some_method(a,
+                       )
+        RUBY
+      end
+
+      it 'autocorrects misindented )' do
+        corrected = autocorrect_source(<<-RUBY.strip_indent)
+          some_method(a,
+                      x: 1,
+                      y: 2
+                      )
+          b =
+            some_method(a,
+                        )
+        RUBY
+        expect(corrected).to eq <<-RUBY.strip_indent
+          some_method(a,
+                      x: 1,
+                      y: 2
+                     )
+          b =
+            some_method(a,
+                       )
+        RUBY
+      end
+    end
+  end
+
+  context 'for method chains' do
+    it 'can handle multiple chains with differing breaks' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        good = foo.methA(:arg1, :arg2, options: :hash)
+                 .methB(
+                   :arg1,
+                   :arg2,
+                 )
+                 .methC
+
+        good = foo.methA(
+                   :arg1,
+                   :arg2,
+                   options: :hash,
+                 )
+                 .methB(
+                   :arg1,
+                   :arg2,
+                 )
+                 .methC
+      RUBY
+    end
+
+    it 'can autocorrect method chains' do
+      corrected = autocorrect_source(<<-RUBY.strip_indent)
+        good = foo.methA(:arg1, :arg2, options: :hash)
+                 .methB(
+                   :arg1,
+                   :arg2,
+             )
+                 .methC
+
+        good = foo.methA(
+                   :arg1,
+                   :arg2,
+                   options: :hash,
+            )
+                 .methB(
+                   :arg1,
+                   :arg2,
+               )
+                 .methC
+      RUBY
+
+      expect(corrected).to eq <<-RUBY.strip_indent
+        good = foo.methA(:arg1, :arg2, options: :hash)
+                 .methB(
+                   :arg1,
+                   :arg2,
+                 )
+                 .methC
+
+        good = foo.methA(
+                   :arg1,
+                   :arg2,
+                   options: :hash,
+                 )
+                 .methB(
+                   :arg1,
+                   :arg2,
+                 )
+                 .methC
+      RUBY
     end
   end
 

--- a/spec/rubocop/cop/layout/closing_parenthesis_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/closing_parenthesis_indentation_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe RuboCop::Cop::Layout::ClosingParenthesisIndentation do
           some_method(
             a
             )
-            ^ Indent `)` the same as the start of the line where `(` is.
+            ^ Indent `)` to column 0 (not 2)
         RUBY
       end
 
@@ -310,7 +310,7 @@ RSpec.describe RuboCop::Cop::Layout::ClosingParenthesisIndentation do
           def some_method(
             a
             )
-            ^ Indent `)` the same as the start of the line where `(` is.
+            ^ Indent `)` to column 0 (not 2)
           end
         RUBY
       end
@@ -387,7 +387,7 @@ RSpec.describe RuboCop::Cop::Layout::ClosingParenthesisIndentation do
           w = x * (
             y + z
             )
-            ^ Indent `)` the same as the start of the line where `(` is.
+            ^ Indent `)` to column 0 (not 2)
         RUBY
       end
 

--- a/spec/rubocop/cop/layout/closing_parenthesis_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/closing_parenthesis_indentation_spec.rb
@@ -67,38 +67,38 @@ RSpec.describe RuboCop::Cop::Layout::ClosingParenthesisIndentation do
         expect_no_offenses('some_method()')
       end
 
-        it 'accepts a correctly indented )' do
-          expect_no_offenses(<<-RUBY.strip_indent)
+      it 'accepts a correctly indented )' do
+        expect_no_offenses(<<-RUBY.strip_indent)
+          some_method(a,
+            x: 1,
+            y: 2
+          )
+          b =
             some_method(a,
-              x: 1,
-              y: 2
-            )
-            b =
-              some_method(a,
-                         )
-          RUBY
-        end
+                       )
+        RUBY
+      end
 
-        it 'autocorrects misindented )' do
-          corrected = autocorrect_source(<<-RUBY.strip_indent)
+      it 'autocorrects misindented )' do
+        corrected = autocorrect_source(<<-RUBY.strip_indent)
+          some_method(a,
+            x: 1,
+            y: 2
+                      )
+          b =
             some_method(a,
-              x: 1,
-              y: 2
                         )
-            b =
-              some_method(a,
-                          )
-          RUBY
-          expect(corrected).to eq <<-RUBY.strip_indent
+        RUBY
+        expect(corrected).to eq <<-RUBY.strip_indent
+          some_method(a,
+            x: 1,
+            y: 2
+          )
+          b =
             some_method(a,
-              x: 1,
-              y: 2
-            )
-            b =
-              some_method(a,
-                         )
-          RUBY
-        end
+                       )
+        RUBY
+      end
     end
   end
 

--- a/spec/rubocop/path_util_spec.rb
+++ b/spec/rubocop/path_util_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe RuboCop::PathUtil do
       expect(described_class.match_path?(
                "#{Dir.pwd}/dir/file",
                "#{Dir.pwd}/dir/dir/file"
-      )).to be(false)
+             )).to be(false)
     end
 
     it 'matches glob expressions' do


### PR DESCRIPTION
I think the best approach for this cop is to remove most of the logic and
let it depend on where the parameters are aligned at.  I think there should
be only two rules:

If the method is called (or defined) and the arguments/parameters...

* span more than one line, the closing parenthesis should be
outdented by one `IndentationWidth` from the last argument/parameter
* are all on one line, the closing parenthesis should be aligned
with the opening parenthesis

This lets the other cops like `Layout/FirstParameterIndentation`,
`Layout/FirstMethodParameterLineBreak`,
`Layout/FirstMethodArgumentLineBreak`,
`Layout/MultilineMethodDefinitionBraceLayout`,
`Layout/MultilineMethodCallBraceLayout` and `Layout/AlignParameters` be
responsible for their jobs and `Layout/ClosingParenthesisIndentation` would
simply be the result of the end of that flow.

By simplifying the cop, it allows for all of the cases described in #5650,
all of my use cases here, and will keep almost every current
`ClosingParenthesisIndentation` spec passing.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/