### PR TITLE
[Fix #5686] Fix first line spacing for symbol and word arrays with partial newlines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 * [#5726](https://github.com/bbatsov/rubocop/issues/5726): Fix false positive for `:class_name` option in Rails/InverseOf cop. ([@bdewater][])
+* [#5686](https://github.com/bbatsov/rubocop/issues/5686): Fix a regression for `Style/SymbolArray` and `Style/WordArray` for multiline Arrays. ([@istateside][])
 * [#5561](https://github.com/bbatsov/rubocop/issues/5561): Fix `Lint/ShadowedArgument` false positive with shorthand assignments. ([@akhramov][])
 * [#4298](https://github.com/bbatsov/rubocop/issues/4298): Fix auto-correction of `Performance/RegexpMatch` to produce code that safe guards against the receiver being `nil`. ([@rrosenblum][])
 * [#5738](https://github.com/bbatsov/rubocop/issues/5738): Make `Rails/HttpStatus` ignoring hash order to fix false negative. ([@pocke][])
@@ -3287,3 +3288,4 @@
 [@YukiJikumaru]: https://github.com/YukiJikumaru
 [@jlfaber]: https://github.com/jlfaber
 [@drewpterry]: https://github.com/drewpterry
+[@istateside]: https://github.com/istateside

--- a/lib/rubocop/cop/mixin/percent_literal.rb
+++ b/lib/rubocop/cop/mixin/percent_literal.rb
@@ -61,11 +61,12 @@ module RuboCop
       def autocorrect_multiline_words(node, escape, delimiters)
         base_line_number = node.first_line
         previous_line_number = base_line_number
-        contents = node.children.map do |word_node|
+        contents = node.children.map.with_index do |word_node, index|
           line_breaks = line_breaks(word_node,
                                     node.source,
                                     previous_line_number,
-                                    base_line_number)
+                                    base_line_number,
+                                    index)
           previous_line_number = word_node.first_line
           content = escaped_content(word_node, escape, delimiters)
           line_breaks + content
@@ -85,14 +86,14 @@ module RuboCop
         end.join(' ')
       end
 
-      def line_breaks(node, source, previous_line_number, base_line_number)
+      def line_breaks(node, source, previous_line_num, base_line_num, node_idx)
         source_in_lines = source.split("\n")
-        if node.first_line == previous_line_number
-          node.first_line == base_line_number ? '' : ' '
+        if node.first_line == previous_line_num
+          node_idx.zero? && node.first_line == base_line_num ? '' : ' '
         else
-          begin_line_number = previous_line_number - base_line_number + 1
-          end_line_number = node.first_line - base_line_number + 1
-          lines = source_in_lines[begin_line_number...end_line_number]
+          begin_line_num = previous_line_num - base_line_num + 1
+          end_line_num = node.first_line - base_line_num + 1
+          lines = source_in_lines[begin_line_num...end_line_num]
           "\n" + lines.join("\n").split(node.source).first
         end
       end

--- a/spec/rubocop/cop/style/symbol_array_spec.rb
+++ b/spec/rubocop/cop/style/symbol_array_spec.rb
@@ -135,6 +135,19 @@ RSpec.describe RuboCop::Cop::Style::SymbolArray, :config do
           ]
         RUBY
       end
+
+      it 'autocorrects an array using partial newlines' do
+        new_source = autocorrect_source(<<-RUBY)
+          [:foo, :bar, :baz,
+          :boz, :buz,
+          :biz]
+        RUBY
+        expect(new_source).to eq(<<-RUBY)
+          %i[foo bar baz
+          boz buz
+          biz]
+        RUBY
+      end
     end
   end
 

--- a/spec/rubocop/cop/style/word_array_spec.rb
+++ b/spec/rubocop/cop/style/word_array_spec.rb
@@ -163,6 +163,19 @@ RSpec.describe RuboCop::Cop::Style::WordArray, :config do
       RUBY
     end
 
+    it 'auto-corrects an array of words using partial newlines' do
+      new_source = autocorrect_source(<<-RUBY)
+        ["foo", "bar", "baz",
+        "boz", "buz",
+        "biz"]
+      RUBY
+      expect(new_source).to eq(<<-RUBY)
+        %w(foo bar baz
+        boz buz
+        biz)
+      RUBY
+    end
+
     it 'detects right value of MinSize to use for --auto-gen-config' do
       inspect_source(<<-RUBY.strip_indent)
         ['one', 'two', 'three']


### PR DESCRIPTION
A regression was introduced in https://github.com/bbatsov/rubocop/commit/2ee27d2a55d44c973dc8c6eb57a8bec76b7b769e which caused the Style/SymbolArray and Style/WordArray to improperly autocorrect arrays that use partial newlines. In  RuboCop::Cop::PercentLiteral#line_breaks, when deciding whether to insert a space between entries on a line, we check if the current node's line number matches the previous node's line number. If we're handling the first line of an Array, we do not insert the space. However, this doesn't account for cases where there are multiple elements on the first line, like the following:
```ruby
number_array = ['one', 'two', 'three',
                'four', 'five',
                'six']
```

In this case, we would not add a space between "one" and "two", because we're still handling the first line. Autocorrecting would result in:
```ruby
number_array = %w(onetwothree
                  four five
                  six)
```

We can fix it by tracking the index of words in each line, and only skip adding the space for the very first word.

This seemed to be most minimal change that would make this work, but I'd be happy to take a different approach if we want to avoid passing another argument. Had to rename two other args to fit the fifth in with the line length.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
