### PR TITLE
Update parser to at least 2.5.0.5

### DIFF
--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |s|
   }
 
   s.add_runtime_dependency('parallel', '~> 1.10')
-  s.add_runtime_dependency('parser', '>= 2.5')
+  s.add_runtime_dependency('parser', '>= 2.5.0.5')
   s.add_runtime_dependency('powerpack', '~> 0.1')
   s.add_runtime_dependency('rainbow', '>= 2.2.2', '< 4.0')
   s.add_runtime_dependency('ruby-progressbar', '~> 1.7')


### PR DESCRIPTION
`parser 2.5.0.4` was removed, see:
https://github.com/whitequark/parser/issues/470
and:
https://rubygems.org/gems/parser

I am not sure if it is the correct way to jump from `2.5` to `2.5.0.5`. But since `parser 2.5.0.4` has been removed it seems like a plausible solution to me. 

I ommited a `CHANGELOG` entry because this isn't a user facing change. But I can of course add one if necessary. 