### PR TITLE
Fix false positive for `Style/EmptyLineAfterGuardClause`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Changes
 
 * [#5734](https://github.com/bbatsov/rubocop/pull/5734): Add `by`, `on`, `in` and `at` to allowed names of `Naming/UncommunicativeMethodParamName` cop in default config. ([@AlexWayfer][])
+* [#5720](https://github.com/bbatsov/rubocop/pull/5720): Fix false positive for `Style/EmptyLineAfterGuardClause` when guard clause is after heredoc. ([@koic][])
 
 ## 0.54.0 (2018-03-21)
 

--- a/lib/rubocop/cop/style/empty_line_after_guard_clause.rb
+++ b/lib/rubocop/cop/style/empty_line_after_guard_clause.rb
@@ -41,13 +41,7 @@ module RuboCop
         MSG = 'Add empty line after guard clause.'.freeze
 
         def on_if(node)
-          return unless contains_guard_clause?(node)
-
-          return if next_line_rescue_or_ensure?(node)
-          return if next_sibling_parent_empty_or_else?(node)
-          return if next_sibling_empty_or_guard_clause?(node)
-
-          return if next_line_empty?(node)
+          return if correct_style?(node)
 
           add_offense(node)
         end
@@ -60,6 +54,15 @@ module RuboCop
         end
 
         private
+
+        def correct_style?(node)
+          !contains_guard_clause?(node) ||
+            next_line_rescue_or_ensure?(node) ||
+            next_sibling_parent_empty_or_else?(node) ||
+            next_sibling_empty_or_guard_clause?(node) ||
+            last_argument_is_heredoc?(node) ||
+            next_line_empty?(node)
+        end
 
         def contains_guard_clause?(node)
           node.if_branch && node.if_branch.guard_clause?
@@ -88,6 +91,11 @@ module RuboCop
           return true if next_sibling.nil?
 
           next_sibling.if_type? && contains_guard_clause?(next_sibling)
+        end
+
+        def last_argument_is_heredoc?(node)
+          node.children.last && node.children.last.send_type? &&
+            node.children.last.last_argument.heredoc?
         end
       end
     end

--- a/spec/rubocop/cop/style/empty_line_after_guard_clause_spec.rb
+++ b/spec/rubocop/cop/style/empty_line_after_guard_clause_spec.rb
@@ -147,6 +147,18 @@ RSpec.describe RuboCop::Cop::Style::EmptyLineAfterGuardClause do
     RUBY
   end
 
+  it 'does not register offence when guard clause is after heredoc' do
+    expect_no_offenses(<<-RUBY.strip_indent)
+      def foo
+        raise ArgumentError, <<-MSG unless path
+          Must be called with mount point
+        MSG
+
+        bar
+      end
+    RUBY
+  end
+
   it 'registers an offence for methods starting with end_' do
     expect_offense(<<-RUBY.strip_indent)
       def foo


### PR DESCRIPTION
Related #5679.

This PR fixes a false positive for Style/EmptyLineAfterGuardClause when guard clause is after heredoc.

## Reproduction code

```ruby
def foo
  raise ArgumentError, <<-MSG unless path
    Must be called with mount point
  MSG

  bar
end
```

:memo: I found this false positivity below.
https://github.com/rails/rails/blob/v5.2.0.rc2/actionpack/lib/action_dispatch/routing/mapper.rb#L614-L622

## Expected behavior

No offenses.

## Actual behavior and Steps to reproduce the problem

```console
% rubocop /tmp/example.rb --only Style/EmptyLineAfterGuardClause
Inspecting 1 file
C

Offenses:

/tmp/example.rb:2:3: C: Style/EmptyLineAfterGuardClause: Add empty line
after guard clause.
  raise ArgumentError, <<-MSG unless path
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

1 file inspected, 1 offense detected
```

## RuboCop version

```console
% rubocop -V
0.54.0 (using Parser 2.5.0.4, running on ruby 2.5.0 x86_64-darwin17)
```

This PR fixes the above false positive.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
