### PR TITLE
Travis: use jruby-9.2.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ cache: bundler
 language: ruby
 dist: trusty
 rvm:
-  - jruby-9.1.17.0
+  - jruby-9.2.0.0
   - jruby-head
   - 2.1.10
   - 2.2.10


### PR DESCRIPTION
This PR updates the CI matrix to use the latest available JRuby.

See http://jruby.org/2018/05/24/jruby-9-2-0-0.html for release notes.