### PR TITLE
Teach Performance/{Start, End}With cops to look for `Regexp#match?`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### Bug fixes
 
+* [#5744](https://github.com/bbatsov/rubocop/pull/5744): Teach `Performance/StartWith` and `EndWith` cops to look for `Regexp#match?`. ([@bdewater][])
 * [#5683](https://github.com/bbatsov/rubocop/issues/5683): Fix message for `Naming/UncommunicativeXParamName` cops. ([@jlfaber][])
 * [#5680](https://github.com/bbatsov/rubocop/issues/5680): Fix `Layout/ElseAlignment` for `rescue/else/ensure` inside `do/end` blocks. ([@YukiJikumaru][])
 * [#5642](https://github.com/bbatsov/rubocop/pull/5642): Fix `Style/Documentation` `:nodoc:` for compact-style nested modules/classes. ([@ojab][])

--- a/lib/rubocop/cop/performance/end_with.rb
+++ b/lib/rubocop/cop/performance/end_with.rb
@@ -8,6 +8,7 @@ module RuboCop
       #
       # @example
       #   # bad
+      #   'abc'.match?(/bc\Z/)
       #   'abc' =~ /bc\Z/
       #   'abc'.match(/bc\Z/)
       #
@@ -19,7 +20,7 @@ module RuboCop
         SINGLE_QUOTE = "'".freeze
 
         def_node_matcher :redundant_regex?, <<-PATTERN
-          {(send $!nil? {:match :=~} (regexp (str $#literal_at_end?) (regopt)))
+          {(send $!nil? {:match :=~ :match?} (regexp (str $#literal_at_end?) (regopt)))
            (send (regexp (str $#literal_at_end?) (regopt)) {:match :=~} $_)}
         PATTERN
 

--- a/lib/rubocop/cop/performance/start_with.rb
+++ b/lib/rubocop/cop/performance/start_with.rb
@@ -8,6 +8,7 @@ module RuboCop
       #
       # @example
       #   # bad
+      #   'abc'.match?(/\Aab/)
       #   'abc' =~ /\Aab/
       #   'abc'.match(/\Aab/)
       #
@@ -19,7 +20,7 @@ module RuboCop
         SINGLE_QUOTE = "'".freeze
 
         def_node_matcher :redundant_regex?, <<-PATTERN
-          {(send $!nil? {:match :=~} (regexp (str $#literal_at_start?) (regopt)))
+          {(send $!nil? {:match :=~ :match?} (regexp (str $#literal_at_start?) (regopt)))
            (send (regexp (str $#literal_at_start?) (regopt)) {:match :=~} $_)}
         PATTERN
 

--- a/manual/cops_performance.md
+++ b/manual/cops_performance.md
@@ -272,6 +272,7 @@ would suffice.
 
 ```ruby
 # bad
+'abc'.match?(/bc\Z/)
 'abc' =~ /bc\Z/
 'abc'.match(/bc\Z/)
 
@@ -689,6 +690,7 @@ This cop identifies unnecessary use of a regex where
 
 ```ruby
 # bad
+'abc'.match?(/\Aab/)
 'abc' =~ /\Aab/
 'abc'.match(/\Aab/)
 

--- a/spec/rubocop/cop/performance/end_with_spec.rb
+++ b/spec/rubocop/cop/performance/end_with_spec.rb
@@ -70,6 +70,7 @@ RSpec.describe RuboCop::Cop::Performance::EndWith do
     end
   end
 
+  include_examples('different match methods', '.match?')
   include_examples('different match methods', ' =~')
   include_examples('different match methods', '.match')
 

--- a/spec/rubocop/cop/performance/start_with_spec.rb
+++ b/spec/rubocop/cop/performance/start_with_spec.rb
@@ -61,6 +61,7 @@ RSpec.describe RuboCop::Cop::Performance::StartWith do
     end
   end
 
+  include_examples('different match methods', '.match?')
   include_examples('different match methods', ' =~')
   include_examples('different match methods', '.match')
 


### PR DESCRIPTION
As I found out for https://github.com/JuanitoFatas/fast-ruby/pull/150 `match?` can be just as fast for small strings, but as the string size grows the performance gap widens.

* [x] Wrote good commit messages.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.
