### PR TITLE
[Fix #5561] Lint/ShadowedArgument shorthand assignment false positive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#5561](https://github.com/bbatsov/rubocop/issues/5561): Fix `Lint/ShadowedArgument` false positive with shorthand assignments. ([@akhramov][])
+
 ## 0.54.0 (2018-03-21)
 
 ### New features

--- a/lib/rubocop/cop/lint/shadowed_argument.rb
+++ b/lib/rubocop/cop/lint/shadowed_argument.rb
@@ -95,6 +95,9 @@ module RuboCop
           argument.assignments.reduce(true) do |location_known, assignment|
             assignment_node = assignment.meta_assignment_node || assignment.node
 
+            # Shorthand assignments always use their arguments
+            next false if assignment_node.shorthand_asgn?
+
             node_within_block_or_conditional =
               node_within_block_or_conditional?(assignment_node.parent,
                                                 argument.scope.node)

--- a/spec/rubocop/cop/lint/shadowed_argument_spec.rb
+++ b/spec/rubocop/cop/lint/shadowed_argument_spec.rb
@@ -42,6 +42,17 @@ RSpec.describe RuboCop::Cop::Lint::ShadowedArgument, :config do
         end
       end
 
+      context 'when argument was used in shorthand assignment' do
+        it 'does not register an offense' do
+          expect_no_offenses(<<-RUBY.strip_indent)
+            def do_something(bar)
+              bar = 'baz' if foo
+              bar ||= {}
+            end
+          RUBY
+        end
+      end
+
       context 'when binding is used' do
         it 'registers an offense' do
           expect_offense(<<-RUBY.strip_indent)


### PR DESCRIPTION
`Lint/ShadowedArgument` doesn't handle the case of shorthand
assignments and treats them as not using their arguments.

This change adds an additional check for shorthand assignments.
-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
