### PR TITLE
Register a single offense per method in SafeNavigationConsistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 * [#5286](https://github.com/bbatsov/rubocop/issues/5286): Fix `Lint/SafeNavigationChain` not detecting chained operators after block. ([@Darhazer][])
+* Fix bug where `Lint/SafeNavigationConsistency` registers multiple offenses for the same method call. ([@rrosenblum][])
 
 ## 0.55.0 (2018-04-16)
 

--- a/spec/rubocop/cop/lint/safe_navigation_consistency_spec.rb
+++ b/spec/rubocop/cop/lint/safe_navigation_consistency_spec.rb
@@ -126,6 +126,14 @@ RSpec.describe RuboCop::Cop::Lint::SafeNavigationConsistency do
       RUBY
     end
 
+    it 'registers a single offense when safe navigation is ' \
+      'used multiple times' do
+      expect_offense(<<-RUBY.strip_indent)
+        foo&.bar && foo&.baz || foo.qux
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Ensure that safe navigation is used consistently inside of `&&` and `||`.
+      RUBY
+    end
+
     context 'auto-correct' do
       it 'does not correct non dot methods' do
         new_source = autocorrect_source(<<-RUBY.strip_indent)


### PR DESCRIPTION
Without the fix, this will register 2 offenses. 
```ruby
foo&.bar && foo&.baz || foo.qux 
            ^^^^^^^^^^^^^^^^^^^ Ensure that safe navigation is used consistently inside of `&&` and `||`.
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Ensure that safe navigation is used consistently inside of `&&` and `||`.
```