### PR TITLE
Fix bug in RangeHelp where range_by_whole_lines goes past end of buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 * [#5894](https://github.com/bbatsov/rubocop/pull/5894): Fix `Rails/AssertNot` to allow it to have failure message. ([@koic][])
 * [#5888](https://github.com/bbatsov/rubocop/issues/5888): Do not register an offense for `headers` or `env` keyword arguments in `Rails/HttpPositionalArguments`. ([@rrosenblum][])
 * Fix the indentation of autocorrected closing squiggly heredocs. ([@garettarrowood][])
-* [#5908](https://github.com/bbatsov/rubocop/pull/5908): Fix `Style/BracesAroundHashParameters` auto-correct sometimes going past the end of the file. ([@EiNSTeiN-][])
+* [#5908](https://github.com/bbatsov/rubocop/pull/5908): Fix `Style/BracesAroundHashParameters` auto-correct going past the end of the file when the closing curly brace is on the last line of a file. ([@EiNSTeiN-][])
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [#5894](https://github.com/bbatsov/rubocop/pull/5894): Fix `Rails/AssertNot` to allow it to have failure message. ([@koic][])
 * [#5888](https://github.com/bbatsov/rubocop/issues/5888): Do not register an offense for `headers` or `env` keyword arguments in `Rails/HttpPositionalArguments`. ([@rrosenblum][])
 * Fix the indentation of autocorrected closing squiggly heredocs. ([@garettarrowood][])
+* [#5908](https://github.com/bbatsov/rubocop/pull/5908): Fix `Style/BracesAroundHashParameters` auto-correct sometimes going past the end of the file. ([@EiNSTeiN-][])
 
 ### Changes
 
@@ -3381,3 +3382,4 @@
 [@balbesina]: https://github.com/balbesina
 [@cupakromer]: https://github.com/cupakromer
 [@TikiTDO]: https://github.com/TikiTDO
+[@EiNSTeiN-]: https://github.com/EiNSTeiN-

--- a/lib/rubocop/cop/mixin/range_help.rb
+++ b/lib/rubocop/cop/mixin/range_help.rb
@@ -63,17 +63,13 @@ module RuboCop
       def range_by_whole_lines(range, include_final_newline: false)
         buffer = @processed_source.buffer
 
-        begin_pos = range.begin_pos
-        begin_offset = range.column
-        begin_of_first_line = begin_pos - begin_offset
-
         last_line = buffer.source_line(range.last_line)
-        end_pos = range.end_pos
         end_offset = last_line.length - range.last_column
         end_offset += 1 if include_final_newline
-        end_of_last_line = end_pos + end_offset
 
-        Parser::Source::Range.new(buffer, begin_of_first_line, end_of_last_line)
+        range
+          .adjust(begin_pos: -range.column, end_pos: end_offset)
+          .intersect(buffer.source_range)
       end
 
       ## Helpers for above range methods. Do not use inside Cops.

--- a/spec/rubocop/cop/range_help_spec.rb
+++ b/spec/rubocop/cop/range_help_spec.rb
@@ -180,6 +180,7 @@ RSpec.describe RuboCop::Cop::RangeHelp do
         let(:include_final_newline) { true }
 
         it { is_expected.to eq('newline_at_end') }
+        it { expect(output_range.end_pos).to eq(source.size) }
       end
     end
   end

--- a/spec/rubocop/cop/style/braces_around_hash_parameters_spec.rb
+++ b/spec/rubocop/cop/style/braces_around_hash_parameters_spec.rb
@@ -261,6 +261,14 @@ RSpec.describe RuboCop::Cop::Style::BracesAroundHashParameters, :config do
         expect(corrected).to eq('get :i, x: 1')
       end
     end
+
+    context 'in a method call with multi line arguments without parentheses' do
+      it 'removes hash braces' do
+        src = "render 'foo', {\n  foo: bar\n}"
+        corrected = autocorrect_source(src)
+        expect(corrected).to eq("render 'foo', \n  foo: bar\n")
+      end
+    end
   end
 
   context 'when EnforcedStyle is no_braces' do


### PR DESCRIPTION
This fixes a bug where `RangeHelp#range_by_whole_lines` may return a range that goes past the end of the buffer when `include_final_newline` argument is true. This is because of the line `end_offset += 1 if include_final_newline`.

I added 2 tests that fail without this fix, the original bug I encountered was from `BracesAroundHashParameters` when the hash being removed occurs at the very end of the ruby code.
