### PR TITLE
CI against JRuby 9.1.17.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ cache: bundler
 language: ruby
 dist: trusty
 rvm:
-  - jruby-9.1.16.0
+  - jruby-9.1.17.0
   - jruby-head
   - 2.1.10
   - 2.2.10


### PR DESCRIPTION
JRuby 9.1.17.0 has been released and available on Travis CI.
http://jruby.org/2018/04/23/jruby-9-1-17-0
