### PR TITLE
[Fix #5914] Fix false negative for `Layout/SpaceInsideReferenceBrackets`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Fix the indentation of autocorrected closing squiggly heredocs. ([@garettarrowood][])
 * [#5908](https://github.com/bbatsov/rubocop/pull/5908): Fix `Style/BracesAroundHashParameters` auto-correct going past the end of the file when the closing curly brace is on the last line of a file. ([@EiNSTeiN-][])
 * Fix a bug where `Style/FrozenStringLiteralComment` would be added to the second line if the first line is empty. ([@rrosenblum][])
+* [#5914](https://github.com/bbatsov/rubocop/issues/5914): Make `Layout/SpaceInsideReferenceBrackets` aware of `no_space` when using nested reference brackets. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/layout/space_inside_reference_brackets.rb
+++ b/lib/rubocop/cop/layout/space_inside_reference_brackets.rb
@@ -111,10 +111,14 @@ module RuboCop
         end
 
         def left_ref_bracket(node, tokens)
-          if node.method?(:[]=)
+          current_token = tokens.reverse.find(&:left_ref_bracket?)
+          previous_token = previous_token(current_token)
+
+          if node.method?(:[]=) ||
+             previous_token && !previous_token.right_bracket?
             tokens.find(&:left_ref_bracket?)
           else
-            tokens.reverse.find(&:left_ref_bracket?)
+            current_token
           end
         end
 
@@ -129,6 +133,11 @@ module RuboCop
               return token
             end
           end
+        end
+
+        def previous_token(current_token)
+          index = processed_source.tokens.index(current_token)
+          index.nil? || index.zero? ? nil : processed_source.tokens[index - 1]
         end
 
         def empty_config

--- a/spec/rubocop/cop/layout/space_inside_reference_brackets_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_reference_brackets_spec.rb
@@ -208,6 +208,15 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideReferenceBrackets, :config do
         .to eq(['Do not use space inside reference brackets.'])
     end
 
+    it 'registers offense in outer ref brackets' do
+      inspect_source(<<-RUBY.strip_indent)
+        record[ options[:attribute] ]
+      RUBY
+      expect(cop.offenses.size).to eq(2)
+      expect(cop.messages.uniq)
+        .to eq(['Do not use space inside reference brackets.'])
+    end
+
     context 'auto-correct' do
       it 'fixes multiple offenses in one set of ref brackets' do
         new_source = autocorrect_source(<<-RUBY.strip_indent)


### PR DESCRIPTION
Fixes #5914.

This PR makes `Layout/SpaceInsideReferenceBrackets` aware of `no_space` when using nested refefence brackets.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
