### PR TITLE
Don't concatenate method name and arguments in empty methods without method def parentheses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Bug fixes
 
+* Fix bug in `Style/EmptyMethod` which concatenated the method name and first argument if no method def parentheses are used. ([@thomasbrus][])
 * [#5819](https://github.com/bbatsov/rubocop/issues/5819): Fix `Rails/SaveBang` when using negated if. ([@Edouard-chin][])
 * [#5286](https://github.com/bbatsov/rubocop/issues/5286): Fix `Lint/SafeNavigationChain` not detecting chained operators after block. ([@Darhazer][])
 * Fix bug where `Lint/SafeNavigationConsistency` registers multiple offenses for the same method call. ([@rrosenblum][])
@@ -3351,3 +3352,4 @@
 [@PointlessOne]: https://github.com/PointlessOne
 [@JacobEvelyn]: https://github.com/JacobEvelyn
 [@shanecav84]: https://github.com/shanecav84
+[@thomasbrus]: https://github.com/thomasbrus

--- a/lib/rubocop/cop/style/empty_method.rb
+++ b/lib/rubocop/cop/style/empty_method.rb
@@ -73,10 +73,13 @@ module RuboCop
         end
 
         def corrected(node)
-          arguments = node.arguments? ? node.arguments.source : ''
-          scope     = node.receiver ? "#{node.receiver.source}." : ''
+          has_parentheses = parentheses?(node.arguments)
 
-          signature = [scope, node.method_name, arguments].join
+          arguments   = node.arguments? ? node.arguments.source : ''
+          extra_space = node.arguments? && !has_parentheses ? ' ' : ''
+          scope       = node.receiver ? "#{node.receiver.source}." : ''
+
+          signature = [scope, node.method_name, extra_space, arguments].join
 
           ["def #{signature}", 'end'].join(joint(node))
         end

--- a/spec/rubocop/cop/style/empty_method_spec.rb
+++ b/spec/rubocop/cop/style/empty_method_spec.rb
@@ -53,6 +53,11 @@ RSpec.describe RuboCop::Cop::Style::EmptyMethod, :config do
                       'def foo(bar, baz); end'
 
       it_behaves_like 'code with offense',
+                      ['def foo bar, baz',
+                       'end'].join("\n"),
+                      'def foo bar, baz; end'
+
+      it_behaves_like 'code with offense',
                       ['def foo',
                        '',
                        'end'].join("\n"),


### PR DESCRIPTION
So we had some (unconventional) code in our repository that was incorrectly corrected by `Style/EmptyMethod`:

Before:
```ruby
def some_method arg
end
```

After:
```ruby
def some_methodarg; end
```

Even with `Style/MethodDefParentheses` enabled, the end result was the same (I suppose because of the order in which they are applied). This PR adds an extra space between the method_name and arguments if necessary:

```ruby
def some_method arg; end
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/