### PR TITLE
Fixes #5838 and unit test

### DIFF
--- a/lib/rubocop/cop/lint/unneeded_cop_enable_directive.rb
+++ b/lib/rubocop/cop/lint/unneeded_cop_enable_directive.rb
@@ -26,6 +26,7 @@ module RuboCop
         def investigate(processed_source)
           return if processed_source.blank?
           offenses = processed_source.comment_config.extra_enabled_comments
+          offenses.reject! { |comment, _| all_enabled?(comment) }
           offenses.each do |comment, name|
             add_offense(
               [comment, name],
@@ -89,6 +90,10 @@ module RuboCop
           else
             range_class.new(buffer, start, comment.loc.expression.end_pos)
           end
+        end
+
+        def all_enabled?(comment)
+          comment.text =~ /rubocop\s*:\s*enable\s+all\b/
         end
       end
     end

--- a/spec/rubocop/cop/lint/unneeded_cop_enable_directive_spec.rb
+++ b/spec/rubocop/cop/lint/unneeded_cop_enable_directive_spec.rb
@@ -45,6 +45,14 @@ RSpec.describe RuboCop::Cop::Lint::UnneededCopEnableDirective do
     RUBY
   end
 
+  it 'raises no errors when named cop is disabled by name and enabled by all' do
+    expect_no_offenses(<<-RUBY.strip_indent)
+      # rubocop:disable Metrics/LineLength
+      fooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo = barrrrrrrrrrrrrrrrrrrrrrrrrr
+      # rubocop:enable all
+    RUBY
+  end
+
   context 'autocorrection' do
     context 'when entire comment unnecessarily enables' do
       let(:source) do


### PR DESCRIPTION
Issue based upon CommentConfig#extra_enabled_comments returning individually enabled cops after finding enable all where the default state would have been for them to be enabled anyway.

This caused comment to contain rubocop:enabel all but the name of the offence to match the individual cop and a failure in cop_name_indentation to index the position.

Workaround is to reject offences in the cop containing enable all in the comment.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/