### PR TITLE
[Fix #5784] Fix false positive for `Rails/HasManyOrHasOneDependent`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#5286](https://github.com/bbatsov/rubocop/issues/5286): Fix `Lint/SafeNavigationChain` not detecting chained operators after block. ([@Darhazer][])
 * Fix bug where `Lint/SafeNavigationConsistency` registers multiple offenses for the same method call. ([@rrosenblum][])
 * [#5791](https://github.com/bbatsov/rubocop/issues/5791): Fix exception in `Lint/SafeNavigationConsistency` when there is code around the condition. ([@rrosenblum][])
+* [#5784](https://github.com/bbatsov/rubocop/issues/5784): Fix a false positive for `Rails/HasManyOrHasOneDependent` when using nested `with_options`. ([@koic][])
 
 ## 0.55.0 (2018-04-16)
 

--- a/lib/rubocop/cop/rails/has_many_or_has_one_dependent.rb
+++ b/lib/rubocop/cop/rails/has_many_or_has_one_dependent.rb
@@ -63,8 +63,18 @@ module RuboCop
 
           n = node.parent.begin_type? ? node.parent.parent : node.parent
 
-          if with_options_block(n)
-            return true if valid_options?(with_options_block(n))
+          contain_valid_options_in_with_options_block?(n)
+        end
+
+        def contain_valid_options_in_with_options_block?(node)
+          if with_options_block(node)
+            return true if valid_options?(with_options_block(node))
+
+            return false unless node.parent
+
+            return true if contain_valid_options_in_with_options_block?(
+              node.parent.parent
+            )
           end
 
           false

--- a/spec/rubocop/cop/rails/has_many_or_has_one_dependent_spec.rb
+++ b/spec/rubocop/cop/rails/has_many_or_has_one_dependent_spec.rb
@@ -146,5 +146,20 @@ RSpec.describe RuboCop::Cop::Rails::HasManyOrHasOneDependent do
         end
       end
     end
+
+    context 'Nested `with_options` block' do
+      it 'does not register an offense when `dependent: :destroy` is present' do
+        expect_no_offenses(<<-RUBY.strip_indent)
+          class Article < ApplicationRecord
+            with_options dependent: :destroy do
+              has_many :tags
+              with_options class_name: 'Tag' do
+                has_many :special_tags, foreign_key: :special_id, inverse_of: :special
+              end
+            end
+          end
+        RUBY
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes #5784.

This PR fixes the following false positive.

```console
% cat app/models/article.rb
class Article < ApplicationRecord
  with_options dependent: :destroy do
    has_many :tags
    with_options class_name: "Tag" do
      has_many :special_tags, foreign_key: :special_id, inverse_of:
      :special
    end
  end
end
```

```console
% rubocop app/models/article.rb --only Rails/HasManyOrHasOneDependent
Inspecting 1 file
C

Offenses:

app/models/article.rb:5:7: C: Rails/HasManyOrHasOneDependent: Specify a
:dependent option.
      has_many :special_tags, foreign_key: :special_id, inverse_of:
      :special
      ^^^^^^^^

1 file inspected, 1 offense detected
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
