### PR TITLE
Remove unnecessary condition in rubocop.gemspec

### DIFF
--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -26,15 +26,13 @@ Gem::Specification.new do |s|
   s.licenses = ['MIT']
   s.summary = 'Automatic Ruby code style checking tool.'
 
-  if s.respond_to?(:metadata=)
-    s.metadata = {
-      'homepage_uri' => 'https://rubocop.readthedocs.io/',
-      'changelog_uri' => 'https://github.com/bbatsov/rubocop/blob/master/CHANGELOG.md',
-      'source_code_uri' => 'https://github.com/bbatsov/rubocop/',
-      'documentation_uri' => 'https://rubocop.readthedocs.io/',
-      'bug_tracker_uri' => 'https://github.com/bbatsov/rubocop/issues'
-    }
-  end
+  s.metadata = {
+    'homepage_uri' => 'https://rubocop.readthedocs.io/',
+    'changelog_uri' => 'https://github.com/bbatsov/rubocop/blob/master/CHANGELOG.md',
+    'source_code_uri' => 'https://github.com/bbatsov/rubocop/',
+    'documentation_uri' => 'https://rubocop.readthedocs.io/',
+    'bug_tracker_uri' => 'https://github.com/bbatsov/rubocop/issues'
+  }
 
   s.add_runtime_dependency('parallel', '~> 1.10')
   s.add_runtime_dependency('parser', '>= 2.5')


### PR DESCRIPTION
`Gem::Specification#metadata` method has been added in RubyGems 2.0.0.

- https://github.com/rubygems/rubygems/blob/v2.7.6/History.txt#L1892
- https://github.com/rubygems/rubygems/commit/be483b99d8a53bce3e6faf9e6f3c3a5df452974e

RuboCop supports Ruby 2.1 or higher, we will not have the opportunity to use old RubyGems under 2.0.0.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
