### PR TITLE
[Fix #5286] `Lint/SafeNavigationChain` not detecting chained operators after block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#5286](https://github.com/bbatsov/rubocop/issues/5286): Fix `Lint/SafeNavigationChain` not detecting chained operators after block. ([@Darhazer][])
+
 ## 0.55.0 (2018-04-16)
 
 ### New features

--- a/lib/rubocop/cop/lint/safe_navigation_chain.rb
+++ b/lib/rubocop/cop/lint/safe_navigation_chain.rb
@@ -31,7 +31,10 @@ module RuboCop
               ' after safe navigation operator.'.freeze
 
         def_node_matcher :bad_method?, <<-PATTERN
+        {
           (send $(csend ...) $_ ...)
+          (send $(block (csend ...) ...) $_ ...)
+        }
         PATTERN
 
         minimum_target_ruby_version 2.3

--- a/spec/rubocop/cop/lint/safe_navigation_chain_spec.rb
+++ b/spec/rubocop/cop/lint/safe_navigation_chain_spec.rb
@@ -73,6 +73,24 @@ RSpec.describe RuboCop::Cop::Lint::SafeNavigationChain, :config do
       RUBY
     end
 
+    it 'registers an offense for ordinary method chain exists after ' \
+      'safe navigation method call with a block-pass' do
+      expect_offense(<<-RUBY.strip_indent)
+        something
+        x&.select(&:foo).bar
+                        ^^^^ Do not chain ordinary method call after safe navigation operator.
+      RUBY
+    end
+
+    it 'registers an offense for ordinary method chain exists after ' \
+      'safe navigation method call with a block' do
+      expect_offense(<<-RUBY.strip_indent)
+        something
+        x&.select { |x| foo(x) }.bar
+                                ^^^^ Do not chain ordinary method call after safe navigation operator.
+      RUBY
+    end
+
     it 'registers an offense for safe navigation with < operator' do
       expect_offense(<<-RUBY.strip_indent)
         x&.foo < bar


### PR DESCRIPTION
P.S. Sorry for messing the previous changelog entry :blush: 

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
