### PR TITLE
[Fix #5766] Add a new line between the frozen string literal comment and code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * [#5720](https://github.com/bbatsov/rubocop/pull/5720): Fix false positive for `Style/EmptyLineAfterGuardClause` when guard clause is after heredoc. ([@koic][])
 * [#5760](https://github.com/bbatsov/rubocop/pull/5760): Fix incorrect offense location for `Style/EmptyLineAfterGuardClause` when guard clause is after heredoc argument. ([@koic][])
 * [#5764](https://github.com/bbatsov/rubocop/pull/5764): Fix `Style/Unpackfirst` false positive of `unpack('h*').take(1)`. ([@parkerfinch][])
+* [#5766](https://github.com/bbatsov/rubocop/issues/5766): Update `Style/FrozenStringLiteralComment` auto-correction to insert a new line between the comment and the code. ([@rrosenblum][])
 
 ### Changes
 

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -267,10 +267,9 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
         expect(cli.run(['--format', 'offenses', '-a', 'example.rb'])).to eq(0)
         expect($stdout.string).to eq(<<-RESULT.strip_indent)
 
-          1  Layout/EmptyLineAfterMagicComment
           1  Style/FrozenStringLiteralComment
           --
-          2  Total
+          1  Total
 
         RESULT
         expect(IO.read('example.rb'))

--- a/spec/rubocop/cop/style/frozen_string_literal_comment_spec.rb
+++ b/spec/rubocop/cop/style/frozen_string_literal_comment_spec.rb
@@ -171,6 +171,7 @@ RSpec.describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
 
         expect(new_source).to eq(<<-RUBY.strip_indent)
           # frozen_string_literal: true
+
           puts 1
         RUBY
       end
@@ -184,6 +185,7 @@ RSpec.describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
         expect(new_source).to eq(<<-RUBY.strip_indent)
           #!/usr/bin/env ruby
           # frozen_string_literal: true
+
           puts 1
         RUBY
       end
@@ -197,6 +199,7 @@ RSpec.describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
         expect(new_source).to eq(<<-RUBY.strip_indent)
           # encoding: utf-8
           # frozen_string_literal: true
+
           puts 1
         RUBY
       end
@@ -213,6 +216,7 @@ RSpec.describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
           #!/usr/bin/env ruby
           # encoding: utf-8
           # frozen_string_literal: true
+
           puts 1
         RUBY
       end


### PR DESCRIPTION
This fixes #5766