### PR TITLE
Move REPL command from rake to bin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * [#5887](https://github.com/bbatsov/rubocop/issues/5887): Remove `Lint/SplatKeywordArguments` cop. ([@koic][])
 * [#5761](https://github.com/bbatsov/rubocop/pull/5761): Add `httpdate` to accepted `Rails/TimeZone` methods. ([@cupakromer][])
 * [#5899](https://github.com/bbatsov/rubocop/pull/5899): Add `xmlschema` to accepted `Rails/TimeZone` methods. ([@koic][])
+* [#5906](https://github.com/bbatsov/rubocop/pull/5906): Move REPL command from `rake repl` task to `bin/console` command. ([@koic][])
 
 ## 0.56.0 (2018-05-14)
 

--- a/Rakefile
+++ b/Rakefile
@@ -63,6 +63,8 @@ YARD::Rake::YardocTask.new
 
 desc 'Open a REPL for experimentation'
 task :repl do
+  warn 'DEPRECATION WARNING: `rake repl` is deprecated and ' \
+       'will be removed in RuboCop 0.58.0. Please use `bin/console`.'
   require 'pry'
   require 'rubocop'
   ARGV.clear

--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,9 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'pry'
+require 'rubocop'
+
+ARGV.clear
+
+RuboCop.pry

--- a/manual/development.md
+++ b/manual/development.md
@@ -69,7 +69,7 @@ $ ruby-parse -e '!array.empty?'
 Now, it's time to debug our expression using the REPL from RuboCop:
 
 ```sh
-$ rake repl
+$ bin/console
 ```
 
 First we need to declare the code that we want to match, and use the


### PR DESCRIPTION
Related PR #5905.

The main stream of Gem's REPL running seems to be `bin/console` command.
`bundle gem` also uses the following template.
https://github.com/bundler/bundler/blob/v1.16.2/lib/bundler/templates/newgem/bin/console.tt

This PR moves REPL command from `rake repl` task to `bin/console` command then it helps Gem developers to execute REPL intuitively.

In order not to confuse RuboCop developers, This PR suddenly did not remove `rake repl` task, but instead display a warning to remove in the future RuboCop 0.58.0.

```console
% rake repl
DEPRECATION WARNING: `rake repl` is deprecated and will be removed in
RuboCop 0.58.0. Please use `bin/console`.
[1] pry(RuboCop)>
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
