### PR TITLE
Docs for Rails/ReadWriteAttribute

### DIFF
--- a/lib/rubocop/cop/rails/read_write_attribute.rb
+++ b/lib/rubocop/cop/rails/read_write_attribute.rb
@@ -3,8 +3,15 @@
 module RuboCop
   module Cop
     module Rails
-      # This cop checks for the use of the read_attribute or
-      # write_attribute methods.
+      # This cop checks for the use of the read_attribute or write_attribute
+      # methods, and recommends square brackets instead.
+      #
+      # If an attribute is missing from the instance (for example, when
+      # initialized by a partial `select`) then read_attribute will return nil,
+      # but square brackets will raise an ActiveModel::MissingAttributeError.
+      #
+      # Explicitly raising an error in this situation is preferable, and that
+      # is why rubocop recommends using square brackets.
       #
       # @example
       #

--- a/manual/cops_rails.md
+++ b/manual/cops_rails.md
@@ -1202,8 +1202,15 @@ Enabled by default | Supports autocorrection
 --- | ---
 Enabled | Yes
 
-This cop checks for the use of the read_attribute or
-write_attribute methods.
+This cop checks for the use of the read_attribute or write_attribute
+methods, and recommends square brackets instead.
+
+If an attribute is missing from the instance (for example, when
+initialized by a partial `select`) then read_attribute will return nil,
+but square brackets will raise an ActiveModel::MissingAttributeError.
+
+Explicitly raising an error in this situation is preferable, and that
+is why rubocop recommends using square brackets.
 
 ### Examples
 


### PR DESCRIPTION
Explains the reason behind this cop. I really don't care what language we use
here, but I just want to document that there is no functional difference between
eg. [] and read_attribute. People encountering this cop will want to know that.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [N/A] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [N/A] Added tests.
* [N/A] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
