### PR TITLE
Fix broken link in Node Pattern doc

### DIFF
--- a/manual/node_pattern.md
+++ b/manual/node_pattern.md
@@ -13,7 +13,7 @@ and solves a problem that RuboCop contributors were facing for a long time:
 
 - Ability to declaratively define rules for node search, matching, and capture.
 
-The code below belongs to [Style/ArrayJoin](http://www.rubydoc.info/github/bbatsov/rubocop/Rubocop/Cop/Style/ArrayJoin)
+The code below belongs to [Style/ArrayJoin](http://www.rubydoc.info/github/bbatsov/RuboCop/RuboCop/Cop/Style/ArrayJoin)
 cop and it's in favor of `Array#join` over `Array#*`. Then it tries to find
 code like `%w(one two three) * ", "` and suggest to use `#join` instead.
 
@@ -292,4 +292,3 @@ directly. It's easy to read and hack on.
 
 The [specs](https://github.com/bbatsov/rubocop/blob/master/spec/rubocop/node_pattern_spec.rb)
 are also very useful to comprehend each feature.
-


### PR DESCRIPTION
This PR fixes a broken hyperlink in Node Pattern doc.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
