### PR TITLE
[Fix #5840] ignore methods that nil responds to in SafeNavigationConsistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * [#4666](https://github.com/bbatsov/rubocop/issues/4666): `--stdin` always treats input as Ruby source irregardless of filename. ([@PointlessOne][])
 * [#5668](https://github.com/bbatsov/rubocop/issues/5668): Fix an issue where files with unknown extensions, listed in `AllCops/Include` were not inspected when passing the file name as an option. ([@drenmi][])
 * [#5809](https://github.com/bbatsov/rubocop/issues/5809): Fix exception `Lint/PercentStringArray` and `Lint/PercentSymbolArray` when the inspected file is binary encoded. ([@akhramov][])
+* [#5840](https://github.com/bbatsov/rubocop/issues/5840): Do not register an offense for methods that `nil` responds to in `Lint/SafeNavigationConsistency`. ([@rrosenblum][])
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * Split `Style/MethodMissing` into two cops, `Style/MethodMissingSuper` and `Style/MissingRespondToMissing`. ([@rrosenblum][])
 * [#5757](https://github.com/bbatsov/rubocop/issues/5757): Add `AllowInMultilineConditions` option to `Style/ParenthesesAroundCondition` cop. ([@Darhazer][])
 * [#5806](https://github.com/bbatsov/rubocop/issues/5806): Fix `Layout/SpaceInsideReferenceBrackets` when assigning a reference bracket to a reference bracket. ([@joshuapinter][])
+* Add `try!` to the list of whitelisted methods for `Lint/SafeNavigationChain` and `Style/SafeNavigation`. ([@rrosenblum][])
 
 ## 0.55.0 (2018-04-16)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -1598,6 +1598,14 @@ Lint/SafeNavigationChain:
     - presence
     - try
 
+Lint/SafeNavigationConsistency:
+  Whitelist:
+    - present?
+    - blank?
+    - presence
+    - try
+    - try!
+
 # Checks for shadowed arguments
 Lint/ShadowedArgument:
   IgnoreImplicitReferences: false

--- a/config/default.yml
+++ b/config/default.yml
@@ -1331,6 +1331,7 @@ Style/SafeNavigation:
     - blank?
     - presence
     - try
+    - try!
 
 Style/Semicolon:
   # Allow `;` to separate several expressions on the same line.
@@ -1597,6 +1598,7 @@ Lint/SafeNavigationChain:
     - blank?
     - presence
     - try
+    - try!
 
 Lint/SafeNavigationConsistency:
   Whitelist:

--- a/lib/rubocop/cop/lint/safe_navigation_consistency.rb
+++ b/lib/rubocop/cop/lint/safe_navigation_consistency.rb
@@ -28,6 +28,7 @@ module RuboCop
       #
       class SafeNavigationConsistency < Cop
         include IgnoredNode
+        include NilMethods
 
         MSG = 'Ensure that safe navigation is used consistently ' \
           'inside of `&&` and `||`.'.freeze
@@ -82,6 +83,7 @@ module RuboCop
         def unsafe_method_calls(method_calls, safe_nav_receiver)
           method_calls.select do |method_call|
             safe_nav_receiver == method_call.receiver &&
+              !nil_methods.include?(method_call.method_name) &&
               !ignored_node?(method_call)
           end
         end

--- a/manual/cops_lint.md
+++ b/manual/cops_lint.md
@@ -1719,6 +1719,12 @@ foo&.bar || foo&.baz
 foo&.bar && (foobar.baz || foo&.baz)
 ```
 
+### Configurable attributes
+
+Name | Default value | Configurable values
+--- | --- | ---
+Whitelist | `present?`, `blank?`, `presence`, `try`, `try!` | Array
+
 ## Lint/ScriptPermission
 
 Enabled by default | Supports autocorrection

--- a/manual/cops_lint.md
+++ b/manual/cops_lint.md
@@ -1685,7 +1685,7 @@ x&.foo || bar
 
 Name | Default value | Configurable values
 --- | --- | ---
-Whitelist | `present?`, `blank?`, `presence`, `try` | Array
+Whitelist | `present?`, `blank?`, `presence`, `try`, `try!` | Array
 
 ## Lint/SafeNavigationConsistency
 

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -4960,7 +4960,7 @@ foo.bar > 2 if foo
 Name | Default value | Configurable values
 --- | --- | ---
 ConvertCodeThatCanStartToReturnNil | `false` | Boolean
-Whitelist | `present?`, `blank?`, `presence`, `try` | Array
+Whitelist | `present?`, `blank?`, `presence`, `try`, `try!` | Array
 
 ## Style/SelfAssignment
 

--- a/spec/rubocop/cop/lint/safe_navigation_consistency_spec.rb
+++ b/spec/rubocop/cop/lint/safe_navigation_consistency_spec.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::Lint::SafeNavigationConsistency do
+RSpec.describe RuboCop::Cop::Lint::SafeNavigationConsistency, :config do
   subject(:cop) { described_class.new(config) }
 
-  let(:config) { RuboCop::Config.new }
+  let(:cop_config) do
+    { 'Whitelist' => %w[present? blank? try presence] }
+  end
 
   context 'target_ruby_version >= 2.3', :ruby23 do
     it 'allows && without safe navigation' do
@@ -21,6 +23,12 @@ RSpec.describe RuboCop::Cop::Lint::SafeNavigationConsistency do
     it 'allows safe navigation when different variables are used' do
       expect_no_offenses(<<-RUBY.strip_indent)
         foo&.bar || foobar.baz
+      RUBY
+    end
+
+    it 'allows calls to methods that nil responds to' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        return true if a.nil? || a&.whatever?
       RUBY
     end
 
@@ -64,8 +72,8 @@ RSpec.describe RuboCop::Cop::Lint::SafeNavigationConsistency do
 
     it 'registers an offense for non dot method calls' do
       expect_offense(<<-RUBY.strip_indent)
-        foo&.start_with?('a') || foo =~ /b/
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Ensure that safe navigation is used consistently inside of `&&` and `||`.
+        foo&.zero? || foo > 5
+        ^^^^^^^^^^^^^^^^^^^^^ Ensure that safe navigation is used consistently inside of `&&` and `||`.
       RUBY
     end
 


### PR DESCRIPTION
This fixes #5840.