### PR TITLE
Remove backticks from EnforcedStyle of document

### DIFF
--- a/lib/rubocop/cop/rails/http_status.rb
+++ b/lib/rubocop/cop/rails/http_status.rb
@@ -5,7 +5,7 @@ module RuboCop
     module Rails
       # Enforces use of symbolic or numeric value to define HTTP status.
       #
-      # @example `EnforcedStyle: symbolic` (default)
+      # @example EnforcedStyle: symbolic (default)
       #   # bad
       #   render :foo, status: 200
       #   render json: { foo: 'bar' }, status: 200
@@ -18,7 +18,7 @@ module RuboCop
       #   render plain: 'foo/bar', status: :not_modified
       #   redirect_to root_url, status: :moved_permanently
       #
-      # @example `EnforcedStyle: numeric`
+      # @example EnforcedStyle: numeric
       #   # bad
       #   render :foo, status: :ok
       #   render json: { foo: 'bar' }, status: :not_found

--- a/manual/cops_rails.md
+++ b/manual/cops_rails.md
@@ -704,7 +704,7 @@ Enforces use of symbolic or numeric value to define HTTP status.
 
 ### Examples
 
-#### `EnforcedStyle: symbolic` (default)
+#### EnforcedStyle: symbolic (default)
 
 ```ruby
 # bad
@@ -719,7 +719,7 @@ render json: { foo: 'bar' }, status: :ok
 render plain: 'foo/bar', status: :not_modified
 redirect_to root_url, status: :moved_permanently
 ```
-#### `EnforcedStyle: numeric`
+#### EnforcedStyle: numeric
 
 ```ruby
 # bad


### PR DESCRIPTION
This PR is a small change of document.
It removes backtiks from `EnforcedStyle` names of `Rails/HttpStatus` document.
The purpose is to unify it with `EnforcedStyle` of other documents.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
