### PR TITLE
[Fix #5551] `Lint/Void` not detecting void context in single line blocks.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * [#5760](https://github.com/bbatsov/rubocop/pull/5760): Fix incorrect offense location for `Style/EmptyLineAfterGuardClause` when guard clause is after heredoc argument. ([@koic][])
 * [#5764](https://github.com/bbatsov/rubocop/pull/5764): Fix `Style/Unpackfirst` false positive of `unpack('h*').take(1)`. ([@parkerfinch][])
 * [#5766](https://github.com/bbatsov/rubocop/issues/5766): Update `Style/FrozenStringLiteralComment` auto-correction to insert a new line between the comment and the code. ([@rrosenblum][])
+* [#5551](https://github.com/bbatsov/rubocop/issues/5551): Fix `Lint/Volib/rubocop/cop/style/and_or.rbid` not detecting void context in blocks with single expression. ([@Darhazer][])
 
 ### Changes
 
@@ -3298,3 +3299,4 @@
 [@mcfisch]: https://github.com/mcfisch
 [@istateside]: https://github.com/istateside
 [@parkerfinch]: https://github.com/parkerfinch
+[@Darhazer]: https://github.com/Darhazer

--- a/spec/rubocop/cop/lint/void_spec.rb
+++ b/spec/rubocop/cop/lint/void_spec.rb
@@ -176,6 +176,21 @@ RSpec.describe RuboCop::Cop::Lint::Void do
     RUBY
   end
 
+  it 'handles `#each` block with single expression' do
+    expect_offense(<<-RUBY.strip_indent)
+      array.each do |_item|
+        42
+        ^^ Literal `42` used in void context.
+      end
+    RUBY
+  end
+
+  it 'handles empty block' do
+    expect_no_offenses(<<-RUBY.strip_indent)
+      array.each { |_item| }
+    RUBY
+  end
+
   it 'registers two offenses for void literals in `#tap` method' do
     expect_offense(<<-RUBY.strip_indent)
       foo.tap do |x|


### PR DESCRIPTION
Since single expression blocks do not have `begin` node, the cop was not checking them.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
