### PR TITLE
[Fix #4247] Add AllCops/IncludeOnly config parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [#4136](https://github.com/bbatsov/rubocop/issues/4136): Allow more robust `Layout/ClosingParenthesisIndentation` detection including method chaining. ([@jfelchner][])
 * [#5821](https://github.com/bbatsov/rubocop/pull/5821): Support `AR::Migration#up_only` for `Rails/ReversibleMigration` cop. ([@koic][])
 * [#5845](https://github.com/bbatsov/rubocop/pull/5845): Add new `Lint/ErbNewArguments` cop. ([@koic][])
+* [#4247](https://github.com/bbatsov/rubocop/issues/4247): Add new `AllCops/IncludeOnly` configuration parameter. ([@jonas054][])
 
 ### Bug fixes
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -57,6 +57,11 @@ AllCops:
     - '**/Thorfile'
     - '**/Vagabondfile'
     - '**/Vagrantfile'
+  # IncludeOnly is empty in default configuration. If it is overridden in user
+  # configuration, the Include option is disregarded and regular ruby files,
+  # which are normally included by default, don't get included unless they are
+  # listed as a pattern in IncludeOnly.
+  IncludeOnly: []
   Exclude:
     - 'node_modules/**/*'
     - 'vendor/**/*'

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -396,7 +396,11 @@ module RuboCop
     end
 
     def patterns_to_include
-      for_all_cops['Include']
+      include_only_explicitly? ? include_only : for_all_cops['Include']
+    end
+
+    def include_only_explicitly?
+      include_only.any?
     end
 
     def patterns_to_exclude
@@ -453,6 +457,10 @@ module RuboCop
     end
 
     private
+
+    def include_only
+      for_all_cops['IncludeOnly'] || []
+    end
 
     def warn_about_unrecognized_cops(invalid_cop_names)
       invalid_cop_names.each do |name|

--- a/lib/rubocop/target_finder.rb
+++ b/lib/rubocop/target_finder.rb
@@ -128,7 +128,8 @@ module RuboCop
 
     def to_inspect?(file, hidden_files, base_dir_config)
       return false if base_dir_config.file_to_exclude?(file)
-      return true if !hidden_files.include?(file) && ruby_file?(file)
+      return true if !hidden_files.include?(file) && ruby_file?(file) &&
+                     !base_dir_config.include_only_explicitly?
       base_dir_config.file_to_include?(file)
     end
 

--- a/manual/configuration.md
+++ b/manual/configuration.md
@@ -199,7 +199,11 @@ Hidden directories (i.e., directories whose names start with a dot)
 are not searched by default.  If you'd like it to check files that are
 not included by default, you'll need to pass them in on the command
 line, or to add entries for them under `AllCops`/`Include`.  Files and
-directories can also be ignored through `AllCops`/`Exclude`.
+directories can also be ignored through `AllCops`/`Exclude`. The
+parameter `AllCops`/`IncludeOnly` is an empty list in default
+configuration. If you override it locally, RuboCop will only inspect
+files matching the given list of patterns and not include any files by
+default.
 
 Here is an example that might be used for a Rails project:
 

--- a/spec/rubocop/target_finder_spec.rb
+++ b/spec/rubocop/target_finder_spec.rb
@@ -268,6 +268,7 @@ RSpec.describe RuboCop::TargetFinder, :isolated_environment do
 
     it 'picks files specified to be included in config' do
       config = double('config')
+      allow(config).to receive(:include_only_explicitly?).and_return(false)
       allow(config).to receive(:file_to_include?) do |file|
         File.basename(file) == 'file'
       end


### PR DESCRIPTION
This feature makes it possible to add RuboCop inspection slowly in a legacy project. Files and directories can be added for inspection incrementally.

It's an alternative or complement to the existing workflow of adding _cops_ one at a time using the `--auto-gen-config` feature.