### PR TITLE
Modify HttpPositionalArguments to use session instead of headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * [#5809](https://github.com/bbatsov/rubocop/issues/5809): Fix exception `Lint/PercentStringArray` and `Lint/PercentSymbolArray` when the inspected file is binary encoded. ([@akhramov][])
 * [#5840](https://github.com/bbatsov/rubocop/issues/5840): Do not register an offense for methods that `nil` responds to in `Lint/SafeNavigationConsistency`. ([@rrosenblum][])
 * [#5862](https://github.com/bbatsov/rubocop/issues/5862): Fix an incorrect auto-correct for `Lint/LiteralInInterpolation` if contains numbers. ([@koic][])
+* Fix auto-correction of `Rails/HttpPositionalArgumnets` to use `session` instead of `header`. ([@rrosenblum][])
 
 ### Changes
 

--- a/lib/rubocop/cop/rails/http_positional_arguments.rb
+++ b/lib/rubocop/cop/rails/http_positional_arguments.rb
@@ -22,7 +22,7 @@ module RuboCop
         MSG = 'Use keyword arguments instead of ' \
               'positional arguments for http call: `%<verb>s`.'.freeze
         KEYWORD_ARGS = %i[
-          headers env params body flash as xhr session method
+          method params session body flash xhr as
         ].freeze
         HTTP_METHODS = %i[get post put patch delete head].freeze
 
@@ -41,11 +41,11 @@ module RuboCop
           end
         end
 
-        # given a pre Rails 5 method: get :new, user_id: @user.id, {}
+        # given a pre Rails 5 method: get :new, {user_id: @user.id}, {}
         #
         # @return lambda of auto correct procedure
         # the result should look like:
-        #     get :new, params: { user_id: @user.id }, headers: {}
+        #     get :new, params: { user_id: @user.id }, session: {}
         # the http_method is the method used to call the controller
         # the controller node can be a symbol, method, object or string
         # that represents the path/action on the Rails controller
@@ -56,14 +56,14 @@ module RuboCop
 
           controller_action = http_path.source
           params = convert_hash_data(data.first, 'params')
-          headers = convert_hash_data(data.last, 'headers') if data.size > 1
+          session = convert_hash_data(data.last, 'session') if data.size > 1
           # the range of the text to replace, which is the whole line
           code_to_replace = node.loc.expression
           # what to replace with
           format = parentheses_format(node)
           new_code = format(format, name: node.method_name,
                                     action: controller_action,
-                                    params: params, headers: headers)
+                                    params: params, session: session)
           ->(corrector) { corrector.replace(code_to_replace, new_code) }
         end
 
@@ -103,9 +103,9 @@ module RuboCop
 
         def parentheses_format(node)
           if parentheses?(node)
-            '%<name>s(%<action>s%<params>s%<headers>s)'
+            '%<name>s(%<action>s%<params>s%<session>s)'
           else
-            '%<name>s %<action>s%<params>s%<headers>s'
+            '%<name>s %<action>s%<params>s%<session>s'
           end
         end
       end

--- a/spec/rubocop/cop/rails/http_positional_arguments_spec.rb
+++ b/spec/rubocop/cop/rails/http_positional_arguments_spec.rb
@@ -181,7 +181,7 @@ RSpec.describe RuboCop::Cop::Rails::HttpPositionalArguments do
       expect(new_source).to eq('get "/auth/linkedin/callback"')
     end
 
-    it 'does not add headers keyword when env or headers are used' do
+    it 'does not add session keyword when session is not used' do
       source = 'get some_path(profile.id), {},'
       source += " 'HTTP_REFERER' => p_url(p.id).to_s"
       new_source = autocorrect_source(source)
@@ -470,12 +470,12 @@ RSpec.describe RuboCop::Cop::Rails::HttpPositionalArguments do
       expect(new_source).to eq('get "/auth/linkedin/callback"')
     end
 
-    it 'does add headers keyword when env or headers are used' do
+    it 'does add session keyword when session is used' do
       source = 'get some_path(profile.id), {},'
       source += " 'HTTP_REFERER' => p_url(p.id).to_s"
       new_source = autocorrect_source(source)
       output = 'get some_path(profile.id),'
-      output += " headers: { 'HTTP_REFERER' => p_url(p.id).to_s }"
+      output += " session: { 'HTTP_REFERER' => p_url(p.id).to_s }"
       expect(new_source).to eq(output)
     end
 
@@ -486,7 +486,7 @@ RSpec.describe RuboCop::Cop::Rails::HttpPositionalArguments do
       new_source = autocorrect_source(source)
       output = 'get some_path(profile.id), params:'
       output += ' { user_id: @user.id, profile_id: p.id },'
-      output += " headers: { 'HTTP_REFERER' => p_url(p.id).to_s }"
+      output += " session: { 'HTTP_REFERER' => p_url(p.id).to_s }"
       expect(new_source).to eq(output)
     end
 

--- a/spec/rubocop/cop/rails/http_positional_arguments_spec.rb
+++ b/spec/rubocop/cop/rails/http_positional_arguments_spec.rb
@@ -4,6 +4,10 @@ RSpec.describe RuboCop::Cop::Rails::HttpPositionalArguments do
   context 'rails 4', :rails4, :config do
     subject(:cop) { described_class.new(config) }
 
+    it 'does not register an offense for get method' do
+      expect_no_offenses('get :create, user_id: @user.id')
+    end
+
     it 'does not register an offense for post method' do
       expect_no_offenses('post :create, user_id: @user.id')
     end
@@ -12,20 +16,22 @@ RSpec.describe RuboCop::Cop::Rails::HttpPositionalArguments do
       expect_no_offenses('patch :update, user_id: @user.id')
     end
 
+    it 'does not register an offense for put method' do
+      expect_no_offenses('put :update, user_id: @user.id')
+    end
+
     it 'does not register an offense for delete method' do
       expect_no_offenses('delete :destroy, id: @user.id')
     end
 
-    it 'accepts for not HTTP method' do
-      expect_no_offenses('puts :create, user_id: @user.id')
+    it 'does not register an offense for head method' do
+      expect_no_offenses('head :destroy, id: @user.id')
     end
 
-    describe 'when using process' do
-      it 'does not register an offense' do
-        expect_no_offenses(<<-RUBY.strip_indent)
-          process :new, method: :get, params: { user_id: @user.id }
-        RUBY
-      end
+    it 'does not register an offense for process method' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        process :new, method: :get, params: { user_id: @user.id }
+      RUBY
     end
 
     [
@@ -40,24 +46,14 @@ RSpec.describe RuboCop::Cop::Rails::HttpPositionalArguments do
         end
 
         it 'does not register an offense' do
-          inspect_source(source)
-          expect(cop.messages.empty?).to be(true)
+          expect_no_offenses(source)
         end
       end
     end
 
     describe '.get' do
-      let(:source) do
-        'get :new, user_id: @user.id'
-      end
-
       it 'does not register an offense' do
         expect_no_offenses('get :new, user_id: @user.id')
-      end
-
-      it 'does not auto-correct' do
-        new_source = autocorrect_source(source)
-        expect(new_source).to eq(source)
       end
 
       describe 'no params' do
@@ -68,212 +64,87 @@ RSpec.describe RuboCop::Cop::Rails::HttpPositionalArguments do
     end
 
     describe '.patch' do
-      let(:source) do
-        <<-RUBY.strip_indent
-        patch :update,
-                  id: @user.id,
-                  ac: {
-                    article_id: @article1.id,
-                    profile_id: @profile1.id,
-                    content: 'Some Text'
-                  }
-        RUBY
-      end
-
       it 'does not register an offense' do
         expect_no_offenses(<<-RUBY.strip_indent)
           patch :update,
-                    id: @user.id,
-                    ac: {
-                      article_id: @article1.id,
-                      profile_id: @profile1.id,
-                      content: 'Some Text'
-                    }
+                id: @user.id,
+                ac: {
+                  article_id: @article1.id,
+                  profile_id: @profile1.id,
+                  content: 'Some Text'
+                }
         RUBY
-      end
-
-      it 'does not auto-correct' do
-        new_source = autocorrect_source(source)
-        expect(new_source).to eq(source)
       end
     end
 
     describe '.post' do
-      let(:source) do
-        <<-RUBY.strip_indent
-        post :create,
-                  id: @user.id,
-                  ac: {
-                    article_id: @article1.id,
-                    profile_id: @profile1.id,
-                    content: 'Some Text'
-                  }
-        RUBY
-      end
-
       it 'does not register an offense' do
         expect_no_offenses(<<-RUBY.strip_indent)
           post :create,
-                    id: @user.id,
-                    ac: {
-                      article_id: @article1.id,
-                      profile_id: @profile1.id,
-                      content: 'Some Text'
-                    }
+               id: @user.id,
+               ac: {
+                 article_id: @article1.id,
+                 profile_id: @profile1.id,
+                 content: 'Some Text'
+               }
         RUBY
       end
+    end
 
-      it 'does not auto-correct' do
-        new_source = autocorrect_source(source)
-        expect(new_source).to eq(source)
+    %w[get post patch put head delete].each do |keyword|
+      it 'does not register an offense when keyword is used ' \
+        'in a chained method call' do
+        expect_no_offenses("@user.#{keyword}.id = ''")
       end
-    end
-
-    %w[post get patch put delete].each do |keyword|
-      it 'does not register an offense when keyword' do
-        source = "@user.#{keyword}.id = ''"
-        inspect_source(source)
-        expect(cop.offenses.size).to eq(0)
-      end
-    end
-
-    it 'does not auto-correct http action when method' do
-      source = 'post user_attrs, id: 1'
-      inspect_source(source)
-      expect(cop.offenses.size).to eq(0)
-      new_source = autocorrect_source(source)
-      expect(new_source).to eq(source)
-    end
-
-    it 'does not auto-correct http action when symbol' do
-      source = 'post :user_attrs, id: 1'
-      inspect_source(source)
-      expect(cop.offenses.size).to eq(0)
-      new_source = autocorrect_source(source)
-      expect(new_source).to eq(source)
-    end
-
-    it 'does not auto-correct' do
-      source = 'post(:user_attrs, id: 1)'
-      inspect_source(source)
-      expect(cop.offenses.size).to eq(0)
-      new_source = autocorrect_source(source)
-      expect(new_source).to eq(source)
-    end
-
-    it 'does not register when post is found' do
-      expect_no_offenses(<<-RUBY.strip_indent)
-        if post.stint_title.present?
-         true
-         end
-      RUBY
-    end
-
-    it 'does not remove quotes when single quoted' do
-      source = "get '/auth/linkedin/callback'"
-      new_source = autocorrect_source(source)
-      expect(new_source).to eq("get '/auth/linkedin/callback'")
-    end
-
-    it 'does not remove quotes when double quoted' do
-      source = 'get "/auth/linkedin/callback"'
-      new_source = autocorrect_source(source)
-      expect(new_source).to eq('get "/auth/linkedin/callback"')
-    end
-
-    it 'does not add session keyword when session is not used' do
-      source = 'get some_path(profile.id), {},'
-      source += " 'HTTP_REFERER' => p_url(p.id).to_s"
-      new_source = autocorrect_source(source)
-      expect(new_source).to eq(source)
-    end
-
-    it 'does not duplicate brackets when hash is already supplied' do
-      source = 'get some_path(profile.id), '
-      source += '{ user_id: @user.id, profile_id: p.id },'
-      source += " 'HTTP_REFERER' => p_url(p.id).to_s"
-      new_source = autocorrect_source(source)
-      expect(new_source).to eq(source)
-    end
-
-    it 'does not auto-correct http action when params is a method call' do
-      source = 'post :create, confirmation_data'
-      inspect_source(source)
-      expect(cop.offenses.size).to eq(0)
-      new_source = autocorrect_source(source)
-      expect(new_source).to eq(source)
-    end
-
-    it 'does not auto-correct http action when params and action names ' \
-      'are method calls' do
-      source = 'post user_attrs, params'
-      inspect_source(source)
-      expect(cop.offenses.size).to eq(0)
-      new_source = autocorrect_source(source)
-      expect(new_source).to eq(source)
-    end
-
-    # rubocop:disable LineLength
-    it 'does not auto-correct http action when parameter matches keyword name' do
-      source = 'post :create, id: 7, comment: { body: "hei" }'
-      inspect_source(source)
-      expect(cop.offenses.size).to eq(0)
-      new_source = autocorrect_source(source)
-      expect(new_source).to eq(source)
-    end
-
-    it 'does not auto-correct http action when format keyword included ' \
-      'but not alone' do
-      source = 'post :create, id: 7, format: :rss'
-      inspect_source(source)
-      expect(cop.offenses.size).to eq(0)
-      new_source = autocorrect_source(source)
-      expect(new_source).to eq(source)
-    end
-
-    it 'does not auto-correct when params is a lvar' do
-      source = <<-RUBY.strip_indent
-        params = { id: 1 }
-        post user_attrs, params
-      RUBY
-      inspect_source(source)
-      expect(cop.offenses.size).to eq(0)
-      new_source = autocorrect_source(source)
-      expect(new_source).to eq(source)
-    end
-
-    it 'does not auto-correct http action when params is a method call ' \
-      'with chain' do
-      source = 'post user_attrs, params.merge(foo: bar)'
-      inspect_source(source)
-      expect(cop.offenses.size).to eq(0)
-      new_source = autocorrect_source(source)
-      expect(new_source).to eq(source)
     end
   end
 
   context 'rails 5 and above', :rails5 do
     subject(:cop) { described_class.new }
 
+    it 'registers an offense for get method' do
+      expect_offense(<<-RUBY.strip_indent)
+        get :create, user_id: @user.id
+        ^^^ Use keyword arguments instead of positional arguments for http call: `get`.
+      RUBY
+    end
+
     it 'registers an offense for post method' do
-      source = 'post :create, user_id: @user.id'
-      inspect_source(source)
-      expect(cop.offenses.size).to eq(1)
+      expect_offense(<<-RUBY.strip_indent)
+        post :create, user_id: @user.id
+        ^^^^ Use keyword arguments instead of positional arguments for http call: `post`.
+      RUBY
     end
 
     it 'registers an offense for patch method' do
-      source = 'patch :update, user_id: @user.id'
-      inspect_source(source)
-      expect(cop.offenses.size).to eq(1)
+      expect_offense(<<-RUBY.strip_indent)
+        patch :update, user_id: @user.id
+        ^^^^^ Use keyword arguments instead of positional arguments for http call: `patch`.
+      RUBY
+    end
+
+    it 'registers an offense for put method' do
+      expect_offense(<<-RUBY.strip_indent)
+        put :create, user_id: @user.id
+        ^^^ Use keyword arguments instead of positional arguments for http call: `put`.
+      RUBY
     end
 
     it 'registers an offense for delete method' do
-      source = 'delete :destroy, id: @user.id'
-      inspect_source(source)
-      expect(cop.offenses.size).to eq(1)
+      expect_offense(<<-RUBY.strip_indent)
+        delete :create, user_id: @user.id
+        ^^^^^^ Use keyword arguments instead of positional arguments for http call: `delete`.
+      RUBY
     end
 
-    it 'accepts for not HTTP method' do
+    it 'registers an offense for head method' do
+      expect_offense(<<-RUBY.strip_indent)
+        head :create, user_id: @user.id
+        ^^^^ Use keyword arguments instead of positional arguments for http call: `head`.
+      RUBY
+    end
+
+    it 'accepts non HTTP methods' do
       expect_no_offenses('puts :create, user_id: @user.id')
     end
 
@@ -292,26 +163,13 @@ RSpec.describe RuboCop::Cop::Rails::HttpPositionalArguments do
       'format: :json'
     ].each do |keyword_args|
       describe "when using keyword args #{keyword_args}" do
-        let(:source) do
-          "get :new, #{keyword_args}"
-        end
-
         it 'does not register an offense' do
-          inspect_source(source)
-          expect(cop.messages.empty?).to be(true)
+          expect_no_offenses("get :new, #{keyword_args}")
         end
       end
     end
 
     describe '.get' do
-      let(:source) do
-        'get :new, user_id: @user.id'
-      end
-
-      let(:corrected_result) do
-        'get :new, params: { user_id: @user.id }'
-      end
-
       it 'registers an offense' do
         expect_offense(<<-RUBY.strip_indent)
           get :new, user_id: @user.id
@@ -320,8 +178,8 @@ RSpec.describe RuboCop::Cop::Rails::HttpPositionalArguments do
       end
 
       it 'autocorrects offense' do
-        new_source = autocorrect_source(source)
-        expect(new_source).to eq(corrected_result)
+        new_source = autocorrect_source('get :new, user_id: @user.id')
+        expect(new_source).to eq('get :new, params: { user_id: @user.id }')
       end
 
       describe 'no params' do
@@ -332,222 +190,146 @@ RSpec.describe RuboCop::Cop::Rails::HttpPositionalArguments do
     end
 
     describe '.patch' do
-      let(:source) do
-        <<-RUBY.strip_indent
-        patch :update,
-                  id: @user.id,
-                  ac: {
-                    article_id: @article1.id,
-                    profile_id: @profile1.id,
-                    content: 'Some Text'
-                  }
-        RUBY
-      end
-
-      let(:corrected_result) do
-        <<-RUBY.strip_indent
-        patch :update, params: { id: @user.id, ac: {
-                    article_id: @article1.id,
-                    profile_id: @profile1.id,
-                    content: 'Some Text'
-                  } }
-        RUBY
-      end
-
-      it 'registers an offense' do
-        expect_offense(<<-RUBY.strip_indent)
-          patch :update,
-          ^^^^^ Use keyword arguments instead of positional arguments for http call: `patch`.
-                    id: @user.id,
-                    ac: {
-                      article_id: @article1.id,
-                      profile_id: @profile1.id,
-                      content: 'Some Text'
-                    }
-        RUBY
-      end
-
       it 'autocorrects offense' do
-        new_source = autocorrect_source(source)
-        expect(new_source).to eq(corrected_result)
+        new_source = autocorrect_source(<<-RUBY.strip_indent)
+          patch :update,
+                id: @user.id,
+                ac: {
+                  article_id: @article1.id,
+                  profile_id: @profile1.id,
+                  content: 'Some Text'
+                }
+        RUBY
+
+        expect(new_source).to eq(<<-RUBY.strip_indent)
+          patch :update, params: { id: @user.id, ac: {
+                  article_id: @article1.id,
+                  profile_id: @profile1.id,
+                  content: 'Some Text'
+                } }
+        RUBY
       end
     end
 
     describe '.post' do
-      let(:source) do
-        <<-RUBY.strip_indent
-        post :create,
-                  id: @user.id,
-                  ac: {
-                    article_id: @article1.id,
-                    profile_id: @profile1.id,
-                    content: 'Some Text'
-                  }
-        RUBY
-      end
-
-      let(:corrected_result) do
-        <<-RUBY.strip_indent
-        post :create, params: { id: @user.id, ac: {
-                    article_id: @article1.id,
-                    profile_id: @profile1.id,
-                    content: 'Some Text'
-                  } }
-        RUBY
-      end
-
-      it 'registers an offense' do
-        expect_offense(<<-RUBY.strip_indent)
-          post :create,
-          ^^^^ Use keyword arguments instead of positional arguments for http call: `post`.
-                    id: @user.id,
-                    ac: {
-                      article_id: @article1.id,
-                      profile_id: @profile1.id,
-                      content: 'Some Text'
-                    }
-        RUBY
-      end
-
       it 'autocorrects offense' do
-        new_source = autocorrect_source(source)
-        expect(new_source).to eq(corrected_result)
+        new_source = autocorrect_source(<<-RUBY.strip_indent)
+          post :create,
+               id: @user.id,
+               ac: {
+                 article_id: @article1.id,
+                 profile_id: @profile1.id,
+                 content: 'Some Text'
+               }
+        RUBY
+
+        expect(new_source).to eq(<<-RUBY.strip_indent)
+        post :create, params: { id: @user.id, ac: {
+               article_id: @article1.id,
+               profile_id: @profile1.id,
+               content: 'Some Text'
+             } }
+        RUBY
       end
     end
 
-    %w[post get patch put delete].each do |keyword|
+    %w[head post get patch put delete].each do |keyword|
       it 'does not register an offense when keyword' do
-        source = "@user.#{keyword}.id = ''"
-        inspect_source(source)
-        expect(cop.offenses.size).to eq(0)
+        expect_no_offenses("@user.#{keyword}.id = ''")
       end
     end
 
     it 'auto-corrects http action when method' do
-      source = 'post user_attrs, id: 1'
-      inspect_source(source)
-      expect(cop.offenses.size).to eq(1)
-      new_source = autocorrect_source(source)
-      expected = 'post user_attrs, params: { id: 1 }'
-      expect(new_source).to eq(expected)
+      new_source = autocorrect_source('post user_attrs, id: 1')
+      expect(new_source).to eq('post user_attrs, params: { id: 1 }')
     end
 
     it 'auto-corrects http action when symbol' do
-      source = 'post :user_attrs, id: 1'
-      inspect_source(source)
-      expect(cop.offenses.size).to eq(1)
-      new_source = autocorrect_source(source)
-      expected = 'post :user_attrs, params: { id: 1 }'
-      expect(new_source).to eq(expected)
+      new_source = autocorrect_source('post :user_attrs, id: 1')
+      expect(new_source).to eq('post :user_attrs, params: { id: 1 }')
     end
 
-    it 'maintains parentheses in auto-correcting' do
-      source = 'post(:user_attrs, id: 1)'
-      inspect_source(source)
-      expect(cop.offenses.size).to eq(1)
-      new_source = autocorrect_source(source)
-      expected = 'post(:user_attrs, params: { id: 1 })'
-      expect(new_source).to eq(expected)
+    it 'maintains parentheses when auto-correcting' do
+      new_source = autocorrect_source('post(:user_attrs, id: 1)')
+      expect(new_source).to eq('post(:user_attrs, params: { id: 1 })')
     end
 
-    it 'does not register when post is found' do
-      expect_no_offenses(<<-RUBY.strip_indent)
-        if post.stint_title.present?
-         true
-         end
+    it 'maintains quotes when auto-correcting' do
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
+        get '/auth/linkedin/callback', id: 1
       RUBY
-    end
-
-    it 'does not remove quotes when single quoted' do
-      source = "get '/auth/linkedin/callback'"
-      new_source = autocorrect_source(source)
-      expect(new_source).to eq("get '/auth/linkedin/callback'")
-    end
-
-    it 'does not remove quotes when double quoted' do
-      source = 'get "/auth/linkedin/callback"'
-      new_source = autocorrect_source(source)
-      expect(new_source).to eq('get "/auth/linkedin/callback"')
+      expect(new_source).to eq(<<-RUBY.strip_indent)
+        get '/auth/linkedin/callback', params: { id: 1 }
+      RUBY
     end
 
     it 'does add session keyword when session is used' do
-      source = 'get some_path(profile.id), {},'
-      source += " 'HTTP_REFERER' => p_url(p.id).to_s"
-      new_source = autocorrect_source(source)
-      output = 'get some_path(profile.id),'
-      output += " session: { 'HTTP_REFERER' => p_url(p.id).to_s }"
-      expect(new_source).to eq(output)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
+        get some_path(profile.id), {}, 'HTTP_REFERER' => p_url(p.id).to_s
+      RUBY
+
+      expect(new_source).to eq(<<-RUBY.strip_indent)
+        get some_path(profile.id), session: { 'HTTP_REFERER' => p_url(p.id).to_s }
+      RUBY
     end
 
     it 'does not duplicate brackets when hash is already supplied' do
-      source = 'get some_path(profile.id), '
-      source += '{ user_id: @user.id, profile_id: p.id },'
-      source += " 'HTTP_REFERER' => p_url(p.id).to_s"
-      new_source = autocorrect_source(source)
-      output = 'get some_path(profile.id), params:'
-      output += ' { user_id: @user.id, profile_id: p.id },'
-      output += " session: { 'HTTP_REFERER' => p_url(p.id).to_s }"
-      expect(new_source).to eq(output)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
+        get some_path(profile.id), { user_id: @user.id, profile_id: p.id }, 'HTTP_REFERER' => p_url(p.id).to_s
+      RUBY
+
+      expect(new_source).to eq(<<-RUBY.strip_indent)
+        get some_path(profile.id), params: { user_id: @user.id, profile_id: p.id }, session: { 'HTTP_REFERER' => p_url(p.id).to_s }
+      RUBY
     end
 
     it 'auto-corrects http action when params is a method call' do
-      source = 'post :create, confirmation_data'
-      inspect_source(source)
-      expect(cop.offenses.size).to eq(1)
-      new_source = autocorrect_source(source)
-      output = 'post :create, params: confirmation_data'
-      expect(new_source).to eq(output)
+      new_source = autocorrect_source('post :create, confirmation_data')
+      expect(new_source).to eq('post :create, params: confirmation_data')
     end
 
-    it 'auto-corrects http action when parameter matches special keyword name' do
-      source = 'post :create, id: 7, comment: { body: "hei" }'
-      inspect_source(source)
-      expect(cop.offenses.size).to eq(1)
-      new_source = autocorrect_source(source)
-      output = 'post :create, params: { id: 7, comment: { body: "hei" } }'
-      expect(new_source).to eq(output)
+    it 'auto-corrects http action when parameter matches ' \
+      'special keyword name' do
+      new_source = autocorrect_source(<<-RUBY)
+        post :create, id: 7, comment: { body: "hei" }
+      RUBY
+
+      expect(new_source).to eq(<<-RUBY)
+        post :create, params: { id: 7, comment: { body: "hei" } }
+      RUBY
     end
 
     it 'auto-corrects http action when format keyword included but not alone' do
-      source = 'post :create, id: 7, format: :rss'
-      inspect_source(source)
-      expect(cop.offenses.size).to eq(1)
-      new_source = autocorrect_source(source)
-      output = 'post :create, params: { id: 7, format: :rss }'
-      expect(new_source).to eq(output)
+      new_source = autocorrect_source('post :create, id: 7, format: :rss')
+      expect(new_source).to eq('post :create, params: { id: 7, format: :rss }')
     end
 
     it 'auto-corrects http action when params is a lvar' do
-      source = <<-RUBY.strip_indent
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         params = { id: 1 }
         post user_attrs, params
       RUBY
-      inspect_source(source)
-      expect(cop.offenses.size).to eq(1)
-      new_source = autocorrect_source(source)
+
       expect(new_source).to eq(<<-RUBY.strip_indent)
         params = { id: 1 }
         post user_attrs, params: params
       RUBY
     end
 
-    it 'auto-corrects http action when params and action name are method calls' do
-      source = 'post user_attrs, params'
-      inspect_source(source)
-      expect(cop.offenses.size).to eq(1)
-      new_source = autocorrect_source(source)
-      expected = 'post user_attrs, params: params'
-      expect(new_source).to eq(expected)
+    it 'auto-corrects http action when params and action name ' \
+      'are method calls' do
+      new_source = autocorrect_source('post user_attrs, params')
+      expect(new_source).to eq('post user_attrs, params: params')
     end
 
     it 'auto-corrects http action when params is a method call with chain' do
-      source = 'post user_attrs, params.merge(foo: bar)'
-      inspect_source(source)
-      expect(cop.offenses.size).to eq(1)
-      new_source = autocorrect_source(source)
-      expected = 'post user_attrs, params: params.merge(foo: bar)'
-      expect(new_source).to eq(expected)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
+        post user_attrs, params.merge(foo: bar)
+      RUBY
+
+      expect(new_source).to eq(<<-RUBY.strip_indent)
+        post user_attrs, params: params.merge(foo: bar)
+      RUBY
     end
   end
 end
-# rubocop:enable LineLength


### PR DESCRIPTION
I have been working on upgrading a Rails project and started getting errors about `headers` not being a valid keyword argument. It looks like `session`is supposed to be used.

https://github.com/rails/rails/blob/master/actionpack/lib/action_controller/test_case.rb#L460