### PR TITLE
Revert "[Fix #5426] Make `Rails/InverseOf` accept `inverse_of: nil` to opt-out (#5430)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 * [#5726](https://github.com/bbatsov/rubocop/issues/5726): Fix false positive for `:class_name` option in Rails/InverseOf cop. ([@bdewater][])
+* [#5730](https://github.com/bbatsov/rubocop/pull/5730): Stop `Rails/InverseOf` cop allowing `inverse_of: nil` to opt-out. ([@bdewater][])
 * [#5561](https://github.com/bbatsov/rubocop/issues/5561): Fix `Lint/ShadowedArgument` false positive with shorthand assignments. ([@akhramov][])
 * [#4298](https://github.com/bbatsov/rubocop/issues/4298): Fix auto-correction of `Performance/RegexpMatch` to produce code that safe guards against the receiver being `nil`. ([@rrosenblum][])
 * [#5738](https://github.com/bbatsov/rubocop/issues/5738): Make `Rails/HttpStatus` ignoring hash order to fix false negative. ([@pocke][])

--- a/lib/rubocop/cop/rails/inverse_of.rb
+++ b/lib/rubocop/cop/rails/inverse_of.rb
@@ -4,11 +4,16 @@ module RuboCop
   module Cop
     module Rails
       # This cop looks for has_(one|many) and belongs_to associations where
-      # ActiveRecord can't automatically determine the inverse association
-      # because of a scope or the options used. This can result in unnecessary
-      # queries in some circumstances. `:inverse_of` must be manually specified
-      # for associations to work in both ways, or set to `false` or `nil`
-      # to opt-out.
+      # Active Record can't automatically determine the inverse association
+      # because of a scope or the options used. Using the blog with order scope
+      # example below, traversing the a Blog's association in both directions
+      # with `blog.posts.first.blog` would cause the `blog` to be loaded from
+      # the database twice.
+      #
+      # `:inverse_of` must be manually specified for Active Record to use the
+      # associated object in memory, or set to `false` to opt-out. Note that
+      # setting `nil` does not stop Active Record from trying to determine the
+      # inverse automatically, and is not considered a valid value for this.
       #
       # @example
       #   # good
@@ -59,15 +64,6 @@ module RuboCop
       #     has_many(:posts,
       #       -> { order(published_at: :desc) },
       #       inverse_of: false
-      #     )
-      #   end
-      #
-      #   # good
-      #   # You can also opt-out with specifying `inverse_of: nil`.
-      #   class Blog < ApplicationRecord
-      #     has_many(:posts,
-      #       -> { order(published_at: :desc) },
-      #       inverse_of: nil
       #     )
       #   end
       #
@@ -139,7 +135,9 @@ module RuboCop
 
         minimum_target_rails_version 4.1
 
-        MSG = 'Specify an `:inverse_of` option.'.freeze
+        SPECIFY_MSG = 'Specify an `:inverse_of` option.'.freeze
+        NIL_MSG = 'You specified `inverse_of: nil`, you probably meant to ' \
+          'use `inverse_of: false`.'.freeze
 
         def_node_matcher :association_recv_arguments, <<-PATTERN
           (send $_ {:has_many :has_one :belongs_to} _ $...)
@@ -170,7 +168,11 @@ module RuboCop
         PATTERN
 
         def_node_matcher :inverse_of_option?, <<-PATTERN
-          (pair (sym :inverse_of) _)
+          (pair (sym :inverse_of) !nil)
+        PATTERN
+
+        def_node_matcher :inverse_of_nil_option?, <<-PATTERN
+          (pair (sym :inverse_of) nil)
         PATTERN
 
         def on_send(node)
@@ -187,7 +189,7 @@ module RuboCop
                         options_requiring_inverse_of?(options)
 
           return if options_contain_inverse_of?(options)
-          add_offense(node, location: :selector)
+          add_offense(node, message: message(options), location: :selector)
         end
 
         def scope?(arguments)
@@ -225,6 +227,16 @@ module RuboCop
         def same_context_in_with_options?(arg, recv)
           return true if arg.nil? && recv.nil?
           arg && recv && arg.children[0] == recv.children[0]
+        end
+
+        private
+
+        def message(options)
+          if options.any? { |opt| inverse_of_nil_option?(opt) }
+            NIL_MSG
+          else
+            SPECIFY_MSG
+          end
         end
       end
     end

--- a/manual/cops_rails.md
+++ b/manual/cops_rails.md
@@ -748,11 +748,16 @@ Enabled by default | Supports autocorrection
 Enabled | No
 
 This cop looks for has_(one|many) and belongs_to associations where
-ActiveRecord can't automatically determine the inverse association
-because of a scope or the options used. This can result in unnecessary
-queries in some circumstances. `:inverse_of` must be manually specified
-for associations to work in both ways, or set to `false` or `nil`
-to opt-out.
+Active Record can't automatically determine the inverse association
+because of a scope or the options used. Using the blog with order scope
+example below, traversing the a Blog's association in both directions
+with `blog.posts.first.blog` would cause the `blog` to be loaded from
+the database twice.
+
+`:inverse_of` must be manually specified for Active Record to use the
+associated object in memory, or set to `false` to opt-out. Note that
+setting `nil` does not stop Active Record from trying to determine the
+inverse automatically, and is not considered a valid value for this.
 
 ### Examples
 
@@ -805,15 +810,6 @@ class Blog < ApplicationRecord
   has_many(:posts,
     -> { order(published_at: :desc) },
     inverse_of: false
-  )
-end
-
-# good
-# You can also opt-out with specifying `inverse_of: nil`.
-class Blog < ApplicationRecord
-  has_many(:posts,
-    -> { order(published_at: :desc) },
-    inverse_of: nil
   )
 end
 ```

--- a/spec/rubocop/cop/rails/inverse_of_spec.rb
+++ b/spec/rubocop/cop/rails/inverse_of_spec.rb
@@ -21,10 +21,13 @@ RSpec.describe RuboCop::Cop::Rails::InverseOf do
       )
     end
 
-    it 'does not register an offense when specifying `inverse_of: nil`' do
-      expect_no_offenses(
-        'has_many :foo, -> () { where(bar: true) }, inverse_of: nil'
-      )
+    it 'registers an offense when specifying `inverse_of: nil`' do
+      expect_offense(<<-RUBY.strip_indent)
+        class Person
+          has_many :foo, -> () { where(bar: true) }, inverse_of: nil
+          ^^^^^^^^ You specified `inverse_of: nil`, you probably meant to use `inverse_of: false`.
+        end
+      RUBY
     end
   end
 


### PR DESCRIPTION
This reverts commit b12978c3bed026359f5b3cd6aba88b0e6cafcb39. /cc @wata727 @johnnyshields

ActiveRecord specifically checks for `false`, not a falsey value, to stop evaluating if the inverse can be found automatically: 

https://github.com/rails/rails/blob/d35875b7a3f559155a9378cbe9203b0b8ea580f9/activerecord/lib/active_record/reflection.rb#L647-L652

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
