### PR TITLE
[Fix #5806] Space inside reference brackets when assigning another reference bracket.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 * Split `Style/MethodMissing` into two cops, `Style/MethodMissingSuper` and `Style/MissingRespondToMissing`. ([@rrosenblum][])
 * [#5757](https://github.com/bbatsov/rubocop/issues/5757): Add `AllowInMultilineConditions` option to `Style/ParenthesesAroundCondition` cop. ([@Darhazer][])
+* [#5806](https://github.com/bbatsov/rubocop/issues/5806): Fix `Layout/SpaceInsideReferenceBrackets` when assigning a reference bracket to a reference bracket. ([@joshuapinter][])
 
 ## 0.55.0 (2018-04-16)
 

--- a/lib/rubocop/cop/layout/space_inside_reference_brackets.rb
+++ b/lib/rubocop/cop/layout/space_inside_reference_brackets.rb
@@ -66,7 +66,7 @@ module RuboCop
           return if node.multiline?
           return unless bracket_method?(node)
           tokens = tokens(node)
-          left_token = left_ref_bracket(tokens)
+          left_token = left_ref_bracket(node, tokens)
           return unless left_token
           right_token = closing_bracket(tokens, left_token)
 
@@ -101,7 +101,7 @@ module RuboCop
 
         def reference_brackets(node)
           tokens = tokens(node)
-          left = left_ref_bracket(tokens)
+          left = left_ref_bracket(node, tokens)
           [left, closing_bracket(tokens, left)]
         end
 
@@ -110,8 +110,12 @@ module RuboCop
           BRACKET_METHODS.include?(method)
         end
 
-        def left_ref_bracket(tokens)
-          tokens.reverse.find(&:left_ref_bracket?)
+        def left_ref_bracket(node, tokens)
+          if node.method?(:[]=)
+            tokens.find(&:left_ref_bracket?)
+          else
+            tokens.reverse.find(&:left_ref_bracket?)
+          end
         end
 
         def closing_bracket(tokens, opening_bracket)

--- a/spec/rubocop/cop/layout/space_inside_reference_brackets_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_reference_brackets_spec.rb
@@ -109,6 +109,30 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideReferenceBrackets, :config do
       RUBY
     end
 
+    it 'registers an offense when a reference bracket with a leading whitespace
+        is assigned by another reference bracket' do
+      expect_offense(<<-RUBY.strip_indent)
+        a[ "foo"] = b["something"]
+          ^ Do not use space inside reference brackets.
+      RUBY
+    end
+
+    it 'registers an offense when a reference bracket with a trailing whitespace
+        is assigned by another reference bracket' do
+      expect_offense(<<-RUBY.strip_indent)
+        a["foo" ] = b["something"]
+               ^ Do not use space inside reference brackets.
+      RUBY
+    end
+
+    it 'registers an offense when a reference bracket is assigned by another
+        reference bracket with trailing whitespace' do
+      expect_offense(<<-RUBY.strip_indent)
+        a["foo"] = b["something" ]
+                                ^ Do not use space inside reference brackets.
+      RUBY
+    end
+
     it 'accepts square brackets as method name' do
       expect_no_offenses(<<-RUBY.strip_indent)
         def Vector.[](*array)
@@ -246,6 +270,30 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideReferenceBrackets, :config do
         c[ "foo" ] = "qux"
         d[ :bar ] = var
         e[ ] = baz
+      RUBY
+    end
+
+    it 'registers an offense when a reference bracket with no leading whitespace
+        is assigned by another reference bracket' do
+      expect_offense(<<-RUBY.strip_indent)
+        a["foo" ] = b[ "something" ]
+         ^ Use space inside reference brackets.
+      RUBY
+    end
+
+    it 'registers an offense when a reference bracket with no trailing
+        whitespace is assigned by another reference bracket' do
+      expect_offense(<<-RUBY.strip_indent)
+        a[ "foo"] = b[ "something" ]
+                ^ Use space inside reference brackets.
+      RUBY
+    end
+
+    it 'registers an offense when a reference bracket is assigned by another
+        reference bracket with no trailing whitespace' do
+      expect_offense(<<-RUBY.strip_indent)
+        a[ "foo" ] = b[ "something"]
+                                   ^ Use space inside reference brackets.
       RUBY
     end
 


### PR DESCRIPTION
When assigning a reference bracket to another reference bracket, the `Layout/SpaceInsideReferenceBracket` Cop fails to pickup on the _assignee_ reference bracket correctly.

Examples:

**`EnforcedStyle: no_space`**
```ruby
a[ "foo"] = b["something"]
```

The above example would not register an offence when `EnforcedStyle: no_space` is set.

**`EnforcedStyle: space`**
```ruby
a["foo" ] = b[ "something" ]
```

The above example would not register an offence when `EnforcedStyle: space` is set.

The issue is due to how the `left_ref_bracket` method searches from the end of the node to the beginning of the node to find the _first_ left reference bracket that it encounters.

This works fine for all other test cases, especially when there are multiple reference brackets, however, when a reference bracket is being assigned to another reference bracket, this mistakenly picks up the _assignor_ left reference bracket (i.e. `b[`) instead of the _assignee_ left reference bracket (i.e. `a[`).

To handle this, we simple modify the `left_ref_bracket` method to check to see if the node is using the `[]=` method. If it is, look for the first left reference bracket from the _start_ of the node.

If the node is not using the `[]=` method, do as it normally does and check for the first left reference bracket from the _end_ of the node.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together. **Please do when merging in on your side.**
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
