### PR TITLE
[#4910] Add examples for `Style/SpecialGlobalVars`

### DIFF
--- a/lib/rubocop/cop/style/special_global_vars.rb
+++ b/lib/rubocop/cop/style/special_global_vars.rb
@@ -3,7 +3,59 @@
 module RuboCop
   module Cop
     module Style
+      #
       # This cop looks for uses of Perl-style global variables.
+      #
+      # @example EnforcedStyle: use_english_names (default)
+      #   # good
+      #   puts $LOAD_PATH
+      #   puts $LOADED_FEATURES
+      #   puts $PROGRAM_NAME
+      #   puts $ERROR_INFO
+      #   puts $ERROR_POSITION
+      #   puts $FIELD_SEPARATOR # or $FS
+      #   puts $OUTPUT_FIELD_SEPARATOR # or $OFS
+      #   puts $INPUT_RECORD_SEPARATOR # or $RS
+      #   puts $OUTPUT_RECORD_SEPARATOR # or $ORS
+      #   puts $INPUT_LINE_NUMBER # or $NR
+      #   puts $LAST_READ_LINE
+      #   puts $DEFAULT_OUTPUT
+      #   puts $DEFAULT_INPUT
+      #   puts $PROCESS_ID # or $PID
+      #   puts $CHILD_STATUS
+      #   puts $LAST_MATCH_INFO
+      #   puts $IGNORECASE
+      #   puts $ARGV # or ARGV
+      #   puts $MATCH
+      #   puts $PREMATCH
+      #   puts $POSTMATCH
+      #   puts $LAST_PAREN_MATCH
+      #
+      # @example EnforcedStyle: use_perl_names
+      #   # good
+      #   puts $:
+      #   puts $"
+      #   puts $0
+      #   puts $!
+      #   puts $@
+      #   puts $;
+      #   puts $,
+      #   puts $/
+      #   puts $\
+      #   puts $.
+      #   puts $_
+      #   puts $>
+      #   puts $<
+      #   puts $$
+      #   puts $?
+      #   puts $~
+      #   puts $=
+      #   puts $*
+      #   puts $&
+      #   puts $`
+      #   puts $'
+      #   puts $+
+      #
       class SpecialGlobalVars < Cop
         include ConfigurableEnforcedStyle
 

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -4910,6 +4910,63 @@ Enabled | Yes
 
 This cop looks for uses of Perl-style global variables.
 
+### Examples
+
+#### EnforcedStyle: use_english_names (default)
+
+```ruby
+# good
+puts $LOAD_PATH
+puts $LOADED_FEATURES
+puts $PROGRAM_NAME
+puts $ERROR_INFO
+puts $ERROR_POSITION
+puts $FIELD_SEPARATOR # or $FS
+puts $OUTPUT_FIELD_SEPARATOR # or $OFS
+puts $INPUT_RECORD_SEPARATOR # or $RS
+puts $OUTPUT_RECORD_SEPARATOR # or $ORS
+puts $INPUT_LINE_NUMBER # or $NR
+puts $LAST_READ_LINE
+puts $DEFAULT_OUTPUT
+puts $DEFAULT_INPUT
+puts $PROCESS_ID # or $PID
+puts $CHILD_STATUS
+puts $LAST_MATCH_INFO
+puts $IGNORECASE
+puts $ARGV # or ARGV
+puts $MATCH
+puts $PREMATCH
+puts $POSTMATCH
+puts $LAST_PAREN_MATCH
+```
+#### EnforcedStyle: use_perl_names
+
+```ruby
+# good
+puts $:
+puts $"
+puts $0
+puts $!
+puts $@
+puts $;
+puts $,
+puts $/
+puts $\
+puts $.
+puts $_
+puts $>
+puts $<
+puts $$
+puts $?
+puts $~
+puts $=
+puts $*
+puts $&
+puts $`
+puts $'
+puts $+
+```
+
 ### Configurable attributes
 
 Name | Default value | Configurable values


### PR DESCRIPTION
Related to issue #4910.
This commit adds an examples to `Style/SpecialGlobalVars` cop.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
