### PR TITLE
Fix documentation typo

### DIFF
--- a/lib/rubocop/cop/layout/first_parameter_indentation.rb
+++ b/lib/rubocop/cop/layout/first_parameter_indentation.rb
@@ -4,8 +4,8 @@ module RuboCop
   module Cop
     module Layout
       # This cop checks the indentation of the first parameter in a method call.
-      # Parameters after the first one are checked by Style/AlignParameters, not
-      # by this cop.
+      # Parameters after the first one are checked by Layout/AlignParameters,
+      # not by this cop.
       #
       # @example
       #

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -1804,8 +1804,8 @@ Enabled by default | Supports autocorrection
 Enabled | Yes
 
 This cop checks the indentation of the first parameter in a method call.
-Parameters after the first one are checked by Style/AlignParameters, not
-by this cop.
+Parameters after the first one are checked by Layout/AlignParameters,
+not by this cop.
 
 ### Examples
 


### PR DESCRIPTION
Parameter indentation is checked by `Layout/AlignParameters`, not `Style/AlignParameters`. For reference, Layout cop files were moved from style dir to layout dir in d778a57b.