### PR TITLE
Adds missing force-exclusion option to CLI option list

### DIFF
--- a/manual/basic_usage.md
+++ b/manual/basic_usage.md
@@ -85,6 +85,7 @@ Command flag                    | Description
 `--[no-]color`                  | Force color output on or off.
 `--parallel`                    | Use available CPUs to execute inspection in parallel.
 `--ignore-parent-exlusion`      | Ignores all Exclude: settings from all .rubocop.yml files present in parent folders. This is useful when you are importing submodules when you want to test them without being affected by the parent module's rubocop settings.
+`--force-exclusion`             | Force excluding files specified in the configuration `Exclude` even if they are explicitly passed as arguments.
 
 Default command-line options are loaded from `.rubocop` and `RUBOCOP_OPTS` and are combined with command-line options that are explicitly passed to `rubocop`.
 Thus, the options have the following order of precedence (from highest to lowest):


### PR DESCRIPTION
This PR adds the `force-exclusion` option to the CLI option list. The option was added in in 2014, but is currently absent from the manual.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [ ] ~Commit message starts with `[Fix #issue-number]` (if the related issue exists).~
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] ~Squashed related commits together.~
* [ ] ~Added tests.~
* [ ] ~Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format]~(../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] ~Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.~

[1]: http://chris.beams.io/posts/git-commit/
