### PR TITLE
[Fix #5668] Fix an issue where included files weren't inspected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * [#5791](https://github.com/bbatsov/rubocop/issues/5791): Fix exception in `Lint/SafeNavigationConsistency` when there is code around the condition. ([@rrosenblum][])
 * [#5784](https://github.com/bbatsov/rubocop/issues/5784): Fix a false positive for `Rails/HasManyOrHasOneDependent` when using nested `with_options`. ([@koic][])
 * [#4666](https://github.com/bbatsov/rubocop/issues/4666): `--stdin` always treats input as Ruby source irregardless of filename. ([@PointlessOne][])
+* [#5668](https://github.com/bbatsov/rubocop/issues/5668): Fix an issue where files with unknown extensions, listed in `AllCops/Include` were not inspected when passing the file name as an option. ([@drenmi][])
 
 ### Changes
 

--- a/lib/rubocop/target_finder.rb
+++ b/lib/rubocop/target_finder.rb
@@ -194,10 +194,18 @@ module RuboCop
         ruby_executable?(file)
     end
 
+    def configured_include?(file)
+      @config_store.for(file).file_to_include?(file)
+    end
+
+    def included_file?(file)
+      ruby_file?(file) || configured_include?(file)
+    end
+
     def process_explicit_path(path)
       files = path.include?('*') ? Dir[path] : [path]
 
-      files.select! { |file| ruby_file?(file) }
+      files.select! { |file| included_file?(file) }
 
       return files unless force_exclusion?
 

--- a/spec/rubocop/target_finder_spec.rb
+++ b/spec/rubocop/target_finder_spec.rb
@@ -155,6 +155,48 @@ RSpec.describe RuboCop::TargetFinder, :isolated_environment do
       end
     end
 
+    context 'when some non-known Ruby files are specified in the ' \
+            'configuration Include and they are explicitly passed ' \
+            'as arguments' do
+      before do
+        create_file('.rubocop.yml', <<-YAML.strip_indent)
+          AllCops:
+            Include:
+              - dir1/file
+        YAML
+      end
+
+      let(:args) do
+        ['dir1/file']
+      end
+
+      it 'includes them' do
+        expect(found_basenames)
+          .to contain_exactly('file')
+      end
+    end
+
+    context 'when some non-known Ruby files are specified in the ' \
+            'configuration Include and they are not explicitly passed ' \
+            'as arguments' do
+      before do
+        create_file('.rubocop.yml', <<-YAML.strip_indent)
+          AllCops:
+            Include:
+              - dir1/file
+        YAML
+      end
+
+      let(:args) do
+        ['dir1/**/*']
+      end
+
+      it 'includes them' do
+        expect(found_basenames)
+          .to contain_exactly('executable', 'file', 'ruby1.rb', 'ruby2.rb')
+      end
+    end
+
     context 'when input is passed on stdin' do
       let(:options) do
         {


### PR DESCRIPTION
This change addresses an issue where files under the following circumstances:

 - the file is not a "known" Ruby file,
 - the file is included in `AllCops/Include`, and
 - the file, or a path containing the file, is passed as an argument.

would not be inspected.

Example:

```yml
AllCops:
  Include:
    - Somefile
```

Outcome:

```sh
rubocop --list-target-files Somefile
$
```

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [X] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
