### PR TITLE
Fix FormatString EnforcedStyle: sprintf good example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### New features
 
-* switch good and bad examples in `Style/FormatString` EnforcedStyle: sprintf. ([@matass][])
+* Switch good and bad examples in `Style/FormatString` EnforcedStyle: sprintf. ([@matass][])
 * [#5801](https://github.com/bbatsov/rubocop/pull/5801): Add new `Rails/RefuteMethods` cop. ([@koic][])
 * [#5805](https://github.com/bbatsov/rubocop/pull/5805): Add new `Rails/AssertNot` cop. ([@composerinteralia][])
 * [#4136](https://github.com/bbatsov/rubocop/issues/4136): Allow more robust `Layout/ClosingParenthesisIndentation` detection including method chaining. ([@jfelchner][])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+* switch good and bad examples in `Style/FormatString` EnforcedStyle: sprintf. ([@matass][])
 * [#5801](https://github.com/bbatsov/rubocop/pull/5801): Add new `Rails/RefuteMethods` cop. ([@koic][])
 * [#5805](https://github.com/bbatsov/rubocop/pull/5805): Add new `Rails/AssertNot` cop. ([@composerinteralia][])
 * [#4136](https://github.com/bbatsov/rubocop/issues/4136): Allow more robust `Layout/ClosingParenthesisIndentation` detection including method chaining. ([@jfelchner][])

--- a/lib/rubocop/cop/style/format_string.rb
+++ b/lib/rubocop/cop/style/format_string.rb
@@ -22,10 +22,10 @@ module RuboCop
       # @example EnforcedStyle: sprintf
       #   # bad
       #   puts sprintf('%10s', 'hoge')
+      #   puts '%10s' % 'hoge'
       #
       #   # good
       #   puts format('%10s', 'hoge')
-      #   puts '%10s' % 'hoge'
       #
       # @example EnforcedStyle: percent
       #   # bad

--- a/lib/rubocop/cop/style/format_string.rb
+++ b/lib/rubocop/cop/style/format_string.rb
@@ -29,11 +29,11 @@ module RuboCop
       #
       # @example EnforcedStyle: percent
       #   # bad
-      #   puts format('%10s', 'hoge')
       #   puts sprintf('%10s', 'hoge')
+      #   puts '%10s' % 'hoge'
       #
       #   # good
-      #   puts '%10s' % 'hoge'
+      #   puts format('%10s', 'hoge')
       #
       class FormatString < Cop
         include ConfigurableEnforcedStyle

--- a/lib/rubocop/cop/style/format_string.rb
+++ b/lib/rubocop/cop/style/format_string.rb
@@ -21,11 +21,11 @@ module RuboCop
       #
       # @example EnforcedStyle: sprintf
       #   # bad
-      #   puts format('%10s', 'hoge')
-      #   puts '%10s' % 'hoge'
+      #   puts sprintf('%10s', 'hoge')
       #
       #   # good
-      #   puts sprintf('%10s', 'hoge')
+      #   puts format('%10s', 'hoge')
+      #   puts '%10s' % 'hoge'
       #
       # @example EnforcedStyle: percent
       #   # bad

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -1899,11 +1899,11 @@ puts format('%10s', 'hoge')
 
 ```ruby
 # bad
-puts format('%10s', 'hoge')
-puts '%10s' % 'hoge'
+puts sprintf('%10s', 'hoge')
 
 # good
-puts sprintf('%10s', 'hoge')
+puts format('%10s', 'hoge')
+puts '%10s' % 'hoge'
 ```
 #### EnforcedStyle: percent
 

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -1900,10 +1900,10 @@ puts format('%10s', 'hoge')
 ```ruby
 # bad
 puts sprintf('%10s', 'hoge')
+puts '%10s' % 'hoge'
 
 # good
 puts format('%10s', 'hoge')
-puts '%10s' % 'hoge'
 ```
 #### EnforcedStyle: percent
 

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -1909,11 +1909,11 @@ puts format('%10s', 'hoge')
 
 ```ruby
 # bad
-puts format('%10s', 'hoge')
 puts sprintf('%10s', 'hoge')
+puts '%10s' % 'hoge'
 
 # good
-puts '%10s' % 'hoge'
+puts format('%10s', 'hoge')
 ```
 
 ### Configurable attributes


### PR DESCRIPTION
```
Style/FormatString: Favor format over sprintf.
      sprintf('%10s', 'hoge')
      ^^^^^^^
```

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
