### PR TITLE
[Fix #5821] Support `AR::Migration#up_only` for `Rails/ReversibleMigration`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#5801](https://github.com/bbatsov/rubocop/pull/5801): Add new `Rails/RefuteMethods` cop. ([@koic][])
 * [#5805](https://github.com/bbatsov/rubocop/pull/5805): Add new `Rails/AssertNot` cop. ([@composerinteralia][])
 * [#4136](https://github.com/bbatsov/rubocop/issues/4136): Allow more robust `Layout/ClosingParenthesisIndentation` detection including method chaining. ([@jfelchner][])
+* [#5821](https://github.com/bbatsov/rubocop/pull/5821): Support `AR::Migration#up_only` for `Rails/ReversibleMigration` cop. ([@koic][])
 
 ### Bug fixes
 

--- a/lib/rubocop/cop/rails/reversible_migration.rb
+++ b/lib/rubocop/cop/rails/reversible_migration.rb
@@ -157,7 +157,7 @@ module RuboCop
 
         def on_send(node)
           return unless within_change_method?(node)
-          return if within_reversible_block?(node)
+          return if within_reversible_or_up_only_block?(node)
 
           check_irreversible_schema_statement_node(node)
           check_drop_table_node(node)
@@ -168,7 +168,7 @@ module RuboCop
 
         def on_block(node)
           return unless within_change_method?(node)
-          return if within_reversible_block?(node)
+          return if within_reversible_or_up_only_block?(node)
 
           check_change_table_node(node.send_node, node.body)
         end
@@ -261,9 +261,11 @@ module RuboCop
           end
         end
 
-        def within_reversible_block?(node)
+        def within_reversible_or_up_only_block?(node)
           node.each_ancestor(:block).any? do |ancestor|
-            ancestor.block_type? && ancestor.send_node.method?(:reversible)
+            ancestor.block_type? &&
+              ancestor.send_node.method?(:reversible) ||
+              ancestor.send_node.method?(:up_only)
           end
         end
 

--- a/spec/rubocop/cop/rails/reversible_migration_spec.rb
+++ b/spec/rubocop/cop/rails/reversible_migration_spec.rb
@@ -43,6 +43,10 @@ RSpec.describe RuboCop::Cop::Rails::ReversibleMigration, :config do
     execute "ALTER TABLE `pages_linked_pages` ADD UNIQUE `page_id_linked_page_id` (`page_id`,`linked_page_id`)"
   RUBY
 
+  it_behaves_like :accepts, 'up_only', <<-RUBY
+    up_only { execute "UPDATE posts SET published = 'true'" }
+  RUBY
+
   context 'within block' do
     it_behaves_like :accepts, 'create_table', <<-RUBY
       [:users, :articles].each do |table|


### PR DESCRIPTION
Fixes #5821.

This PR supports the following `AR::Migration#up_only` method.

```console
% cat db/migrate/example.rb
class AddPublishedToPosts < ActiveRecord::Migration[5.2]
  def change
    add_column :posts, :published, :boolean, default: false

    up_only do
      execute "UPDATE posts SET published = 'true'"
    end
  end
end
```

http://api.rubyonrails.org/classes/ActiveRecord/Migration.html#method-i-up_only

This PR fixes the following false posive when using Rails 5.2.0.

```console
% rubocop db/migrate/example.rb --only Rails/ReversibleMigration
Inspecting 1 file
C

Offenses:

db/migrate/example.rb:6:7: C: Rails/ReversibleMigration: execute is not
reversible.
      execute "UPDATE posts SET published = 'true'"
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

1 file inspected, 1 offense detected
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
