### PR TITLE
Fix rack-version related flaky test

### DIFF
--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -42,6 +42,8 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('unicode-display_width', '~> 1.0', '>= 1.0.1')
 
   s.add_development_dependency('bundler', '~> 1.3')
-  s.add_development_dependency('rack')
+  # TODO: loosen rack dependency once Ruby 2.1.0 support is dropped.
+  # See https://git.io/vxWRB
+  s.add_development_dependency('rack', '>= 1.6.9', '< 2.0')
 end
 # rubocop:enable Metrics/BlockLength


### PR DESCRIPTION
Currently 2.1.0 tests fail sporadically on travis due to bundler
unable to install rack dependency. ([an example](https://travis-ci.org/bbatsov/rubocop/jobs/356344273)).
This happens because rack is declared as an open dependency, but rack
2.0+ [does not support Ruby 2.1.0](https://github.com/rack/rack/blob/1a408687493175250408fe87c5046bf1adfa6386/rack.gemspec#L29). However, sometimes tests pass,
because, I believe, some nodes have correct version of rack cached.

This change adds an interval for rack dev dependency, ensuring that
bundler won't try to install an inappropriate version of rack.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
