### PR TITLE
Remove `spec/support_cop_helper.rb` from the gemspec

### DIFF
--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -17,8 +17,7 @@ Gem::Specification.new do |s|
   DESCRIPTION
 
   s.email = 'rubocop@googlegroups.com'
-  s.files = `git ls-files assets bin config lib LICENSE.txt README.md \
-             spec/support/cop_helper.rb`
+  s.files = `git ls-files assets bin config lib LICENSE.txt README.md`
             .split($RS)
   s.executables = s.files.grep(%r{^bin/}) { |f| File.basename(f) }
   s.extra_rdoc_files = ['LICENSE.txt', 'README.md']


### PR DESCRIPTION
This file has been moved to `lib/rubocop/rspec/cop_helper.rb`.
https://github.com/bbatsov/rubocop/pull/3179
However, it still exists in the gemspec `files` configuration.
So this change just removes it from the gemspec.



