### PR TITLE
Remove unused method from NestedPercentLiteral

### DIFF
--- a/lib/rubocop/cop/lint/nested_percent_literal.rb
+++ b/lib/rubocop/cop/lint/nested_percent_literal.rb
@@ -38,14 +38,6 @@ module RuboCop
 
         private
 
-        def str_content(node)
-          if node.str_type?
-            node.children[0]
-          else
-            node.children.map { |c| str_content(c) }.join
-          end
-        end
-
         def contains_percent_literals?(node)
           node.each_child_node.any? do |child|
             literal = child.children.first.to_s.scrub


### PR DESCRIPTION
The `NestedPercentLiteral.str_content` method seems to never have been used. It’s a verbatim copy of `ImplicitStringConcatenation.str_content` so my guess is it was copied by accident.

cc @asherkach re. #4712.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
