### PR TITLE
Fix #4298: Safe guard against nil receiver in RegexpMatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 * [#5561](https://github.com/bbatsov/rubocop/issues/5561): Fix `Lint/ShadowedArgument` false positive with shorthand assignments. ([@akhramov][])
+* [#4298](https://github.com/bbatsov/rubocop/issues/4298): Fix auto-correction of `Performance/RegexpMatch` to produce code that safe guards against the receiver being `nil`. ([@rrosenblum][])
 
 ## 0.54.0 (2018-03-21)
 

--- a/spec/rubocop/cop/performance/regexp_match_spec.rb
+++ b/spec/rubocop/cop/performance/regexp_match_spec.rb
@@ -314,11 +314,21 @@ RSpec.describe RuboCop::Cop::Performance::RegexpMatch, :config do
     it_behaves_like(:all_legacy_match_methods, 'matching by =~`',
                     '/re/ =~ foo', '/re/.match?(foo)')
     it_behaves_like(:all_legacy_match_methods, 'matching by =~`',
-                    'foo =~ /re/', 'foo.match?(/re/)')
+                    'foo =~ /re/', '/re/.match?(foo)')
     it_behaves_like(:all_legacy_match_methods, 'matching by =~`',
                     '"foo" =~ re', '"foo".match?(re)')
     it_behaves_like(:all_legacy_match_methods, 'matching by =~`',
+                    're =~ "foo"', '"foo".match?(re)')
+    it_behaves_like(:all_legacy_match_methods, 'matching by =~`',
                     ':foo =~ re', ':foo.match?(re)')
+    it_behaves_like(:all_legacy_match_methods, 'matching by =~`',
+                    're =~ :foo', ':foo.match?(re)')
+    it_behaves_like(:all_legacy_match_methods, 'matching by =~`',
+                    're =~ foo', 're&.match?(foo)')
+    it_behaves_like(:all_legacy_match_methods, 'matching by =~`',
+                    're =~ FOO', 'FOO.match?(re)')
+    it_behaves_like(:all_legacy_match_methods, 'matching by =~`',
+                    'FOO =~ re', 'FOO.match?(re)')
     it_behaves_like(:all_legacy_match_methods, 'matching by ===`',
                     '/re/ === foo', '/re/.match?(foo)')
     it_behaves_like(:all_legacy_match_methods, 'matching by ===`',


### PR DESCRIPTION
This fixes #4298.

There is some back and forth on whether we should correct `foo =~ bar` using safe navigation, `foo&.match?(bar)` or leaving it up to the user to solve themselves. We could make this configurable if that is desired.