### PR TITLE
[Fix #5862] Fix incorrect autocorrect `Lint/LiteralInInterpolation`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * [#5668](https://github.com/bbatsov/rubocop/issues/5668): Fix an issue where files with unknown extensions, listed in `AllCops/Include` were not inspected when passing the file name as an option. ([@drenmi][])
 * [#5809](https://github.com/bbatsov/rubocop/issues/5809): Fix exception `Lint/PercentStringArray` and `Lint/PercentSymbolArray` when the inspected file is binary encoded. ([@akhramov][])
 * [#5840](https://github.com/bbatsov/rubocop/issues/5840): Do not register an offense for methods that `nil` responds to in `Lint/SafeNavigationConsistency`. ([@rrosenblum][])
+* [#5862](https://github.com/bbatsov/rubocop/issues/5862): Fix an incorrect auto-correct for `Lint/LiteralInInterpolation` if contains numbers. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/lint/literal_in_interpolation.rb
+++ b/lib/rubocop/cop/lint/literal_in_interpolation.rb
@@ -50,6 +50,10 @@ module RuboCop
 
         def autocorrected_value(node)
           case node.type
+          when :int
+            node.children.last.to_i.to_s
+          when :float
+            node.children.last.to_f.to_s
           when :str
             node.children.last
           when :sym

--- a/spec/rubocop/cop/lint/literal_in_interpolation_spec.rb
+++ b/spec/rubocop/cop/lint/literal_in_interpolation_spec.rb
@@ -73,11 +73,12 @@ RSpec.describe RuboCop::Cop::Lint::LiteralInInterpolation do
 
   it_behaves_like('literal interpolation', 1)
   it_behaves_like('literal interpolation', -1)
-  it_behaves_like('literal interpolation', 1_123)
-  it_behaves_like('literal interpolation', 123_456_789_123_456_789)
-  it_behaves_like('literal interpolation', 1.2e-3)
-  it_behaves_like('literal interpolation', 0xaabb)
-  it_behaves_like('literal interpolation', 0o377)
+  it_behaves_like('literal interpolation', '1_123', '1123')
+  it_behaves_like('literal interpolation',
+                  '123_456_789_123_456_789', '123456789123456789')
+  it_behaves_like('literal interpolation', '1.2e-3', '0.0012')
+  it_behaves_like('literal interpolation', '0xaabb', '43707')
+  it_behaves_like('literal interpolation', '0o377', '255')
   it_behaves_like('literal interpolation', 2.0)
   it_behaves_like('literal interpolation', '[]', '[]')
   it_behaves_like('literal interpolation', '["a", "b"]', '[\"a\", \"b\"]')


### PR DESCRIPTION
Fixes #5862.

This PR fixes an incorrect auto-correct for `Lint/LiteralInInterpolation` if contains numbers.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
