### PR TITLE
Add spec for JSONLoad autocorrect

### DIFF
--- a/spec/rubocop/cop/security/json_load_spec.rb
+++ b/spec/rubocop/cop/security/json_load_spec.rb
@@ -41,4 +41,8 @@ RSpec.describe RuboCop::Cop::Security::JSONLoad, :config do
       ::JSON.dump(arg)
     RUBY
   end
+
+  it 'autocorrects .load to .parse' do
+    expect(autocorrect_source('JSON.load(arg)')).to eq 'JSON.parse(arg)'
+  end
 end


### PR DESCRIPTION
Before, the autocorrect feature of `Security/JSONLoad` was not tested at all.

This change increases coverage for lib/rubocop/cop/security/json_load.rb from 90.91 % to 100 %.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
