### PR TITLE
Fix Style/CommandLiteral autocorrection when %x is not configured

### DIFF
--- a/lib/rubocop/cop/style/command_literal.rb
+++ b/lib/rubocop/cop/style/command_literal.rb
@@ -95,7 +95,7 @@ module RuboCop
           return if contains_backtick?(node)
 
           replacement = if backtick_literal?(node)
-                          ['%x', ''].zip(preferred_delimiters).map(&:join)
+                          ['%x', ''].zip(preferred_delimiter).map(&:join)
                         else
                           %w[` `]
                         end
@@ -169,9 +169,21 @@ module RuboCop
           node.loc.begin.source == '`'
         end
 
-        def preferred_delimiters
+        def preferred_delimiter
+          (command_delimiter || default_delimiter).split(//)
+        end
+
+        def command_delimiter
+          preferred_delimiters_config['%x']
+        end
+
+        def default_delimiter
+          preferred_delimiters_config['default']
+        end
+
+        def preferred_delimiters_config
           config.for_cop('Style/PercentLiteralDelimiters') \
-            ['PreferredDelimiters']['%x'].split(//)
+            ['PreferredDelimiters']
         end
       end
     end

--- a/spec/rubocop/cop/style/command_literal_spec.rb
+++ b/spec/rubocop/cop/style/command_literal_spec.rb
@@ -39,6 +39,30 @@ RSpec.describe RuboCop::Cop::Style::CommandLiteral, :config do
     end
   end
 
+  describe 'when PercentLiteralDelimiters only has a default' do
+    let(:cop_config) { { 'EnforcedStyle' => 'percent_x' } }
+    let(:percent_literal_delimiters_config) do
+      { 'PreferredDelimiters' => { 'default' => '()' } }
+    end
+
+    it 'respects the configuration when auto-correcting' do
+      new_source = autocorrect_source('`ls`')
+      expect(new_source).to eq('%x(ls)')
+    end
+  end
+
+  describe 'when PercentLiteralDelimiters is configured and a default exists' do
+    let(:cop_config) { { 'EnforcedStyle' => 'percent_x' } }
+    let(:percent_literal_delimiters_config) do
+      { 'PreferredDelimiters' => { '%x' => '[]', 'default' => '()' } }
+    end
+
+    it 'ignores the default when auto-correcting and' do
+      new_source = autocorrect_source('`ls`')
+      expect(new_source).to eq('%x[ls]')
+    end
+  end
+
   describe 'heredoc commands' do
     let(:cop_config) { { 'EnforcedStyle' => 'backticks' } }
 


### PR DESCRIPTION
It crashed with ``undefined method 'split' for nil:NilClass when`` PreferredDelimiters for %x was not configured. This commit changed the behavior to use the default PreferredDelimiters when %x does not exist.

I also added %x to the default.yml, however, not sure about if this change is desired! 

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/