### PR TITLE
Fix bug in the examples of NodePattern documentation

### DIFF
--- a/lib/rubocop/node_pattern.rb
+++ b/lib/rubocop/node_pattern.rb
@@ -74,7 +74,7 @@ module RuboCop
   # You can nest arbitrarily deep:
   #
   #     # matches node parsed from 'Const = Class.new' or 'Const = Module.new':
-  #     '(casgn nil? const (send (const nil? {:Class :Module}) :new)))'
+  #     '(casgn nil? :Const (send (const nil? {:Class :Module}) :new))'
   #     # matches a node parsed from an 'if', with a '==' comparison,
   #     # and no 'else' branch:
   #     '(if (send _ :== _) _ nil?)'


### PR DESCRIPTION
From the examples of [Node Pattern's doc](https://www.rubydoc.info/gems/rubocop/RuboCop/NodePattern):
```ruby
# matches node parsed from 'Const = Class.new' or 'Const = Module.new':
'(casgn nil? const (send (const nil? {:Class :Module}) :new)))'
```
the matcher is incorrect, so I change it to
```ruby
'(casgn nil? :Const (send (const nil? {:Class :Module}) :new))'
```

-----------------


* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
