### PR TITLE
Suppress stdout in tests

### DIFF
--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -3,6 +3,8 @@
 RSpec.describe RuboCop::ConfigLoader do
   include FileHelper
 
+  include_context 'cli spec behavior'
+
   before { described_class.debug = true }
   after { described_class.debug = false }
 

--- a/spec/rubocop/cop/generator_spec.rb
+++ b/spec/rubocop/cop/generator_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe RuboCop::Cop::Generator do
   end
 
   describe '#write_source' do
+    include_context 'cli spec behavior'
+
     it 'generates a helpful source file with the name filled in' do
       generated_source = <<-RUBY.strip_indent
         # frozen_string_literal: true
@@ -100,6 +102,8 @@ RSpec.describe RuboCop::Cop::Generator do
   end
 
   describe '#write_spec' do
+    include_context 'cli spec behavior'
+
     it 'generates a helpful starting spec file with the class filled in' do
       generated_source = <<-SPEC.strip_indent
         # frozen_string_literal: true


### PR DESCRIPTION
We have a few tests that are outputting to `stdout`. I like my test suites to only print information about the tests themselves.