### PR TITLE
[Fix #5809] Encoding bug in Lint/PercentStringArray and Lint/PercentSymbolArray

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * [#5784](https://github.com/bbatsov/rubocop/issues/5784): Fix a false positive for `Rails/HasManyOrHasOneDependent` when using nested `with_options`. ([@koic][])
 * [#4666](https://github.com/bbatsov/rubocop/issues/4666): `--stdin` always treats input as Ruby source irregardless of filename. ([@PointlessOne][])
 * [#5668](https://github.com/bbatsov/rubocop/issues/5668): Fix an issue where files with unknown extensions, listed in `AllCops/Include` were not inspected when passing the file name as an option. ([@drenmi][])
+* [#5809](https://github.com/bbatsov/rubocop/issues/5809): Fix exception `Lint/PercentStringArray` and `Lint/PercentSymbolArray` when the inspected file is binary encoded. ([@akhramov][])
 
 ### Changes
 

--- a/lib/rubocop/cop/lint/percent_string_array.rb
+++ b/lib/rubocop/cop/lint/percent_string_array.rb
@@ -62,7 +62,7 @@ module RuboCop
             literal = value.children.first.to_s.scrub
 
             # To avoid likely false positives (e.g. a single ' or ")
-            next if literal.gsub(/[^\p{Alnum}]/, '').empty?
+            next if literal.gsub(/[^[[:alnum:]]]/, '').empty?
 
             QUOTES_AND_COMMAS.any? { |pat| literal =~ pat }
           end

--- a/lib/rubocop/cop/lint/percent_symbol_array.rb
+++ b/lib/rubocop/cop/lint/percent_symbol_array.rb
@@ -55,7 +55,7 @@ module RuboCop
             literal = child.children.first
 
             # To avoid likely false positives (e.g. a single ' or ")
-            next if literal.to_s.gsub(/[^\p{Alnum}]/, '').empty?
+            next if literal.to_s.gsub(/[^[[:alnum:]]]/, '').empty?
 
             patterns.any? { |pat| literal =~ pat }
           end

--- a/spec/rubocop/cop/lint/percent_string_array_spec.rb
+++ b/spec/rubocop/cop/lint/percent_string_array_spec.rb
@@ -81,4 +81,23 @@ RSpec.describe RuboCop::Cop::Lint::PercentStringArray do
       expect_no_offenses('%W(\255)')
     end
   end
+
+  context 'with binary encoded source' do
+    it 'adds an offense if tokens contain quotes' do
+      expect_offense(<<-RUBY.b.strip_indent)
+        # encoding: BINARY
+
+        %W[\xC0 "foo"]
+        ^^^^^^^^^^^ Within `%w`/`%W`, quotes and ',' are unnecessary and may be unwanted in the resulting strings.
+      RUBY
+    end
+
+    it 'accepts if tokens contain no quotes' do
+      expect_no_offenses(<<-RUBY.b.strip_indent)
+        # encoding: BINARY
+
+        %W[\xC0 \xC1]
+      RUBY
+    end
+  end
 end

--- a/spec/rubocop/cop/lint/percent_symbol_array_spec.rb
+++ b/spec/rubocop/cop/lint/percent_symbol_array_spec.rb
@@ -34,6 +34,24 @@ RSpec.describe RuboCop::Cop::Lint::PercentSymbolArray do
         RUBY
       end
     end
+    context 'with binary encoded source' do
+      it 'adds an offense if tokens contain quotes' do
+        expect_offense(<<-RUBY.b.strip_indent)
+          # encoding: BINARY
+
+          %i[\xC0 :foo]
+          ^^^^^^^^^^ Within `%i`/`%I`, ':' and ',' are unnecessary and may be unwanted in the resulting symbols.
+        RUBY
+      end
+
+      it 'accepts if tokens contain no quotes' do
+        expect_no_offenses(<<-RUBY.b.strip_indent)
+          # encoding: BINARY
+
+          %i[\xC0 \xC1]
+        RUBY
+      end
+    end
   end
 
   context 'autocorrection' do


### PR DESCRIPTION
Both `Lint/PercentStringArray` and `Lint/PercentSymbolArray` cops use
regexps with fixed encoding. That makes them incompatible with ASCII
and cops failed with an error in some edge-cases. Please refer to
[documentation on Regexp class](http://ruby-doc.org/core-2.5.0/Regexp.html#class-Regexp-label-Encoding)
for further details.

This change converts regexp Character Properties to POSIX
brackets in order to have non-fixed encoding regexps.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
