### PR TITLE
Reduce test-queue workers in Travis CI to optimize build speed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,10 @@ rvm:
 env:
   global:
     - JRUBY_OPTS='--debug -J-Xmx1000M' # get more accurate coverage data in JRuby
+    # Travis CI container has two cores, but Ruby can see 32 cores unfortunately.
+    # See https://github.com/bbatsov/rubocop/pull/5719
+    #     https://docs.travis-ci.com/user/reference/overview/#Virtualisation-Environment-vs-Operating-System
+    - TEST_QUEUE_WORKERS=2
   matrix:
     - 'TASK=spec'
     - 'TASK=ascii_spec'


### PR DESCRIPTION
This change reduces test-queue workers in Traivs CI.
It will reduce CI time as it probably reduces context switching.

Problem
===


Currently test-queue runs with 32 workers.
![180324010751](https://user-images.githubusercontent.com/4361134/37840215-ccd0115c-2eff-11e8-95e3-afc1fccafa0a.png)

However Travis CI actually has only 2 cores unfortunately. https://docs.travis-ci.com/user/reference/overview/#Virtualisation-Environment-vs-Operating-System
So it does not make the builds 32x faster.


Solution
===

Specify `TEST_QUEUE_WORKERS` environment variable.
This change makes the build a little faster.


Benchmark
====

before: https://github.com/pocke/rubocop/pull/9
after: https://github.com/pocke/rubocop/pull/10

This times are picked up from `==> Summary (32 workers in 39.4037s)`.

| version | before   | after    |
|---------|----------|----------|
| 2.1     | 52.3327s | 39.1958s |
| 2.2     | 47.9294s | 37.0284s |
| 2.3     | 42.7906s | 38.6162s |
| 2.4     | 43.3928s | 36.8148s |
| 2.5     | 39.4037s | 35.8205s |

This change makes the builds faster in all Ruby versions.