### PR TITLE
Prevent false positive in Naming/ConstantName when using conditional assignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * [#5674](https://github.com/bbatsov/rubocop/issues/5674): Fix auto-correction of `Layout/EmptyComment` when the empty comment appears on the same line as code. ([@rrosenblum][])
 * [#5679](https://github.com/bbatsov/rubocop/pull/5679): Fix a false positive for `Style/EmptyLineAfterGuardClause` when guard clause is before `rescue` or `ensure`. ([@koic][])
 * [#5694](https://github.com/bbatsov/rubocop/issues/5694): Match Rails versions with multiple digits when reading the TargetRailsVersion from the bundler lock files. ([@roberts1000][])
+* Fix false positive in `Naming/ConstantName` when using conditional assignment. ([@drenmi][])
 
 ### Changes
 

--- a/spec/rubocop/cop/naming/constant_name_spec.rb
+++ b/spec/rubocop/cop/naming/constant_name_spec.rb
@@ -63,12 +63,24 @@ RSpec.describe RuboCop::Cop::Naming::ConstantName do
     expect_no_offenses('AnythingGoes = test')
   end
 
+  it 'does not check names if rhs is a method call with conditional assign' do
+    expect_no_offenses('AnythingGoes ||= test')
+  end
+
   it 'does not check names if rhs is a `Class.new`' do
     expect_no_offenses('Invalid = Class.new(StandardError)')
   end
 
+  it 'does not check names if rhs is a `Class.new` with conditional assign' do
+    expect_no_offenses('Invalid ||= Class.new(StandardError)')
+  end
+
   it 'does not check names if rhs is a `Struct.new`' do
     expect_no_offenses('Investigation = Struct.new(:offenses, :errors)')
+  end
+
+  it 'does not check names if rhs is a `Struct.new` with conditional assign' do
+    expect_no_offenses('Investigation ||= Struct.new(:offenses, :errors)')
   end
 
   it 'does not check names if rhs is a method call with block' do


### PR DESCRIPTION
This cop would register an offense on:

```ruby
CustomError ||= Class.new(StandardError)
```

This change fixes that.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [X] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
