### PR TITLE
[Fix #5685] Add information on Rails version to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ RuboCop supports the following Ruby implementations:
 * MRI 2.1+
 * JRuby 9.0+
 
+The Rails cops support the following versions:
+
+* Rails 4.0+
+
 ## Team
 
 Here's a list of RuboCop's core developers:


### PR DESCRIPTION
The Rails cops don't support Rails versions lower than 4.0. This change adds a note about it in the `README`.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
