### PR TITLE
Remove unnecessary `require 'rubygems'` since Ruby 1.9

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'rubygems'
 require 'bundler'
 require 'bundler/gem_tasks'
 begin


### PR DESCRIPTION
Follow up of #4787. This PR is a nitpick.

> Ruby 1.9 and newer ships with RubyGems built-in

https://guides.rubygems.org/rubygems-basics/

Since RuboCop requires Ruby 2.1.0 or higher, so `require 'rubygems'` is unnecessary.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
