### PR TITLE
Clarify GitHub account displayed by `rake new_cop`

### DIFF
--- a/lib/rubocop/cop/generator.rb
+++ b/lib/rubocop/cop/generator.rb
@@ -98,8 +98,9 @@ module RuboCop
         end
       SPEC
 
-      def initialize(name, output: $stdout)
+      def initialize(name, github_user, output: $stdout)
         @badge = Badge.parse(name)
+        @github_user = github_user
         @output = output
         return if badge.qualified?
 
@@ -145,7 +146,7 @@ module RuboCop
         <<-TODO.strip_indent
           Do 3 steps:
             1. Add an entry to the "New features" section in CHANGELOG.md,
-               e.g. "Add new `#{badge}` cop. ([@your_id][])"
+               e.g. "Add new `#{badge}` cop. ([@#{github_user}][])"
             2. Modify the description of #{badge} in config/enabled.yml
             3. Implement your new cop in the generated file!
         TODO
@@ -153,7 +154,7 @@ module RuboCop
 
       private
 
-      attr_reader :badge, :output
+      attr_reader :badge, :github_user, :output
 
       def write_unless_file_exists(path, contents)
         if File.exist?(path)

--- a/spec/rubocop/cop/generator_spec.rb
+++ b/spec/rubocop/cop/generator_spec.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Generator do
-  subject(:generator) { described_class.new(cop_identifier, output: stdout) }
+  subject(:generator) do
+    described_class.new(cop_identifier, 'your_id', output: stdout)
+  end
 
   let(:stdout) { StringIO.new }
   let(:cop_identifier) { 'Style/FakeCop' }
@@ -87,7 +89,7 @@ RSpec.describe RuboCop::Cop::Generator do
     end
 
     it 'refuses to overwrite existing files' do
-      new_cop = described_class.new('Layout/Tab')
+      new_cop = described_class.new('Layout/Tab', 'your_id')
 
       expect(new_cop).to receive(:exit!)
       expect { new_cop.write_source }
@@ -133,7 +135,7 @@ RSpec.describe RuboCop::Cop::Generator do
     end
 
     it 'refuses to overwrite existing files' do
-      new_cop = described_class.new('Layout/Tab')
+      new_cop = described_class.new('Layout/Tab', 'your_id')
 
       expect(new_cop).to receive(:exit!)
       expect { new_cop.write_spec }
@@ -157,7 +159,7 @@ RSpec.describe RuboCop::Cop::Generator do
 
   describe '.new' do
     it 'does not accept an unqualified cop' do
-      expect { described_class.new('FakeCop') }
+      expect { described_class.new('FakeCop', 'your_id') }
         .to raise_error(ArgumentError)
         .with_message('Specify a cop name with Department/Name style')
     end

--- a/tasks/new_cop.rake
+++ b/tasks/new_cop.rake
@@ -9,7 +9,10 @@ task :new_cop, [:cop] do |_task, args|
     exit!
   end
 
-  generator = RuboCop::Cop::Generator.new(cop_name)
+  github_user = `git config github.user`.chop
+  github_user = 'your_id' if github_user.empty?
+
+  generator = RuboCop::Cop::Generator.new(cop_name, github_user)
 
   generator.write_source
   generator.write_spec


### PR DESCRIPTION
If GitHub account name in .gitconfig is given, it will be used when running `rake new_cop`.

For example, I have the following setting in my .gitconfig.

```
[github]
        user = koic
```

Below is the difference of execution result by this patch.

```diff
 % bundle exec rake new_cop[Department/Name]
 [create] lib/rubocop/cop/department/name.rb
 [create] spec/rubocop/cop/department/name_spec.rb
 [modify] A configuration for the cop is added into config/enabled.yml.
          If you want to disable the cop by default, move the added
          config to config/disabled.yml
 Do 3 steps:
   1. Add an entry to the "New features" section in CHANGELOG.md,
-     e.g. "Add new `Department/Name` cop. ([@your_id][])"
+     e.g. "Add new `Department/Name` cop. ([@koic][])"
   2. Modify the description of Department/Name in config/enabled.yml
   3. Implement your new cop in the generated file!
```

If GitHub account name in .gitconfig isn't given, `@your_id` will be used as before.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
