### PR TITLE
Use the expect_offense helper

### DIFF
--- a/spec/rubocop/cop/layout/space_after_semicolon_spec.rb
+++ b/spec/rubocop/cop/layout/space_after_semicolon_spec.rb
@@ -27,8 +27,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAfterSemicolon do
   context 'inside block braces' do
     shared_examples 'common behavior' do
       it 'accepts a space between a semicolon and a closing brace' do
-        inspect_source('test { ; }')
-        expect(cop.messages.empty?).to be(true)
+        expect_no_offenses('test { ; }')
       end
     end
 
@@ -41,8 +40,10 @@ RSpec.describe RuboCop::Cop::Layout::SpaceAfterSemicolon do
 
       it 'registers an offense for no space between a semicolon and a ' \
          'closing brace' do
-        inspect_source('test { ;}')
-        expect(cop.messages).to eq(['Space missing after semicolon.'])
+        expect_offense(<<-RUBY.strip_indent)
+          test { ;}
+                 ^ Space missing after semicolon.
+        RUBY
       end
     end
 

--- a/spec/rubocop/cop/performance/redundant_match_spec.rb
+++ b/spec/rubocop/cop/performance/redundant_match_spec.rb
@@ -70,33 +70,30 @@ RSpec.describe RuboCop::Cop::Performance::RedundantMatch do
 
   it 'does not register an error when return value of .match is passed ' \
      'to another method' do
-    inspect_source(<<-RUBY.strip_indent)
+    expect_no_offenses(<<-RUBY.strip_indent)
       def method(str)
        something(str.match(/regex/))
       end
     RUBY
-    expect(cop.messages.empty?).to be(true)
   end
 
   it 'does not register an error when return value of .match is stored in an ' \
      'instance variable' do
-    inspect_source(<<-RUBY.strip_indent)
+    expect_no_offenses(<<-RUBY.strip_indent)
       def method(str)
        @var = str.match(/regex/)
        true
       end
     RUBY
-    expect(cop.messages.empty?).to be(true)
   end
 
   it 'does not register an error when return value of .match is returned from' \
      ' surrounding method' do
-    inspect_source(<<-RUBY.strip_indent)
+    expect_no_offenses(<<-RUBY.strip_indent)
       def method(str)
        str.match(/regex/)
       end
     RUBY
-    expect(cop.messages.empty?).to be(true)
   end
 
   it 'does not register an offense when match has a block' do

--- a/spec/rubocop/cop/performance/size_spec.rb
+++ b/spec/rubocop/cop/performance/size_spec.rb
@@ -5,16 +5,12 @@ RSpec.describe RuboCop::Cop::Performance::Size do
 
   it 'does not register an offense when calling count ' \
      'as a stand alone method' do
-    inspect_source('count(items)')
-
-    expect(cop.messages.empty?).to be(true)
+    expect_no_offenses('count(items)')
   end
 
   it 'does not register an offense when calling count on an object ' \
      'other than an array or a hash' do
-    inspect_source('object.count(items)')
-
-    expect(cop.messages.empty?).to be(true)
+    expect_no_offenses('object.count(items)')
   end
 
   describe 'on array' do

--- a/spec/rubocop/cop/style/hash_syntax_spec.rb
+++ b/spec/rubocop/cop/style/hash_syntax_spec.rb
@@ -184,11 +184,6 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
 
       it 'accepts ruby19 syntax when no elements have symbol values ' \
         'in method calls' do
-        inspect_source('func(3, a: 0)')
-        expect(cop.messages.empty?).to be(true)
-      end
-
-      it 'accepts new syntax in method calls' do
         expect_no_offenses('func(3, a: 0)')
       end
 
@@ -206,8 +201,10 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
 
       it 'registers an offense when any element has a symbol value ' \
         'in method calls' do
-        inspect_source('func(3, b: :c)')
-        expect(cop.messages).to eq(['Use hash rockets syntax.'])
+        expect_offense(<<-RUBY.strip_indent)
+          func(3, b: :c)
+                  ^^ Use hash rockets syntax.
+        RUBY
       end
 
       it 'registers an offense when using hash rockets ' \
@@ -449,8 +446,10 @@ RSpec.describe RuboCop::Cop::Style::HashSyntax, :config do
 
       it 'registers an offense when any element has a symbol value ' \
         'in method calls' do
-        inspect_source('func(3, b: :c)')
-        expect(cop.messages).to eq(['Use hash rockets syntax.'])
+        expect_offense(<<-RUBY.strip_indent)
+          func(3, b: :c)
+                  ^^ Use hash rockets syntax.
+        RUBY
       end
 
       it 'auto-corrects to hash rockets ' \


### PR DESCRIPTION
Follow up on #5834
* Replaced cop.messages checks with expect_offense / expect_no_offenses
* Removed 1 duplicated example

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] ~Commit message starts with `[Fix #issue-number]` (if the related issue exists).~
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] ~Added tests.~
* [ ] ~Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).~
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
