### PR TITLE
[Fix #5917] Let inherit_mode work for default configuration too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * [#5761](https://github.com/bbatsov/rubocop/pull/5761): Add `httpdate` to accepted `Rails/TimeZone` methods. ([@cupakromer][])
 * [#5899](https://github.com/bbatsov/rubocop/pull/5899): Add `xmlschema` to accepted `Rails/TimeZone` methods. ([@koic][])
 * [#5906](https://github.com/bbatsov/rubocop/pull/5906): Move REPL command from `rake repl` task to `bin/console` command. ([@koic][])
+* [#5917](https://github.com/bbatsov/rubocop/pull/5917): Let `inherit_mode` work for default configuration too. ([@jonas054][])
 
 ## 0.56.0 (2018-05-14)
 

--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -49,7 +49,6 @@ module RuboCop
         resolver.resolve_inheritance(path, hash, file, debug?)
 
         hash.delete('inherit_from')
-        hash.delete('inherit_mode')
 
         Config.create(hash, path)
       end

--- a/lib/rubocop/config_loader_resolver.rb
+++ b/lib/rubocop/config_loader_resolver.rb
@@ -70,7 +70,9 @@ module RuboCop
         config = handle_disabled_by_default(config, default_configuration)
       end
 
-      Config.new(merge(default_configuration, config), config_file)
+      Config.new(merge(default_configuration, config,
+                       inherit_mode: config['inherit_mode'] || {}),
+                 config_file)
     end
 
     # Returns a new hash where the parameters of the given config hash have
@@ -83,7 +85,7 @@ module RuboCop
       keys_appearing_in_both = base_hash.keys & derived_hash.keys
       keys_appearing_in_both.each do |key|
         if base_hash[key].is_a?(Hash)
-          result[key] = merge(base_hash[key], derived_hash[key])
+          result[key] = merge(base_hash[key], derived_hash[key], **opts)
         elsif should_union?(base_hash, key, opts[:inherit_mode])
           result[key] = base_hash[key] | derived_hash[key]
         elsif opts[:debug]

--- a/manual/configuration.md
+++ b/manual/configuration.md
@@ -128,8 +128,8 @@ The optional directive `inherit_mode` is used to specify which configuration
 keys that have array values should be merged together instead of overriding the
 inherited value.
 
-One caveat is that this directive only works with local and inherited
-configuration files, it is unable to merge with the default.yml config.
+This applies to explicit inheritance using `inherit_from` as well as implicit
+inheritance from the default configuration.
 
 Given the following config:
 ```yaml
@@ -140,6 +140,10 @@ inherit_from:
 inherit_mode:
   merge:
     - Exclude 
+
+AllCops:
+  Exclude:
+    - 'generated/**/*.rb'
 
 Style/For:
   Exclude:
@@ -154,7 +158,8 @@ Style/For:
 ```
 
 The list of `Exclude`s for the `Style/For` cop in this example will be
-`['foo.rb', 'bar.rb']`. 
+`['foo.rb', 'bar.rb']`. Similarly, the `AllCops:Exclude` list will contain all
+the default patterns plus the `generated/**/*.rb` entry that was added locally.
 
 The directive can also be used on individual cop configurations to override
 the global setting.


### PR DESCRIPTION
The change is that `inherit_mode` is considered, not only when evaluating explicit inheritance through `inherit_from`, but also for implicit inheritance from the default configuration.

This allows users to override `AllCops:Include`, for example, without having to copy a long list of patterns.