### PR TITLE
Move some cop options to config/default.yml

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -1640,6 +1640,14 @@ Rails/AssertNot:
   Include:
     - '**/test/**/*'
 
+Rails/Blank:
+  # Convert checks for `nil` or `empty?` to `blank?`
+  NilOrEmpty: true
+  # Convert usages of not `present?` to `blank?`
+  NotPresent: true
+  # Convert usages of `unless` `present?` to `if` `blank?`
+  UnlessPresent: true
+
 Rails/CreateTableWithTimestamps:
   Include:
     - db/migrate/*.rb
@@ -1717,6 +1725,14 @@ Rails/Output:
     - config/**/*.rb
     - db/**/*.rb
     - lib/**/*.rb
+
+Rails/Present:
+  # Convert checks for not `nil` and not `empty?` to `present?`
+  NotNilAndNotEmpty: true
+  # Convert usages of not `blank?` to `present?`
+  NotBlank: true
+  # Convert usages of `unless` `blank?` to `if` `present?`
+  UnlessBlank: true
 
 Rails/ReadWriteAttribute:
   Include:

--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -1112,12 +1112,6 @@ Rails/AssertNot:
 Rails/Blank:
   Description: 'Enforce using `blank?` and `present?`.'
   Enabled: true
-  # Convert checks for `nil` or `empty?` to `blank?`
-  NilOrEmpty: true
-  # Convert usages of not `present?` to `blank?`
-  NotPresent: true
-  # Convert usages of `unless` `present?` to `if` `blank?`
-  UnlessPresent: true
 
 Rails/CreateTableWithTimestamps:
   Description: >-
@@ -1226,12 +1220,6 @@ Rails/Presence:
 Rails/Present:
   Description: 'Enforce using `blank?` and `present?`.'
   Enabled: true
-  NotNilAndNotEmpty: true
-  # Convert checks for not `nil` and not `empty?` to `present?`
-  NotBlank: true
-  # Convert usages of not `blank?` to `present?`
-  UnlessBlank: true
-  # Convert usages of `unless` `blank?` to `if` `present?`
 
 Rails/ReadWriteAttribute:
   Description: >-


### PR DESCRIPTION
This commit is a change similar to #5271.

This commit unifies the setting place by moving those settings of `Rails/Blank` cop and `Rails/Present` cop from config/enabled.yml to config/default.yml.

Related PR #5854.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
