### PR TITLE
CI against Ruby 2.4 and 2.5 on Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,3 +19,7 @@ environment:
     - ruby_version: 22-x64
     - ruby_version: '23'
     - ruby_version: 23-x64
+    - ruby_version: '24'
+    - ruby_version: 24-x64
+    - ruby_version: '25'
+    - ruby_version: 25-x64


### PR DESCRIPTION
Ruby 2.4 and 2.5 has been reelased and these Ruby versions are available on Appveyor.
https://www.appveyor.com/docs/build-environment/#ruby
