### PR TITLE
Remove unneeded `comment_on_line?` check

### DIFF
--- a/lib/rubocop/cop/style/braces_around_hash_parameters.rb
+++ b/lib/rubocop/cop/style/braces_around_hash_parameters.rb
@@ -126,13 +126,10 @@ module RuboCop
           end
         end
 
-        # rubocop:disable Metrics/AbcSize
         def remove_braces_with_whitespace(corrector, node, space)
           right_brace_and_space = right_brace_and_space(node.loc.end, space)
 
-          if processed_source.comment_on_line?(right_brace_and_space.line)
-            remove_braces(corrector, node)
-          elsif node.multiline?
+          if node.multiline?
             remove_braces_with_range(corrector,
                                      left_whole_line_range(node.loc.begin),
                                      right_whole_line_range(node.loc.end))
@@ -143,7 +140,6 @@ module RuboCop
                                      right_brace_and_space)
           end
         end
-        # rubocop:enable Metrics/AbcSize
 
         def remove_braces_with_range(corrector, left_range, right_range)
           corrector.remove(left_range)
@@ -182,11 +178,6 @@ module RuboCop
               whitespace: space[:right]
             )
           range_with_surrounding_comma(brace_and_space, :left)
-        end
-
-        def remove_braces(corrector, node)
-          corrector.remove(node.loc.begin)
-          corrector.remove(node.loc.end)
         end
 
         def add_braces(corrector, node)

--- a/lib/rubocop/processed_source.rb
+++ b/lib/rubocop/processed_source.rb
@@ -106,10 +106,6 @@ module RuboCop
       comment_lines.include?(source_range.line)
     end
 
-    def comment_on_line?(line)
-      comments.any? { |c| c.loc.line == line }
-    end
-
     def comments_before_line(line)
       comments.select { |c| c.location.line <= line }
     end

--- a/spec/rubocop/processed_source_spec.rb
+++ b/spec/rubocop/processed_source_spec.rb
@@ -255,18 +255,6 @@ RSpec.describe RuboCop::ProcessedSource do
       end
     end
 
-    describe '#comment_on_line?' do
-      it 'returns true when passed line number with comment' do
-        expect(processed_source.comment_on_line?(1)).to be true
-        expect(processed_source.comment_on_line?(2)).to be true
-        expect(processed_source.comment_on_line?(3)).to be true
-      end
-
-      it 'returns false when passed line number without comment' do
-        expect(processed_source.comment_on_line?(4)).to be false
-      end
-    end
-
     describe '#commented?' do
       let(:source) { <<-RUBY.strip_indent }
         # comment


### PR DESCRIPTION
This code seems not to be used after e7dc7418fce719883efaec075cad8c038a28810c.

cc @garettarrowood.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
