### PR TITLE
[Fix #5897] Apply symbol and word array conversion to array of size 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug fixes
 
+* [#5897](https://github.com/bbatsov/rubocop/issues/5897): Fix `Style/SymbolArray` and `Style/WordArray` not working on arrays of size 1. ([@TikiTDO][])
 * [#5894](https://github.com/bbatsov/rubocop/pull/5894): Fix `Rails/AssertNot` to allow it to have failure message. ([@koic][])
 * [#5888](https://github.com/bbatsov/rubocop/issues/5888): Do not register an offense for `headers` or `env` keyword arguments in `Rails/HttpPositionalArguments`. ([@rrosenblum][])
 * Fix the indentation of autocorrected closing squiggly heredocs. ([@garettarrowood][])
@@ -3378,3 +3379,4 @@
 [@thomasbrus]: https://github.com/thomasbrus
 [@balbesina]: https://github.com/balbesina
 [@cupakromer]: https://github.com/cupakromer
+[@TikiTDO]: https://github.com/TikiTDO

--- a/config/default.yml
+++ b/config/default.yml
@@ -1405,7 +1405,7 @@ Style/StringMethods:
 
 Style/SymbolArray:
   EnforcedStyle: percent
-  MinSize: 0
+  MinSize: 2
   SupportedStyles:
     - percent
     - brackets
@@ -1511,7 +1511,7 @@ Style/WordArray:
   # The `MinSize` option causes the `WordArray` rule to be ignored for arrays
   # smaller than a certain size.  The rule is only applied to arrays
   # whose element count is greater than or equal to `MinSize`.
-  MinSize: 0
+  MinSize: 2
   # The regular expression `WordRegex` decides what is considered a word.
   WordRegex: !ruby/regexp '/\A[\p{Word}\n\t]+\z/'
 

--- a/lib/rubocop/cop/mixin/array_syntax.rb
+++ b/lib/rubocop/cop/mixin/array_syntax.rb
@@ -8,7 +8,7 @@ module RuboCop
       private
 
       def bracketed_array_of?(element_type, node)
-        return false unless node.square_brackets? && node.values.size > 1
+        return false unless node.square_brackets? && !node.values.empty?
 
         node.values.all? { |value| value.type == element_type }
       end

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -5541,7 +5541,7 @@ of 2 or fewer elements.
 Name | Default value | Configurable values
 --- | --- | ---
 EnforcedStyle | `percent` | `percent`, `brackets`
-MinSize | `0` | Integer
+MinSize | `2` | Integer
 
 ### References
 
@@ -6313,7 +6313,7 @@ array of 2 or fewer elements.
 Name | Default value | Configurable values
 --- | --- | ---
 EnforcedStyle | `percent` | `percent`, `brackets`
-MinSize | `0` | Integer
+MinSize | `2` | Integer
 WordRegex | `(?-mix:\A[\p{Word}\n\t]+\z)` | 
 
 ### References

--- a/spec/rubocop/cop/style/symbol_array_spec.rb
+++ b/spec/rubocop/cop/style/symbol_array_spec.rb
@@ -36,6 +36,11 @@ RSpec.describe RuboCop::Cop::Style::SymbolArray, :config do
       expect(new_source).to eq('%i(one two three)')
     end
 
+    it 'autocorrects arrays of one symbol' do
+      new_source = autocorrect_source('[:one]')
+      expect(new_source).to eq('%i(one)')
+    end
+
     it 'autocorrects arrays of symbols with new line' do
       new_source = autocorrect_source("[:one,\n:two, :three,\n:four]")
       expect(new_source).to eq("%i(one\ntwo three\nfour)")
@@ -58,10 +63,6 @@ RSpec.describe RuboCop::Cop::Style::SymbolArray, :config do
 
     it 'does not register an offense for array starting with %i' do
       expect_no_offenses('%i(one two three)')
-    end
-
-    it 'does not register an offense for array with one element' do
-      expect_no_offenses('[:three]')
     end
 
     it 'does not register an offense if symbol contains whitespace' do
@@ -168,6 +169,17 @@ RSpec.describe RuboCop::Cop::Style::SymbolArray, :config do
     it 'autocorrects an array starting with %i' do
       new_source = autocorrect_source('%i(one @two $three four-five)')
       expect(new_source).to eq("[:one, :@two, :$three, :'four-five']")
+    end
+  end
+
+  context 'with non-default MinSize' do
+    let(:cop_config) do
+      { 'MinSize' => 2,
+        'EnforcedStyle' => 'percent' }
+    end
+
+    it 'does not autocorrects array of one symbol if MinSize > 1' do
+      expect_no_offenses('[:one]')
     end
   end
 end

--- a/spec/rubocop/cop/style/word_array_spec.rb
+++ b/spec/rubocop/cop/style/word_array_spec.rb
@@ -82,10 +82,6 @@ RSpec.describe RuboCop::Cop::Style::WordArray, :config do
       expect_no_offenses('%w(one two three)')
     end
 
-    it 'does not register an offense for array with one element' do
-      expect_no_offenses('["three"]')
-    end
-
     it 'does not register an offense for array with empty strings' do
       expect_no_offenses('["", "two", "three"]')
     end
@@ -132,6 +128,11 @@ RSpec.describe RuboCop::Cop::Style::WordArray, :config do
     it 'auto-corrects an array of words' do
       new_source = autocorrect_source("['one', %q(two), 'three']")
       expect(new_source).to eq('%w(one two three)')
+    end
+
+    it 'auto-corrects an array with one element' do
+      new_source = autocorrect_source("['one']")
+      expect(new_source).to eq('%w(one)')
     end
 
     it 'auto-corrects an array of words and character constants' do
@@ -343,6 +344,18 @@ RSpec.describe RuboCop::Cop::Style::WordArray, :config do
         new_source = autocorrect_source("[')', ']', '(', '[']")
         expect(new_source).to eq('%w[) \\] ( \\[]')
       end
+    end
+  end
+
+  context 'with non-default MinSize' do
+    let(:cop_config) do
+      { 'MinSize' => 2,
+        'WordRegex' => /\A[\p{Word}\n\t]+\z/,
+        'EnforcedStyle' => 'percent' }
+    end
+
+    it 'does not autocorrects arrays of one symbol if MinSize > 1' do
+      expect_no_offenses('["one"]')
     end
   end
 end


### PR DESCRIPTION
Ensures Style/SymbolArray and Style/WordArray work on arrays of size 1 when MinSize allows it.

Fixes #5897