### PR TITLE
Improve ResultCache#file_checksum performance

### DIFF
--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -291,6 +291,10 @@ module RuboCop
       @to_s ||= @hash.to_s
     end
 
+    def signature
+      @signature ||= Digest::MD5.hexdigest(to_s)
+    end
+
     def make_excludes_absolute
       each_key do |key|
         validate_section_presence(key)

--- a/lib/rubocop/result_cache.rb
+++ b/lib/rubocop/result_cache.rb
@@ -132,9 +132,10 @@ module RuboCop
     end
 
     def file_checksum(file, config_store)
-      Digest::MD5.hexdigest(Dir.pwd + file + IO.binread(file) +
-                            File.stat(file).mode.to_s +
-                            config_store.for(file).signature)
+      digester = Digest::MD5.new
+      digester.update(Dir.pwd + file + File.stat(file).mode.to_s + config_store.for(file).signature)
+      digester.file(file)
+      digester.hexdigest
     rescue Errno::ENOENT
       # Spurious files that come and go should not cause a crash, at least not
       # here.

--- a/lib/rubocop/result_cache.rb
+++ b/lib/rubocop/result_cache.rb
@@ -134,7 +134,7 @@ module RuboCop
 
     def file_checksum(file, config_store)
       digester = Digest::MD5.new
-      digester.update(@pwd + file + File.stat(file).mode.to_s + config_store.for(file).signature)
+      digester.update("#{@pwd}#{file}#{File.stat(file).mode}#{config_store.for(file).signature}")
       digester.file(file)
       digester.hexdigest
     rescue Errno::ENOENT

--- a/lib/rubocop/result_cache.rb
+++ b/lib/rubocop/result_cache.rb
@@ -134,7 +134,7 @@ module RuboCop
     def file_checksum(file, config_store)
       Digest::MD5.hexdigest(Dir.pwd + file + IO.binread(file) +
                             File.stat(file).mode.to_s +
-                            config_store.for(file).to_s)
+                            config_store.for(file).signature)
     rescue Errno::ENOENT
       # Spurious files that come and go should not cause a crash, at least not
       # here.

--- a/lib/rubocop/result_cache.rb
+++ b/lib/rubocop/result_cache.rb
@@ -84,6 +84,7 @@ module RuboCop
                         relevant_options_digest(options),
                         file_checksum(file, config_store))
       @cached_data = CachedData.new(file)
+      @pwd = Dir.pwd
     end
 
     def valid?
@@ -133,7 +134,7 @@ module RuboCop
 
     def file_checksum(file, config_store)
       digester = Digest::MD5.new
-      digester.update(Dir.pwd + file + File.stat(file).mode.to_s + config_store.for(file).signature)
+      digester.update(@pwd + file + File.stat(file).mode.to_s + config_store.for(file).signature)
       digester.file(file)
       digester.hexdigest
     rescue Errno::ENOENT


### PR DESCRIPTION
I found a few ways in which the performance of `ResultCache#file_checksum` can be improved, which is a major hotspot when the cache is warm:
 - Use the incremental mode ([`update`](https://ruby-doc.org/stdlib-2.5.0/libdoc/digest/rdoc/Digest/Instance.html#method-i-update)/[`file`](https://ruby-doc.org/stdlib-2.5.0/libdoc/digest/rdoc/Digest/Instance.html#method-i-file)) of the digester to avoid allocating large strings.
 - Reduce the number of bytes processed by the digester by using a memoized config signature rather than the much larger string representation of the config hash.
 - Memoize `Dir.pwd` to avoid unnecessary `getcwd` syscalls in a loop.


In a project I work on that contains nearly 9000 ruby files these optimizations shave about three seconds off rubocop's 10 second runtime for a fully warmed cache.


-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
