### PR TITLE
Add `xmlschema` to accepted `Rails/TimeZone` methods.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * [#5887](https://github.com/bbatsov/rubocop/issues/5887): Remove `Lint/SplatKeywordArguments` cop. ([@koic][])
 * [#5761](https://github.com/bbatsov/rubocop/pull/5761): Add `httpdate` to accepted `Rails/TimeZone` methods. ([@cupakromer][])
+* [#5899](https://github.com/bbatsov/rubocop/pull/5899): Add `xmlschema` to accepted `Rails/TimeZone` methods. ([@koic][])
 
 ## 0.56.0 (2018-05-14)
 

--- a/lib/rubocop/cop/rails/time_zone.rb
+++ b/lib/rubocop/cop/rails/time_zone.rb
@@ -66,7 +66,7 @@ module RuboCop
                                parse at current].freeze
 
         ACCEPTED_METHODS = %i[in_time_zone utc getlocal
-                              iso8601 jisx0301 rfc3339
+                              xmlschema iso8601 jisx0301 rfc3339
                               httpdate to_i to_f].freeze
 
         def on_const(node)


### PR DESCRIPTION
Follow up of #5761 and #1787.

`iso8601` and `rfc3339` methods are aliases of `xmlschema`.
https://github.com/rails/rails/blob/v5.2.0/activesupport/lib/active_support/time_with_zone.rb#L145-L153

If this cop accepts these methods, this cop need to also accept the original `xmlschema`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
