### PR TITLE
Fix false positive for `Style/EmptyLineAfterGuardClause`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * [#5674](https://github.com/bbatsov/rubocop/issues/5674): Fix auto-correction of `Layout/EmptyComment` when the empty comment appears on the same line as code. ([@rrosenblum][])
 * [#5679](https://github.com/bbatsov/rubocop/pull/5679): Fix a false positive for `Style/EmptyLineAfterGuardClause` when guard clause is before `rescue` or `ensure`. ([@koic][])
 * [#5694](https://github.com/bbatsov/rubocop/issues/5694): Match Rails versions with multiple digits when reading the TargetRailsVersion from the bundler lock files. ([@roberts1000][])
+* [#5700](https://github.com/bbatsov/rubocop/pull/5700): Fix a false positive for `Style/EmptyLineAfterGuardClause` when guard clause is before `else`. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/empty_line_after_guard_clause.rb
+++ b/lib/rubocop/cop/style/empty_line_after_guard_clause.rb
@@ -44,6 +44,7 @@ module RuboCop
           return unless contains_guard_clause?(node)
 
           return if next_line_rescue_or_ensure?(node)
+          return if next_sibling_parent_empty_or_else?(node)
           return if next_sibling_empty_or_guard_clause?(node)
 
           return if next_line_empty?(node)
@@ -71,6 +72,15 @@ module RuboCop
         def next_line_rescue_or_ensure?(node)
           parent = node.parent
           parent.nil? || parent.rescue_type? || parent.ensure_type?
+        end
+
+        def next_sibling_parent_empty_or_else?(node)
+          next_sibling = node.parent.children[node.sibling_index + 1]
+          return true if next_sibling.nil?
+
+          parent = next_sibling.parent
+
+          parent && parent.if_type? && parent.else?
         end
 
         def next_sibling_empty_or_guard_clause?(node)

--- a/spec/rubocop/cop/style/empty_line_after_guard_clause_spec.rb
+++ b/spec/rubocop/cop/style/empty_line_after_guard_clause_spec.rb
@@ -109,6 +109,44 @@ RSpec.describe RuboCop::Cop::Style::EmptyLineAfterGuardClause do
     RUBY
   end
 
+  it 'does not register offence when guard clause is before `rescue`-`else`' do
+    expect_no_offenses(<<-RUBY.strip_indent)
+      def foo
+        begin
+          bar
+        rescue SomeException
+          return another_object if something_different?
+        else
+          bar
+        end
+      end
+    RUBY
+  end
+
+  it 'does not register offence when guard clause is before `else`' do
+    expect_no_offenses(<<-RUBY.strip_indent)
+      def foo
+        if cond
+          return another_object if something_different?
+        else
+          bar
+        end
+      end
+    RUBY
+  end
+
+  it 'does not register offence when guard clause is before `elsif`' do
+    expect_no_offenses(<<-RUBY.strip_indent)
+      def foo
+        if cond
+          return another_object if something_different?
+        elsif
+          bar
+        end
+      end
+    RUBY
+  end
+
   it 'registers an offence for methods starting with end_' do
     expect_offense(<<-RUBY.strip_indent)
       def foo


### PR DESCRIPTION
Related #5679.

This PR fixes a false positive for Style/EmptyLineAfterGuardClause when guard clause is before `else`.

## Reproduction code

```ruby
def foo
  if cond
    return another_object if something_different?
  else
    bar
  end
end
```

## Expected behavior

No offenses.

## Actual behavior and Steps to reproduce the problem

```console
% rubocop /tmp/example.rb --only Style/EmptyLineAfterGuardClause
Inspecting 1 file
C

Offenses:

/tmp/example.rb:3:5: C: Style/EmptyLineAfterGuardClause: Add empty line
after guard clause.
    return another_object if something_different?
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

1 file inspected, 1 offense detected
```

## RuboCop version

```console
% rubocop -V
0.53.0 (using Parser 2.5.0.4, running on ruby 2.5.0 x86_64-darwin17)
```

This PR fixes the above false positive.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
