### PR TITLE
[Fix #5656] Prevent `def_node_search` methods from throwing unexpected errors.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ TAGS
 
 # For rubinius:
 #*.rbc
+
+# For RubyMine:
+.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug fixes
 
+* [#5656](https://github.com/bbatsov/rubocop/issues/5656): Fix `def_node_search` to not throw errors when scanning nodes. ([@thomthom][])
 * [#5561](https://github.com/bbatsov/rubocop/issues/5561): Fix `Lint/ShadowedArgument` false positive with shorthand assignments. ([@akhramov][])
 
 ## 0.54.0 (2018-03-21)
@@ -3279,3 +3280,4 @@
 [@YukiJikumaru]: https://github.com/YukiJikumaru
 [@jlfaber]: https://github.com/jlfaber
 [@drewpterry]: https://github.com/drewpterry
+[@thomthom]: https://github.com/thomthom

--- a/lib/rubocop/node_pattern.rb
+++ b/lib/rubocop/node_pattern.rb
@@ -349,7 +349,12 @@ module RuboCop
       end
 
       def compile_literal(cur_node, literal, seq_head)
-        "(#{cur_node}#{'.type' if seq_head} == #{literal})"
+        if seq_head
+          # During def_node_search `cur_node` might not be of Node type.
+          "(#{cur_node}.respond_to?(:type) && #{cur_node}.type == #{literal})"
+        else
+          "(#{cur_node} == #{literal})"
+        end
       end
 
       def compile_predicate(tokens, cur_node, predicate, seq_head)

--- a/spec/rubocop/node_pattern_spec.rb
+++ b/spec/rubocop/node_pattern_spec.rb
@@ -1095,6 +1095,24 @@ RSpec.describe RuboCop::NodePattern do
     end
   end
 
+  describe 'def_node_search' do
+    context 'searching source code with no matches' do
+      let(:ruby) { "module Example\nmsg = 'Hello'\nmsg += 'Foo Bar'\nend" }
+
+      it 'return empty collection' do
+        class Dummy
+          extend RuboCop::NodePattern::Macros
+          pattern_str = '(:lvasgn ... (:send (:const nil? :Foo) :new _ _))'
+          def_node_search(:example_match, pattern_str)
+        end
+        dummy = Dummy.new
+        nodes = dummy.example_match(node)
+        # Must make sure to iterate the returned Enum.
+        expect(nodes.to_a.empty?).to be_truthy
+      end
+    end
+  end
+
   describe 'bad syntax' do
     context 'with empty parentheses' do
       let(:pattern) { '()' }


### PR DESCRIPTION
This addresses issues described in #5656 where methods generated by `def_node_search` might throw errors.

I would get various `TypeError` or `NoMethodError` when attempting to run `def_node_search` methods. They would manifest differently depending on match pattern and source code inspected. In the clearest repo case I could create I had a search for a pattern that did not exist in the examined source code. I was expecting that to not throw any errors.

After stepping through in the debugger and inspecting the body of the generated methods I narrowed the errors I was seeing to `compile_literal`:

https://github.com/bbatsov/rubocop/blob/1df6f7d29a9f5084a187a1ffa01af77fcd874db0/lib/rubocop/node_pattern.rb#L351-L353

This code generates something like this:

```ruby
(temp4.type == :const)
```

The problem is that when using `def_node_search` the node being inspected (in this case `temp4`) might not be of `Node` type.

This PR is an attempt to address that by adding an extra check before calling `.type` on the node. I'm open to alternative solutions, but this is the best I could work out.

All RuboCop tests continued to pass after this change.

I attempted to add a test for this change, though I could not find any existing pattern to test `def_node_search`.