### PR TITLE
Fix incorrect offense for `Style/EmptyLineAfterGuardClause`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [#5561](https://github.com/bbatsov/rubocop/issues/5561): Fix `Lint/ShadowedArgument` false positive with shorthand assignments. ([@akhramov][])
 * [#4298](https://github.com/bbatsov/rubocop/issues/4298): Fix auto-correction of `Performance/RegexpMatch` to produce code that safe guards against the receiver being `nil`. ([@rrosenblum][])
 * [#5738](https://github.com/bbatsov/rubocop/issues/5738): Make `Rails/HttpStatus` ignoring hash order to fix false negative. ([@pocke][])
+* [#5760](https://github.com/bbatsov/rubocop/pull/5760): Fix incorrect offense location for `Style/EmptyLineAfterGuardClause` when guard clause is after heredoc argument. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/empty_line_after_guard_clause.rb
+++ b/lib/rubocop/cop/style/empty_line_after_guard_clause.rb
@@ -39,11 +39,25 @@ module RuboCop
         include RangeHelp
 
         MSG = 'Add empty line after guard clause.'.freeze
+        END_OF_HEREDOC_LINE = 1
 
         def on_if(node)
           return if correct_style?(node)
 
-          add_offense(node)
+          if last_argument_is_heredoc?(node)
+            heredoc_node = last_argument(node)
+
+            num_of_heredoc_lines = heredoc_node.children.size
+            line = node.last_line + num_of_heredoc_lines + END_OF_HEREDOC_LINE
+
+            return if next_line_empty?(line)
+
+            add_offense(heredoc_node, location: :heredoc_end)
+          else
+            return if next_line_empty?(node.last_line)
+
+            add_offense(node)
+          end
         end
 
         def autocorrect(node)
@@ -59,17 +73,15 @@ module RuboCop
           !contains_guard_clause?(node) ||
             next_line_rescue_or_ensure?(node) ||
             next_sibling_parent_empty_or_else?(node) ||
-            next_sibling_empty_or_guard_clause?(node) ||
-            last_argument_is_heredoc?(node) ||
-            next_line_empty?(node)
+            next_sibling_empty_or_guard_clause?(node)
         end
 
         def contains_guard_clause?(node)
           node.if_branch && node.if_branch.guard_clause?
         end
 
-        def next_line_empty?(node)
-          processed_source[node.last_line].blank?
+        def next_line_empty?(line)
+          processed_source[line].blank?
         end
 
         def next_line_rescue_or_ensure?(node)
@@ -94,8 +106,19 @@ module RuboCop
         end
 
         def last_argument_is_heredoc?(node)
-          node.children.last && node.children.last.send_type? &&
-            node.children.last.last_argument.heredoc?
+          last_children = node.children.last
+
+          return false unless last_children && last_children.send_type?
+
+          last_argument = last_argument(node)
+
+          last_argument &&
+            (last_argument.str_type? || last_argument.dstr_type?) &&
+            last_argument.heredoc?
+        end
+
+        def last_argument(node)
+          node.children.last.last_argument
         end
       end
     end

--- a/spec/rubocop/cop/style/empty_line_after_guard_clause_spec.rb
+++ b/spec/rubocop/cop/style/empty_line_after_guard_clause_spec.rb
@@ -37,6 +37,41 @@ RSpec.describe RuboCop::Cop::Style::EmptyLineAfterGuardClause do
     RUBY
   end
 
+  it 'registers an offense for next guard clause not followed by empty line ' \
+     'when guard clause is after heredoc' do
+    expect_offense(<<-RUBY.strip_indent)
+      def foo
+        raise ArgumentError, <<-MSG unless path
+          Must be called with mount point
+        MSG
+      ^^^^^ Add empty line after guard clause.
+        bar
+      end
+    RUBY
+  end
+
+  it 'registers an offense for next guard clause not followed by empty line ' \
+     'when guard clause is after condition without method invocation' do
+    expect_no_offenses(<<-'RUBY'.strip_indent)
+      def foo
+        raise unless $1 == o
+
+        bar
+      end
+    RUBY
+  end
+
+  it 'registers an offense for next guard clause not followed by empty line ' \
+     'when guard clause is after method call with argument' do
+    expect_offense(<<-'RUBY'.strip_indent)
+      def foo
+        raise SerializationError.new("Unsupported argument type: #{argument.class.name}") unless serializer
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Add empty line after guard clause.
+        serializer.serialize(argument)
+      end
+    RUBY
+  end
+
   it 'does not register offence for modifier if' do
     expect_no_offenses(<<-RUBY.strip_indent)
       def foo
@@ -147,11 +182,26 @@ RSpec.describe RuboCop::Cop::Style::EmptyLineAfterGuardClause do
     RUBY
   end
 
-  it 'does not register offence when guard clause is after heredoc' do
+  it 'does not register offence when guard clause is after single line ' \
+     'heredoc' do
     expect_no_offenses(<<-RUBY.strip_indent)
       def foo
         raise ArgumentError, <<-MSG unless path
           Must be called with mount point
+        MSG
+
+        bar
+      end
+    RUBY
+  end
+
+  it 'does not register offence when guard clause is after multiline heredoc' do
+    expect_no_offenses(<<-RUBY.strip_indent)
+      def foo
+        raise ArgumentError, <<-MSG unless path
+          foo
+          bar
+          baz
         MSG
 
         bar


### PR DESCRIPTION
Follow up of https://github.com/bbatsov/rubocop/pull/5720#issuecomment-375878615.

This PR fixes incorrect offense location for `Style/EmptyLineAfterGuardClause` when guard clause is after heredoc argument.

## Reproduction code

```ruby
def foo
  raise ArgumentError, <<-MSG unless path
    Must be called with mount point
  MSG
  bar
end
```

## Expected behavior

```console
% rubocop /tmp/example.rb --only Style/EmptyLineAfterGuardClause
Inspecting 1 file
C

Offenses:

/tmp/example.rb:4:1: C: Style/EmptyLineAfterGuardClause: Add empty line
after guard clause.
  MSG
^^^^^

1 file inspected, 1 offense detected
```

## Actual behavior and Steps to reproduce the problem

```
% rubocop /tmp/example.rb --only Style/EmptyLineAfterGuardClause
Inspecting 1 file
C

Offenses:

/tmp/example.rb:2:3: C: Style/EmptyLineAfterGuardClause: Add empty line
after guard clause.
  raise ArgumentError, <<-MSG unless path
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

1 file inspected, 1 offense detected
```

## RuboCop version

```console
% rubocop -V
0.54.0 (using Parser 2.5.0.5, running on ruby 2.5.1 x86_64-darwin17)
```

Also, this PR will fix bugs included in changes at #5720.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
