### PR TITLE
[#5451]: When using --auto-gen-config, do not ouput offenses unless the --output-offenses flag is also passed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * [#5561](https://github.com/bbatsov/rubocop/issues/5561): Fix `Lint/ShadowedArgument` false positive with shorthand assignments. ([@akhramov][])
 
+### Changes
+
+* [#5451](https://github.com/bbatsov/rubocop/issues/5451): When using --auto-gen-config, do not ouput offenses unless the --output-offenses flag is also passed. ([@drewpterry][])
+
 ## 0.54.0 (2018-03-21)
 
 ### New features

--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -598,6 +598,8 @@ require_relative 'rubocop/formatter/progress_formatter'
 require_relative 'rubocop/formatter/quiet_formatter'
 require_relative 'rubocop/formatter/tap_formatter'
 require_relative 'rubocop/formatter/worst_offenders_formatter'
+# relies on progress formatter
+require_relative 'rubocop/formatter/auto_gen_config_formatter'
 
 require_relative 'rubocop/formatter/formatter_set'
 

--- a/lib/rubocop/cli.rb
+++ b/lib/rubocop/cli.rb
@@ -178,8 +178,12 @@ module RuboCop
       # This must be done after the options have already been processed,
       # because they can affect how ConfigStore behaves
       @options[:formatters] ||= begin
-        cfg = @config_store.for(Dir.pwd).for_all_cops
-        formatter = cfg['DefaultFormatter'] || 'progress'
+        if @options[:auto_gen_config]
+          formatter = 'autogenconf'
+        else
+          cfg = @config_store.for(Dir.pwd).for_all_cops
+          formatter = cfg['DefaultFormatter'] || 'progress'
+        end
         [[formatter, @options[:output_path]]]
       end
 

--- a/lib/rubocop/formatter/auto_gen_config_formatter.rb
+++ b/lib/rubocop/formatter/auto_gen_config_formatter.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Formatter
+    # Does not show individual offenses in the console.
+    class AutoGenConfigFormatter < ProgressFormatter
+      def finished(inspected_files)
+        output.puts
+
+        report_summary(inspected_files.size,
+                       @total_offense_count,
+                       @total_correction_count)
+      end
+    end
+  end
+end

--- a/lib/rubocop/formatter/formatter_set.rb
+++ b/lib/rubocop/formatter/formatter_set.rb
@@ -9,19 +9,20 @@ module RuboCop
     # which invoke same method of each formatters.
     class FormatterSet < Array
       BUILTIN_FORMATTERS_FOR_KEYS = {
-        'progress' => ProgressFormatter,
-        'simple'   => SimpleTextFormatter,
-        'clang'    => ClangStyleFormatter,
-        'fuubar'   => FuubarStyleFormatter,
-        'emacs'    => EmacsStyleFormatter,
-        'json'     => JSONFormatter,
-        'html'     => HTMLFormatter,
-        'files'    => FileListFormatter,
-        'offenses' => OffenseCountFormatter,
-        'disabled' => DisabledLinesFormatter,
-        'worst'    => WorstOffendersFormatter,
-        'tap'      => TapFormatter,
-        'quiet'    => QuietFormatter
+        'progress'     => ProgressFormatter,
+        'simple'       => SimpleTextFormatter,
+        'clang'        => ClangStyleFormatter,
+        'fuubar'       => FuubarStyleFormatter,
+        'emacs'        => EmacsStyleFormatter,
+        'json'         => JSONFormatter,
+        'html'         => HTMLFormatter,
+        'files'        => FileListFormatter,
+        'offenses'     => OffenseCountFormatter,
+        'disabled'     => DisabledLinesFormatter,
+        'worst'        => WorstOffendersFormatter,
+        'tap'          => TapFormatter,
+        'quiet'        => QuietFormatter,
+        'autogenconf'  => AutoGenConfigFormatter
       }.freeze
 
       FORMATTER_APIS = %i[started finished].freeze

--- a/lib/rubocop/options.rb
+++ b/lib/rubocop/options.rb
@@ -353,6 +353,7 @@ module RuboCop
                              '  [w]orst',
                              '  [t]ap',
                              '  [q]uiet',
+                             '  [a]utogenconf',
                              '  custom formatter class name'],
       out:                  ['Write output to a file instead of STDOUT.',
                              'This option applies to the previously',

--- a/manual/formatters.md
+++ b/manual/formatters.md
@@ -64,6 +64,18 @@ lib/foo.rb:6:5: C: Style/Documentation: Missing top-level class documentation co
 26 files inspected, 46 offenses detected
 ```
 
+### Auto Gen Formatter 
+
+Behaves like Progress Formatter except that it will not show any offenses.
+
+```sh
+$ rubocop
+Inspecting 26 files
+..W.C....C..CWCW.C...WC.CC
+
+26 files inspected, 46 offenses detected
+```
+
 ### Clang Style Formatter
 
 The `clang` formatter displays the offenses in a manner similar to `clang`:

--- a/spec/rubocop/cli/cli_auto_gen_config_spec.rb
+++ b/spec/rubocop/cli/cli_auto_gen_config_spec.rb
@@ -725,6 +725,24 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
       end
     end
 
+    describe 'console output' do
+      before do
+        create_file('example1.rb', ['$!'])
+      end
+
+      it 'displays report summary but no offenses' do
+        expect(cli.run(['--auto-gen-config'])).to eq(1)
+
+        expect($stdout.string).to include(<<-OUTPUT.strip_indent)
+          Inspecting 1 file
+          C
+
+          1 file inspected, 1 offense detected
+          Created .rubocop_todo.yml.
+        OUTPUT
+      end
+    end
+
     it 'can be called when there are no files to inspection' do
       expect(cli.run(['--auto-gen-config'])).to eq(0)
     end

--- a/spec/rubocop/formatter/auto_gen_config_formatter_spec.rb
+++ b/spec/rubocop/formatter/auto_gen_config_formatter_spec.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Formatter::AutoGenConfigFormatter do
+  subject(:formatter) { described_class.new(output) }
+
+  let(:output) { StringIO.new }
+
+  let(:files) do
+    %w[lib/rubocop.rb spec/spec_helper.rb bin/rubocop].map do |path|
+      File.expand_path(path)
+    end
+  end
+
+  describe '#report_file_as_mark' do
+    before do
+      formatter.report_file_as_mark(offenses)
+    end
+
+    def offense_with_severity(severity)
+      source_buffer = Parser::Source::Buffer.new('test', 1)
+      source_buffer.source = "a\n"
+      RuboCop::Cop::Offense.new(severity,
+                                Parser::Source::Range.new(source_buffer, 0, 1),
+                                'message',
+                                'CopName')
+    end
+
+    context 'when no offenses are detected' do
+      let(:offenses) { [] }
+
+      it 'prints "."' do
+        expect(output.string).to eq('.')
+      end
+    end
+
+    context 'when a refactor severity offense is detected' do
+      let(:offenses) { [offense_with_severity(:refactor)] }
+
+      it 'prints "R"' do
+        expect(output.string).to eq('R')
+      end
+    end
+
+    context 'when a refactor convention offense is detected' do
+      let(:offenses) { [offense_with_severity(:convention)] }
+
+      it 'prints "C"' do
+        expect(output.string).to eq('C')
+      end
+    end
+
+    context 'when different severity offenses are detected' do
+      let(:offenses) do
+        [
+          offense_with_severity(:refactor),
+          offense_with_severity(:error)
+        ]
+      end
+
+      it 'prints highest level mark' do
+        expect(output.string).to eq('E')
+      end
+    end
+  end
+
+  describe '#finished' do
+    before do
+      formatter.started(files)
+    end
+
+    context 'when any offenses are detected' do
+      before do
+        source_buffer = Parser::Source::Buffer.new('test', 1)
+        source = Array.new(9) do |index|
+          "This is line #{index + 1}."
+        end
+        source_buffer.source = source.join("\n")
+        line_length = source[0].length + 1
+
+        formatter.file_started(files[0], {})
+        formatter.file_finished(
+          files[0],
+          [
+            RuboCop::Cop::Offense.new(
+              :convention,
+              Parser::Source::Range.new(source_buffer,
+                                        line_length + 2,
+                                        line_length + 3),
+              'foo',
+              'Cop'
+            )
+          ]
+        )
+      end
+
+      it 'does not report offenses' do
+        formatter.finished(files)
+        expect(output.string).not_to include('Offenses:')
+      end
+
+      it 'outputs report summary' do
+        formatter.finished(files)
+        expect(output.string).to include <<-OUTPUT.strip_indent
+          3 files inspected, 1 offense detected
+        OUTPUT
+      end
+    end
+
+    context 'when no offenses are detected' do
+      before do
+        files.each do |file|
+          formatter.file_started(file, {})
+          formatter.file_finished(file, [])
+        end
+      end
+
+      it 'does not report offenses' do
+        formatter.finished(files)
+        expect(output.string).not_to include('Offenses:')
+      end
+    end
+
+    it 'calls #report_summary' do
+      formatter.finished(files)
+      expect(output.string).to include <<-OUTPUT.strip_indent
+        3 files inspected, no offenses detected
+      OUTPUT
+    end
+  end
+end

--- a/spec/rubocop/options_spec.rb
+++ b/spec/rubocop/options_spec.rb
@@ -73,6 +73,7 @@ RSpec.describe RuboCop::Options, :isolated_environment do
                                                  [w]orst
                                                  [t]ap
                                                  [q]uiet
+                                                 [a]utogenconf
                                                  custom formatter class name
               -o, --out FILE                   Write output to a file instead of STDOUT.
                                                This option applies to the previously


### PR DESCRIPTION
https://github.com/bbatsov/rubocop/issues/5451

As mentioned in the issue running rubocop with the `--auto-gen-config` option currently displays all offenses in the console, which is not particularly useful for this feature, especially when being run over large code bases.

This makes it so that `--auto-gen-config` will not output offenses to the
console by default.

Additionally, a flag of `--output-offenses` is also added which can be
used in conjuction with the auto-gen-config command to output offenses
to the console if needed.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
