### PR TITLE
Frozen string literal comment space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [#5894](https://github.com/bbatsov/rubocop/pull/5894): Fix `Rails/AssertNot` to allow it to have failure message. ([@koic][])
 * [#5888](https://github.com/bbatsov/rubocop/issues/5888): Do not register an offense for `headers` or `env` keyword arguments in `Rails/HttpPositionalArguments`. ([@rrosenblum][])
 * Fix the indentation of autocorrected closing squiggly heredocs. ([@garettarrowood][])
+* Fix a bug where `Style/FrozenStringLiteralComment` would be added to the second line if the first line is empty. ([@rrosenblum][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/frozen_string_literal_comment.rb
+++ b/lib/rubocop/cop/style/frozen_string_literal_comment.rb
@@ -139,14 +139,37 @@ module RuboCop
         def insert_comment(corrector)
           last_special_comment = last_special_comment(processed_source)
           if last_special_comment.nil?
-            corrector.insert_before(processed_source.tokens[0].pos,
-                                    "#{FROZEN_STRING_LITERAL_ENABLED}\n\n")
-          elsif processed_source.following_line(last_special_comment).empty?
-            corrector.insert_after(last_special_comment.pos,
-                                   "\n#{FROZEN_STRING_LITERAL_ENABLED}")
+            corrector.insert_before(correction_range, preceeding_comment)
           else
-            corrector.insert_after(last_special_comment.pos,
-                                   "\n#{FROZEN_STRING_LITERAL_ENABLED}\n")
+            corrector.insert_after(correction_range, proceeding_comment)
+          end
+        end
+
+        def preceeding_comment
+          if processed_source.tokens[0].space_before?
+            "#{FROZEN_STRING_LITERAL_ENABLED}\n"
+          else
+            "#{FROZEN_STRING_LITERAL_ENABLED}\n\n"
+          end
+        end
+
+        def proceeding_comment
+          last_special_comment = last_special_comment(processed_source)
+          if processed_source.following_line(last_special_comment).empty?
+            "\n#{FROZEN_STRING_LITERAL_ENABLED}"
+          else
+            "\n#{FROZEN_STRING_LITERAL_ENABLED}\n"
+          end
+        end
+
+        def correction_range
+          last_special_comment = last_special_comment(processed_source)
+
+          if last_special_comment.nil?
+            range_with_surrounding_space(range: processed_source.tokens[0],
+                                         side: :left)
+          else
+            last_special_comment.pos
           end
         end
       end

--- a/lib/rubocop/token.rb
+++ b/lib/rubocop/token.rb
@@ -45,7 +45,8 @@ module RuboCop
 
     # Checks if there is whitespace before token
     def space_before?
-      pos.source_buffer.source.match(/\G\s/, begin_pos - 1)
+      position = begin_pos.zero? ? begin_pos : begin_pos - 1
+      pos.source_buffer.source.match(/\G\s/, position)
     end
 
     ## Type Predicates

--- a/spec/rubocop/cop/style/frozen_string_literal_comment_spec.rb
+++ b/spec/rubocop/cop/style/frozen_string_literal_comment_spec.rb
@@ -168,6 +168,20 @@ RSpec.describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
         RUBY
       end
 
+      it 'adds a frozen string literal comment to the first line if one is ' \
+         'missing and handles extra spacing' do
+        new_source = autocorrect_source(<<-RUBY.strip_indent)
+
+          puts 1
+        RUBY
+
+        expect(new_source).to eq(<<-RUBY.strip_indent)
+          # frozen_string_literal: true
+
+          puts 1
+        RUBY
+      end
+
       it 'adds a frozen string literal comment after a shebang' do
         new_source = autocorrect_source(<<-RUBY.strip_indent)
           #!/usr/bin/env ruby

--- a/spec/rubocop/token_spec.rb
+++ b/spec/rubocop/token_spec.rb
@@ -133,6 +133,10 @@ RSpec.describe RuboCop::Token do
       expect(semicolon_token.space_before?).to be nil
       expect(zero_token.space_before?).to be nil
     end
+
+    it 'returns nil when it is on the first line' do
+      expect(processed_source.tokens[0].space_before?).to be nil
+    end
   end
 
   context 'type predicates' do


### PR DESCRIPTION
Given code that begins on the second line, the cop would correct the file to contain a new line on line 1 and the comment on line 2.
```
cat test.rb 

puts 1
```
```
cat test.rb

# frozen_string_literal: true

puts 1
```


There was also a bug where `Token#space_before?` would actually return space after if the token started at position 0. String position -1 is the last character of the string.