### PR TITLE
Drop jruby-head (jruby 9.2.0.0-SNAPSHOT) from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ language: ruby
 dist: trusty
 rvm:
   - jruby-9.1.16.0
-  - jruby-head
   - 2.1.10
   - 2.2.9
   - 2.3.6
@@ -21,7 +20,6 @@ env:
 matrix:
   allow_failures:
     - rvm: ruby-head
-    - rvm: jruby-head
   fast_finish: true
 before_install:
   - gem update --system


### PR DESCRIPTION
jruby-head has been failed in Travis CI for a long while.
https://travis-ci.org/bbatsov/rubocop/builds/356172495

When I opened PR #5048 it already failed.

I've been opened an issue to jruby/jruby as to why CI fails.
https://github.com/jruby/jruby/issues/4809

I'd like to add it again to .travis.yml when the above JRuby issue is solved.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
