### PR TITLE
[Fix #5791] Fix NoMethodError in SafeNavigationConsistency when there is context around the condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#5286](https://github.com/bbatsov/rubocop/issues/5286): Fix `Lint/SafeNavigationChain` not detecting chained operators after block. ([@Darhazer][])
 * Fix bug where `Lint/SafeNavigationConsistency` registers multiple offenses for the same method call. ([@rrosenblum][])
+* [#5791](https://github.com/bbatsov/rubocop/issues/5791): Fix exception in `Lint/SafeNavigationConsistency` when there is code around the condition. ([@rrosenblum][])
 
 ## 0.55.0 (2018-04-16)
 

--- a/lib/rubocop/cop/lint/safe_navigation_consistency.rb
+++ b/lib/rubocop/cop/lint/safe_navigation_consistency.rb
@@ -72,6 +72,7 @@ module RuboCop
           unless parent &&
                  (AST::Node::OPERATOR_KEYWORDS.include?(parent.type) ||
                   (parent.begin_type? &&
+                   parent.parent &&
                    AST::Node::OPERATOR_KEYWORDS.include?(parent.parent.type)))
             return node
           end

--- a/spec/rubocop/cop/lint/safe_navigation_consistency_spec.rb
+++ b/spec/rubocop/cop/lint/safe_navigation_consistency_spec.rb
@@ -52,6 +52,16 @@ RSpec.describe RuboCop::Cop::Lint::SafeNavigationConsistency do
       RUBY
     end
 
+    it 'registers an offense when there is code before or after ' \
+      'the condition' do
+      expect_offense(<<-RUBY.strip_indent)
+        foo = nil
+        foo&.bar || foo.baz
+        ^^^^^^^^^^^^^^^^^^^ Ensure that safe navigation is used consistently inside of `&&` and `||`.
+        something
+      RUBY
+    end
+
     it 'registers an offense for non dot method calls' do
       expect_offense(<<-RUBY.strip_indent)
         foo&.start_with?('a') || foo =~ /b/


### PR DESCRIPTION
This fixes #5791.