### PR TITLE
[Fix #5738] Make `Rails/HttpStatus` ignoring hash order to fix false negative

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#5726](https://github.com/bbatsov/rubocop/issues/5726): Fix false positive for `:class_name` option in Rails/InverseOf cop. ([@bdewater][])
 * [#5561](https://github.com/bbatsov/rubocop/issues/5561): Fix `Lint/ShadowedArgument` false positive with shorthand assignments. ([@akhramov][])
 * [#4298](https://github.com/bbatsov/rubocop/issues/4298): Fix auto-correction of `Performance/RegexpMatch` to produce code that safe guards against the receiver being `nil`. ([@rrosenblum][])
+* [#5738](https://github.com/bbatsov/rubocop/issues/5738): Make `Rails/HttpStatus` ignoring hash order to fix false negative. ([@pocke][])
 
 ### Changes
 

--- a/spec/rubocop/cop/rails/http_status_spec.rb
+++ b/spec/rubocop/cop/rails/http_status_spec.rb
@@ -12,10 +12,14 @@ RSpec.describe RuboCop::Cop::Rails::HttpStatus, :config do
                              ^^^ Prefer `:ok` over `200` to define HTTP status code.
         render json: { foo: 'bar' }, status: 404
                                              ^^^ Prefer `:not_found` over `404` to define HTTP status code.
+        render status: 404, json: { foo: 'bar' }
+                       ^^^ Prefer `:not_found` over `404` to define HTTP status code.
         render plain: 'foo/bar', status: 304
                                          ^^^ Prefer `:not_modified` over `304` to define HTTP status code.
         redirect_to root_url, status: 301
                                       ^^^ Prefer `:moved_permanently` over `301` to define HTTP status code.
+        redirect_to action: 'index', status: 301
+                                             ^^^ Prefer `:moved_permanently` over `301` to define HTTP status code.
       RUBY
     end
 
@@ -98,10 +102,14 @@ RSpec.describe RuboCop::Cop::Rails::HttpStatus, :config do
                              ^^^ Prefer `200` over `:ok` to define HTTP status code.
         render json: { foo: 'bar' }, status: :not_found
                                              ^^^^^^^^^^ Prefer `404` over `:not_found` to define HTTP status code.
+        render status: :not_found, json: { foo: 'bar' }
+                       ^^^^^^^^^^ Prefer `404` over `:not_found` to define HTTP status code.
         render plain: 'foo/bar', status: :not_modified
                                          ^^^^^^^^^^^^^ Prefer `304` over `:not_modified` to define HTTP status code.
         redirect_to root_url, status: :moved_permanently
                                       ^^^^^^^^^^^^^^^^^^ Prefer `301` over `:moved_permanently` to define HTTP status code.
+        redirect_to action: 'index', status: :moved_permanently
+                                             ^^^^^^^^^^^^^^^^^^ Prefer `301` over `:moved_permanently` to define HTTP status code.
       RUBY
     end
 


### PR DESCRIPTION

Fix #5738

Problem
===

Currently `Rails/HttpStatus` checks only first or second pair in hash.

```ruby
render 'index', status: 201
              # ^^^^^^^^^^^ checks
render 'index', something: foobar, status: 201
                                 # ^^^^^^^^^^^ does not check

render status: 201, json: {}
     # ^^^^^^^^^^^ does not check
render json: {}, status: 201
               # ^^^^^^^^^^^ checks
render json: {}, something: foobar, status: 201
                                  # ^^^^^^^^^^^ does not check
```

Solution
===

Make the cop to check all pairs in hash.

Note
===

Originally the cop does not check `redirect_to` with one argument (e.g.  `redirect_to action: :index, status: 301`). But it is a correct style, so the cop should add an offense for the style. This change also fixes this bug.

**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
