### PR TITLE
Allow `by` as method parameter in default config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * [#5561](https://github.com/bbatsov/rubocop/issues/5561): Fix `Lint/ShadowedArgument` false positive with shorthand assignments. ([@akhramov][])
 
+### Changes
+
+* [#5734](https://github.com/bbatsov/rubocop/pull/5734): Add `by` to allowed names of `Naming/UncommunicativeMethodParamName` cop in default config. ([@AlexWayfer][])
+
 ## 0.54.0 (2018-03-21)
 
 ### New features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Changes
 
-* [#5734](https://github.com/bbatsov/rubocop/pull/5734): Add `by` to allowed names of `Naming/UncommunicativeMethodParamName` cop in default config. ([@AlexWayfer][])
+* [#5734](https://github.com/bbatsov/rubocop/pull/5734): Add `by`, `on`, `in` and `at` to allowed names of `Naming/UncommunicativeMethodParamName` cop in default config. ([@AlexWayfer][])
 
 ## 0.54.0 (2018-03-21)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -769,6 +769,7 @@ Naming/UncommunicativeMethodParamName:
     - io
     - id
     - to
+    - by
   # Blacklisted names that will register an offense
   ForbiddenNames: []
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -770,6 +770,9 @@ Naming/UncommunicativeMethodParamName:
     - id
     - to
     - by
+    - 'on'
+    - in
+    - at
   # Blacklisted names that will register an offense
   ForbiddenNames: []
 

--- a/manual/cops_naming.md
+++ b/manual/cops_naming.md
@@ -508,7 +508,7 @@ Name | Default value | Configurable values
 --- | --- | ---
 MinNameLength | `3` | Integer
 AllowNamesEndingInNumbers | `true` | Boolean
-AllowedNames | `io`, `id`, `to` | Array
+AllowedNames | `io`, `id`, `to`, `by` | Array
 ForbiddenNames | `[]` | Array
 
 ## Naming/VariableName

--- a/manual/cops_naming.md
+++ b/manual/cops_naming.md
@@ -508,7 +508,7 @@ Name | Default value | Configurable values
 --- | --- | ---
 MinNameLength | `3` | Integer
 AllowNamesEndingInNumbers | `true` | Boolean
-AllowedNames | `io`, `id`, `to`, `by` | Array
+AllowedNames | `io`, `id`, `to`, `by`, `on`, `in`, `at` | Array
 ForbiddenNames | `[]` | Array
 
 ## Naming/VariableName


### PR DESCRIPTION
Add `by` to AllowedNames in default configuration for cop
Naming/UncommunicativeMethodParamName in order to allow common
methods handling authorship with parameter `update(values, by: user)`

**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
