### PR TITLE
Do not include display_width string extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * [#5899](https://github.com/bbatsov/rubocop/pull/5899): Add `xmlschema` to accepted `Rails/TimeZone` methods. ([@koic][])
 * [#5906](https://github.com/bbatsov/rubocop/pull/5906): Move REPL command from `rake repl` task to `bin/console` command. ([@koic][])
 * [#5917](https://github.com/bbatsov/rubocop/pull/5917): Let `inherit_mode` work for default configuration too. ([@jonas054][])
+* [#5929](https://github.com/bbatsov/rubocop/pull/5929): Stop including string extensions from `unicode/display_width`. ([@nroman-stripe][])
 
 ## 0.56.0 (2018-05-14)
 
@@ -3386,3 +3387,4 @@
 [@cupakromer]: https://github.com/cupakromer
 [@TikiTDO]: https://github.com/TikiTDO
 [@EiNSTeiN-]: https://github.com/EiNSTeiN-
+[@nroman-stripe]: https://github.com/nroman-stripe

--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -11,7 +11,7 @@ require 'powerpack/enumerable/drop_last'
 require 'powerpack/hash/symbolize_keys'
 require 'powerpack/string/blank'
 require 'powerpack/string/strip_indent'
-require 'unicode/display_width'
+require 'unicode/display_width/no_string_ext'
 
 require_relative 'rubocop/version'
 


### PR DESCRIPTION
This avoids unneeded extensions to `String` that is added by `unicode/display_width`. By default `require 'unicode/display_width'` adds `display_{size,width,length}` methods to `String`. Rubocop does not use them however.

This gem has supported this since [v1.0.0](https://github.com/janlelis/unicode-display_width/blob/master/CHANGELOG.md#100).

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `rake default` or `rake parallel`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
