### PR TITLE
[Fix #4247] Make all file inclusion lists configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [#5821](https://github.com/bbatsov/rubocop/pull/5821): Support `AR::Migration#up_only` for `Rails/ReversibleMigration` cop. ([@koic][])
 * [#5800](https://github.com/bbatsov/rubocop/issues/5800): Don't show a stracktrace for invalid command-line params. ([@shanecav84][])
 * [#5845](https://github.com/bbatsov/rubocop/pull/5845): Add new `Lint/ErbNewArguments` cop. ([@koic][])
+* [#4247](https://github.com/bbatsov/rubocop/issues/4247): Remove hard-coded file patterns and use only `Include`, `Exclude` and the new `RubyInterpreters` parameters for file selection. ([@jonas054][])
 
 ### Bug fixes
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -7,8 +7,15 @@ inherit_from:
 
 # Common configuration.
 AllCops:
+  RubyInterpreters:
+    - ruby
+    - macruby
+    - rake
+    - jruby
+    - rbx
   # Include common Ruby source files.
   Include:
+    - '**/*.rb'
     - '**/*.arb'
     - '**/*.axlsx'
     - '**/*.builder'

--- a/lib/rubocop/target_finder.rb
+++ b/lib/rubocop/target_finder.rb
@@ -3,61 +3,6 @@
 require 'set'
 
 module RuboCop
-  RUBY_EXTENSIONS = %w[.rb
-                       .arb
-                       .axlsx
-                       .builder
-                       .fcgi
-                       .gemfile
-                       .gemspec
-                       .god
-                       .jb
-                       .jbuilder
-                       .mspec
-                       .opal
-                       .pluginspec
-                       .podspec
-                       .rabl
-                       .rake
-                       .rbuild
-                       .rbw
-                       .rbx
-                       .ru
-                       .ruby
-                       .spec
-                       .thor
-                       .watchr].freeze
-
-  RUBY_INTERPRETERS = %w[ruby
-                         macruby
-                         rake
-                         jruby
-                         rbx].freeze
-
-  RUBY_FILENAMES = %w[.irbrc
-                      .pryrc
-                      Appraisals
-                      Berksfile
-                      Brewfile
-                      Buildfile
-                      Capfile
-                      Cheffile
-                      Dangerfile
-                      Deliverfile
-                      Fastfile
-                      Gemfile
-                      Guardfile
-                      Jarfile
-                      Mavenfile
-                      Podfile
-                      Puppetfile
-                      Rakefile
-                      Snapfile
-                      Thorfile
-                      Vagabondfile
-                      Vagrantfile
-                      buildfile].freeze
-
   # This class finds target files to inspect by scanning the directory tree
   # and picking ruby files.
   class TargetFinder
@@ -169,20 +114,42 @@ module RuboCop
     end
 
     def ruby_extension?(file)
-      RUBY_EXTENSIONS.include?(File.extname(file))
+      ruby_extensions.include?(File.extname(file))
+    end
+
+    def ruby_extensions
+      ext_patterns = all_cops_include.select do |pattern|
+        pattern.start_with?('**/*.')
+      end
+      ext_patterns.map { |pattern| pattern.sub('**/*', '') }
     end
 
     def ruby_filename?(file)
-      RUBY_FILENAMES.include?(File.basename(file))
+      ruby_filenames.include?(File.basename(file))
+    end
+
+    def ruby_filenames
+      file_patterns = all_cops_include.reject do |pattern|
+        pattern.start_with?('**/*.')
+      end
+      file_patterns.map { |pattern| pattern.sub('**/', '') }
+    end
+
+    def all_cops_include
+      @config_store.for('.').for_all_cops['Include'].map(&:to_s)
     end
 
     def ruby_executable?(file)
       return false unless File.extname(file).empty? && File.exist?(file)
       first_line = File.open(file, &:readline)
-      !(first_line =~ /#!.*(#{RUBY_INTERPRETERS.join('|')})/).nil?
+      !(first_line =~ /#!.*(#{ruby_interpreters(file).join('|')})/).nil?
     rescue EOFError, ArgumentError => e
       warn "Unprocessable file #{file}: #{e.class}, #{e.message}" if debug?
       false
+    end
+
+    def ruby_interpreters(file)
+      @config_store.for(file).for_all_cops['RubyInterpreters']
     end
 
     def stdin?
@@ -195,7 +162,7 @@ module RuboCop
     end
 
     def configured_include?(file)
-      @config_store.for(file).file_to_include?(file)
+      @config_store.for('.').file_to_include?(file)
     end
 
     def included_file?(file)

--- a/manual/configuration.md
+++ b/manual/configuration.md
@@ -191,23 +191,22 @@ directory, `config/default.yml` will be used.
 
 ### Including/Excluding files
 
-RuboCop checks all files found by a recursive search starting from the
-directory it is run in, or directories given as command line
-arguments.  However, it only recognizes files ending with `.rb` or
-extensionless files with a `#!.*ruby` declaration as Ruby files.
-Hidden directories (i.e., directories whose names start with a dot)
-are not searched by default.  If you'd like it to check files that are
-not included by default, you'll need to pass them in on the command
-line, or to add entries for them under `AllCops`/`Include`.  Files and
-directories can also be ignored through `AllCops`/`Exclude`.
+RuboCop does a recursive file search starting from the directory it is
+run in, or directories given as command line arguments.  Files that
+match any pattern listed under `AllCops`/`Include` and extensionless
+files with a hash-bang (`#!`) declaration containing one of the known
+ruby interpreters listed under `AllCops`/`RubyInterpreters` are
+inspected, unless the file also matches a pattern in
+`AllCops`/`Exclude`. Hidden directories (i.e., directories whose names
+start with a dot) are not searched by default.  If you'd like RuboCop
+to check files that are not included by default, you'll need to pass
+them in on the command line, or to add entries for them under
+`AllCops`/`Include`.
 
 Here is an example that might be used for a Rails project:
 
 ```yaml
 AllCops:
-  Include:
-    - '**/Rakefile'
-    - '**/config.ru'
   Exclude:
     - 'db/**/*'
     - 'config/**/*'

--- a/spec/rubocop/cli/cli_options_spec.rb
+++ b/spec/rubocop/cli/cli_options_spec.rb
@@ -88,6 +88,8 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
               Exclude:
                 - Gemfile
               Include:
+                - "**/*.rb"
+                - "**/*.rabl"
                 - "**/*.rabl2"
           YAML
         end

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -970,6 +970,7 @@ RSpec.describe RuboCop::CLI, :isolated_environment do
         AllCops:
           Include:
             - example
+            - "**/*.rb"
             - "**/*.rake"
             - !ruby/regexp /regexp$/
             - .dot1/**/*

--- a/spec/rubocop/target_finder_spec.rb
+++ b/spec/rubocop/target_finder_spec.rb
@@ -3,6 +3,61 @@
 RSpec.describe RuboCop::TargetFinder, :isolated_environment do
   include FileHelper
 
+  RUBY_EXTENSIONS = %w[.rb
+                       .arb
+                       .axlsx
+                       .builder
+                       .fcgi
+                       .gemfile
+                       .gemspec
+                       .god
+                       .jb
+                       .jbuilder
+                       .mspec
+                       .opal
+                       .pluginspec
+                       .podspec
+                       .rabl
+                       .rake
+                       .rbuild
+                       .rbw
+                       .rbx
+                       .ru
+                       .ruby
+                       .spec
+                       .thor
+                       .watchr].freeze
+
+  RUBY_INTERPRETERS = %w[ruby
+                         macruby
+                         rake
+                         jruby
+                         rbx].freeze
+
+  RUBY_FILENAMES = %w[.irbrc
+                      .pryrc
+                      Appraisals
+                      Berksfile
+                      Brewfile
+                      Buildfile
+                      Capfile
+                      Cheffile
+                      Dangerfile
+                      Deliverfile
+                      Fastfile
+                      Gemfile
+                      Guardfile
+                      Jarfile
+                      Mavenfile
+                      Podfile
+                      Puppetfile
+                      Rakefile
+                      Snapfile
+                      Thorfile
+                      Vagabondfile
+                      Vagrantfile
+                      buildfile].freeze
+
   subject(:target_finder) do
     described_class.new(config_store, options)
   end
@@ -13,12 +68,13 @@ RSpec.describe RuboCop::TargetFinder, :isolated_environment do
   let(:debug) { false }
 
   before do
-    create_file('dir1/ruby1.rb',   '# encoding: utf-8')
-    create_file('dir1/ruby2.rb',   '# encoding: utf-8')
-    create_file('dir1/file.txt',   '# encoding: utf-8')
-    create_file('dir1/file',       '# encoding: utf-8')
-    create_file('dir1/executable', '#!/usr/bin/env ruby')
-    create_file('dir2/ruby3.rb',   '# encoding: utf-8')
+    create_file('dir1/ruby1.rb',    '# encoding: utf-8')
+    create_file('dir1/ruby2.rb',    '# encoding: utf-8')
+    create_file('dir1/file.txt',    '# encoding: utf-8')
+    create_file('dir1/file',        '# encoding: utf-8')
+    create_file('dir1/executable',  '#!/usr/bin/env ruby')
+    create_file('dir2/ruby3.rb',    '# encoding: utf-8')
+    create_file('.hidden/ruby4.rb', '# encoding: utf-8')
   end
 
   describe '#find' do
@@ -31,6 +87,10 @@ RSpec.describe RuboCop::TargetFinder, :isolated_environment do
       found_files.each do |file|
         expect(file.sub(/^[A-Z]:/, '')).to start_with('/')
       end
+    end
+
+    it 'does not find hidden files' do
+      expect(found_files).not_to include('.hidden/ruby4.rb')
     end
 
     context 'when no argument is passed' do
@@ -61,6 +121,15 @@ RSpec.describe RuboCop::TargetFinder, :isolated_environment do
       end
     end
 
+    context 'when a hidden directory path is passed' do
+      let(:args) { ['.hidden'] }
+
+      it 'finds files under the specified directory' do
+        expect(found_files.size).to be(1)
+        expect(found_files.first).to include('.hidden/ruby4.rb')
+      end
+    end
+
     context 'when a non-ruby file is passed' do
       let(:args) { ['dir2/file'] }
 
@@ -70,34 +139,64 @@ RSpec.describe RuboCop::TargetFinder, :isolated_environment do
     end
 
     context 'when files with a ruby extension are passed' do
-      let(:args) { RuboCop::RUBY_EXTENSIONS.map { |ext| "dir2/file#{ext}" } }
+      let(:args) { RUBY_EXTENSIONS.map { |ext| "dir2/file#{ext}" } }
 
       it 'picks all the ruby files' do
-        expect(found_basenames).to eq(
-          RuboCop::RUBY_EXTENSIONS.map { |ext| "file#{ext}" }
-        )
+        expect(found_basenames)
+          .to eq(RUBY_EXTENSIONS.map { |ext| "file#{ext}" })
+      end
+
+      context 'when local AllCops/Include lists two patterns' do
+        before do
+          create_file('.rubocop.yml', <<-YAML)
+            AllCops:
+              Include:
+                - '**/*.rb'
+                - '**/*.arb'
+          YAML
+        end
+
+        it 'picks two files' do
+          expect(found_basenames).to eq(%w[file.rb file.arb])
+        end
+
+        context 'when a subdirectory AllCops/Include only lists one pattern' do
+          before do
+            create_file('dir2/.rubocop.yml', <<-YAML)
+              AllCops:
+                Include:
+                  - '**/*.ruby'
+            YAML
+          end
+
+          # Include and Exclude patterns are take from the top directory and
+          # settings in subdirectories are silently ignored.
+          it 'picks two files' do
+            expect(found_basenames).to eq(%w[file.rb file.arb])
+          end
+        end
       end
     end
 
     context 'when a file with a ruby filename is passed' do
-      let(:args) { RuboCop::RUBY_FILENAMES.map { |name| "dir2/#{name}" } }
+      let(:args) { RUBY_FILENAMES.map { |name| "dir2/#{name}" } }
 
       it 'picks all the ruby files' do
-        expect(found_basenames).to eq(RuboCop::RUBY_FILENAMES)
+        expect(found_basenames).to eq(RUBY_FILENAMES)
       end
     end
 
     context 'when files with ruby interpreters are passed' do
-      let(:args) { RuboCop::RUBY_INTERPRETERS.map { |name| "dir2/#{name}" } }
+      let(:args) { RUBY_INTERPRETERS.map { |name| "dir2/#{name}" } }
 
       before do
-        RuboCop::RUBY_INTERPRETERS.each do |interpreter|
+        RUBY_INTERPRETERS.each do |interpreter|
           create_file("dir2/#{interpreter}", "#!/usr/bin/#{interpreter}")
         end
       end
 
       it 'picks all the ruby files' do
-        expect(found_basenames).to eq(RuboCop::RUBY_INTERPRETERS)
+        expect(found_basenames).to eq(RUBY_INTERPRETERS)
       end
     end
 
@@ -183,6 +282,7 @@ RSpec.describe RuboCop::TargetFinder, :isolated_environment do
         create_file('.rubocop.yml', <<-YAML.strip_indent)
           AllCops:
             Include:
+              - '**/*.rb'
               - dir1/file
         YAML
       end
@@ -263,6 +363,7 @@ RSpec.describe RuboCop::TargetFinder, :isolated_environment do
 
     it 'does not pick directories' do
       found_basenames = found_files.map { |f| File.basename(f) }
+      allow(config_store).to receive(:for).and_return({})
       expect(found_basenames).not_to include('dir1')
     end
 
@@ -272,7 +373,10 @@ RSpec.describe RuboCop::TargetFinder, :isolated_environment do
         File.basename(file) == 'file'
       end
       allow(config)
-        .to receive(:for_all_cops).and_return('Exclude' => [])
+        .to receive(:for_all_cops).and_return('Exclude' => [],
+                                              'Include' => [],
+                                              'RubyInterpreters' => [])
+      allow(config).to receive(:[]).and_return([])
       allow(config).to receive(:file_to_exclude?).and_return(false)
       allow(config_store).to receive(:for).and_return(config)
 
@@ -282,7 +386,9 @@ RSpec.describe RuboCop::TargetFinder, :isolated_environment do
     it 'does not pick files specified to be excluded in config' do
       config = double('config').as_null_object
       allow(config)
-        .to receive(:for_all_cops).and_return('Exclude' => [])
+        .to receive(:for_all_cops).and_return('Exclude' => [],
+                                              'Include' => [],
+                                              'RubyInterpreters' => [])
       allow(config).to receive(:file_to_include?).and_return(false)
       allow(config).to receive(:file_to_exclude?) do |file|
         File.basename(file) == 'ruby2.rb'


### PR DESCRIPTION
Before this change, we were hard-coding file extensions, file names, and ruby interpreters, and then adding configured includes from `AllCops/Include`.

Now we add the parameter `AllCops/RubyInterpreters` and add `**/*.rb` to `AllCops/Include`.

By removing the hard-coded lists of things to inspect, this feature makes it possible to introduce RuboCop inspection slowly in a legacy project. Files and directories can be added for inspection incrementally. It's an alternative or complement to the existing workflow of adding cops one at a time using the `--auto-gen-config` feature.

Closes #5847, which was my first attempt at a fix for #4247.