### PR TITLE
Fix indentation of closing squiggly heredoc

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -13,7 +13,7 @@ Metrics/AbcSize:
 # Offense count: 42
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 174
+  Max: 176
 
 # Offense count: 195
 # Configuration parameters: CountComments.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#5894](https://github.com/bbatsov/rubocop/pull/5894): Fix `Rails/AssertNot` to allow it to have failure message. ([@koic][])
 * [#5888](https://github.com/bbatsov/rubocop/issues/5888): Do not register an offense for `headers` or `env` keyword arguments in `Rails/HttpPositionalArguments`. ([@rrosenblum][])
+* Fix the indentation of autocorrected closing squiggly heredocs. ([@garettarrowood][])
 
 ### Changes
 

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -2218,7 +2218,7 @@ are indented one step.
 In Ruby 2.3 or newer, squiggly heredocs (`<<~`) should be used. If you
 use the older rubies, you should introduce some library to your project
 (e.g. ActiveSupport, Powerpack or Unindent).
-Note: When `Metrics/LineLength`'s `AllowHeredoc` is false(not default),
+Note: When `Metrics/LineLength`'s `AllowHeredoc` is false (not default),
       this cop does not add any offenses for long here documents to
       avoid `Metrics/LineLength`'s offenses.
 

--- a/spec/rubocop/cop/layout/indent_heredoc_spec.rb
+++ b/spec/rubocop/cop/layout/indent_heredoc_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe RuboCop::Cop::Layout::IndentHeredoc, :config do
     }
   end
 
-  shared_examples :offense do |name, code, correction = nil|
+  shared_examples :offense do |name, code, correction = nil, strip_fix = true|
     it "registers an offense for #{name}" do
       inspect_source(code.strip_indent)
       expect(cop.offenses.size).to eq(1)
@@ -18,7 +18,11 @@ RSpec.describe RuboCop::Cop::Layout::IndentHeredoc, :config do
 
     it "autocorrects for #{name}" do
       corrected = autocorrect_source_with_loop(code.strip_indent)
-      expect(corrected).to eq(correction.strip_indent)
+      if strip_fix
+        expect(corrected).to eq(correction.strip_indent)
+      else
+        expect(corrected).to eq(correction)
+      end
     end
   end
 
@@ -295,7 +299,22 @@ RSpec.describe RuboCop::Cop::Layout::IndentHeredoc, :config do
           RUBY2
         CORRECTION
 
-        include_examples :accept, 'indentaed, with `~`', <<-RUBY
+        include_examples :offense, 'first line minus-level indented, with `-`',
+                         <<-RUBY, <<-CORRECTION, false
+                  puts <<-#{quote}RUBY2#{quote}
+          def foo
+            bar
+          end
+          RUBY2
+        RUBY
+        puts <<~#{quote}RUBY2#{quote}
+          def foo
+            bar
+          end
+        RUBY2
+        CORRECTION
+
+        include_examples :accept, 'indented, with `~`', <<-RUBY
           <<~#{quote}RUBY2#{quote}
             something
           RUBY2


### PR DESCRIPTION
This is a fix to the broken test attached to the work done in #5190 . Shout out to @cllns for the implementation.

Unfortunately, applying the fix to the `correct_by_squiggly` method created a `Metrics/AbcSize` offense. Refactoring some of the logic into additional methods then resulted in a `Metrics/ClassLength` offense. It may be possible to refactor this logic further into a `Corrector` object. However, such changes seem out of scope for this PR.

Snippet of original summary:
---

As a part of updating the Hanami codebase to use Ruby 2.3's squiggly heredoc <<~, I used rubocop's auto-correct feature. It mostly worked perfectly, but it left the end heredoc delimiters where they were. In our case, this was with 0 spaces.

I've confirmed that this PR fixes the problem above, but I can't figure out how to write a passing spec. The trouble is that the shared_example calls strip_indent on both the code and the correction. If I remove those, this spec passes, but others fail. I'm not sure if I can write a passing spec with the indents being stripped.

---

* [x] Wrote [good commit messages][1].
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
