### PR TITLE
[Fix #5652] Make `Style/OptionHash` aware of implicit parameter passing to super

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * [#5734](https://github.com/bbatsov/rubocop/pull/5734): Add `by`, `on`, `in` and `at` to allowed names of `Naming/UncommunicativeMethodParamName` cop in default config. ([@AlexWayfer][])
 * [#4257](https://github.com/bbatsov/rubocop/issues/4257): Allow specifying module name in `Metrics/BlockLength`'s `ExcludedMethods` configuration option. ([@akhramov][])
 * [#4753](https://github.com/bbatsov/rubocop/issues/4753): Add `IgnoredMethods` option to `Style/MethodCallWithoutArgsParentheses` cop. ([@Darhazer][])
+* [#5652](https://github.com/bbatsov/rubocop/issues/5652): Make `Style/OptionHash` aware of implicit parameter passing to super. ([@Wei-LiangChew][])
 
 ## 0.54.0 (2018-03-21)
 
@@ -3302,3 +3303,4 @@
 [@istateside]: https://github.com/istateside
 [@parkerfinch]: https://github.com/parkerfinch
 [@Darhazer]: https://github.com/Darhazer
+[@Wei-LiangChew]: https://github.com/Wei-LiangChew

--- a/lib/rubocop/cop/style/option_hash.rb
+++ b/lib/rubocop/cop/style/option_hash.rb
@@ -27,6 +27,8 @@ module RuboCop
         PATTERN
 
         def on_args(node)
+          return if super_used?(node)
+
           option_hash(node) do |options|
             add_offense(options)
           end
@@ -37,6 +39,10 @@ module RuboCop
         def suspicious_name?(arg_name)
           cop_config.key?('SuspiciousParamNames') &&
             cop_config['SuspiciousParamNames'].include?(arg_name.to_s)
+        end
+
+        def super_used?(node)
+          node.parent.each_node(:zsuper).any?
         end
       end
     end

--- a/spec/rubocop/cop/style/option_hash_spec.rb
+++ b/spec/rubocop/cop/style/option_hash_spec.rb
@@ -69,4 +69,34 @@ RSpec.describe RuboCop::Cop::Style::OptionHash, :config do
       RUBY
     end
   end
+
+  context 'when passing options hash to super' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        def allowed(foo, options = {})
+          super
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when code exists before call to super' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        def allowed(foo, options = {})
+          bar
+
+          super
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when call to super is in a nested block' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        def allowed(foo, options = {})
+          5.times do
+            super
+          end
+        end
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Previously the cop would add an offense if a method is defined with an
options hash parameter, intended to be passed into a call to super.

The fix was to check if super is called in the method body, and not
register an offense if found.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
