### PR TITLE
simplify dynamic callbacks creation in Cop::Commissioner

### DIFF
--- a/lib/rubocop/cop/commissioner.rb
+++ b/lib/rubocop/cop/commissioner.rb
@@ -11,10 +11,6 @@ module RuboCop
 
       attr_reader :errors
 
-      def self.callback_methods
-        Parser::Meta::NODE_TYPES.map { |type| :"on_#{type}" }
-      end
-
       def initialize(cops, forces = [], options = {})
         @cops = cops
         @forces = forces
@@ -24,30 +20,19 @@ module RuboCop
         reset_errors
       end
 
-      # In the dynamically generated methods below, a call to `super` is used
+      # Create methods like :on_send, :on_super, etc. They will be called
+      # during AST traversal and try to call corresponding methods on cops.
+      # A call to `super` is used
       # to continue iterating over the children of a node.
       # However, if we know that a certain node type (like `int`) never has
       # child nodes, there is no reason to pay the cost of calling `super`.
-      no_child_callbacks = NO_CHILD_NODES.map do |type|
-        :"on_#{type}"
-      end
-
-      callback_methods.each do |callback|
-        next unless method_defined?(callback)
-        class_eval <<-RUBY, __FILE__, __LINE__ + 1
-          def #{callback}(node)
-            @callbacks[:"#{callback}"] ||= @cops.select do |cop|
-              cop.respond_to?(:"#{callback}")
-            end
-            @callbacks[:#{callback}].each do |cop|
-              with_cop_error_handling(cop, node) do
-                cop.send(:#{callback}, node)
-              end
-            end
-
-            #{!no_child_callbacks.include?(callback) && 'super'}
-          end
-        RUBY
+      Parser::Meta::NODE_TYPES.each do |node_type|
+        method_name = :"on_#{node_type}"
+        next unless method_defined?(method_name)
+        define_method(method_name) do |node|
+          trigger_responding_cops(method_name, node)
+          super(node) unless NO_CHILD_NODES.include?(node_type)
+        end
       end
 
       def investigate(processed_source)
@@ -62,6 +47,17 @@ module RuboCop
       end
 
       private
+
+      def trigger_responding_cops(callback, node)
+        @callbacks[callback] ||= @cops.select do |cop|
+          cop.respond_to?(callback)
+        end
+        @callbacks[callback].each do |cop|
+          with_cop_error_handling(cop, node) do
+            cop.send(callback, node)
+          end
+        end
+      end
 
       def reset_errors
         @errors = Hash.new { |hash, k| hash[k] = [] }


### PR DESCRIPTION
Simplify dynamic callbacks creation in `Rubocop::Cop::Commissioner` by using `define_method` over `class_eval` and extracting `trigger_responding_cops` method. I'd say there are three benefits of the suggested approach:
- it's easier to understand what's going on (from my point of view, of course);
- it's more syntax-highlighting friendly;
- it allows us to get rid of `. callback_methods` method and `no_child_callbacks` variable.

Also, added an explanation of purpose of this piece of code — very important thing in places where metaprogramming is used.

No new functionality was added, existing test suite is enough.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
